### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,3 +111,41 @@ These agents are available as GitHub Copilot custom agents within the repository
 - **Categories:** Conversion, messaging, visual hierarchy, friction reduction, mobile, dark mode
 - **Target:** +5-15% engagement and conversion improvements
 - **Files:** `.cursor/agents/frontend-marketing-suggestions.md` + `.github/workflows/frontend-suggestions.yml`
+
+## Cursor Cloud specific instructions
+
+### Monorepo overview
+
+pnpm v10.29.1 workspace managed by Turborepo. Node 20. All packages are ESM (`"type": "module"`).
+Standard commands are in root `package.json` scripts; see the README "Getting Started" section.
+
+### Starting services
+
+| Service | Command | Default port |
+| :--- | :--- | :--- |
+| **web** (Next.js landing) | `pnpm -C apps/web dev` | 3001 |
+| **api** (Express gateway) | `pnpm --filter @tiltcheck/api dev` | 8080 |
+| **discord-bot** | `pnpm --filter @tiltcheck/discord-bot dev` | 8080 (health) |
+| **user-dashboard** | `pnpm --filter @tiltcheck/user-dashboard dev` | 6001 |
+| **control-room** | `pnpm --filter @tiltcheck/control-room dev` | 3003 |
+| **trust-rollup** | `pnpm --filter @tiltcheck/trust-rollup dev` | 3005 |
+| **game-arena** | `pnpm --filter @tiltcheck/game-arena dev` | (Socket.io) |
+
+The API uses `tsx watch --env-file=../../.env` so it picks up the root `.env` automatically.
+The web app (Next.js) reads `NEXT_PUBLIC_*` vars from the root `.env` at build/dev time.
+
+### Environment setup gotchas
+
+- `.env` must be created from `.env.example` before starting services. Set `SKIP_ENV_VALIDATION=true` and `SKIP_DISCORD_LOGIN=true` for local/cloud dev without real credentials.
+- `VAULT_ENCRYPTION_KEY` must be exactly 64 hex characters (32 bytes). Use a dummy key like `0123456789abcdef` repeated 4 times for dev.
+- The API logs `ECONNREFUSED` for PostgreSQL on startup if no DB is running -- this is non-fatal. The server still starts and serves HTTP requests. DB-dependent routes will return errors.
+- Sentry warns `Invalid Sentry Dsn: REPLACE_ME` on API startup -- harmless in dev.
+- `pnpm -r build` fails on `apps/web` due to Next.js prerendering errors. This is a known issue on main. Use `pnpm -C apps/web dev` for development instead of building.
+- Shared packages must be built before running apps: the update script handles this, but if you modify a shared package in `packages/` or `modules/`, rebuild it with `pnpm --filter <pkg>... build` before restarting dependent services.
+- Some native build scripts are ignored by `pnpm.onlyBuiltDependencies` policy. The warning about `pnpm approve-builds` can be safely ignored.
+
+### Lint / test / trust-engine verification
+
+- **Lint:** `pnpm lint` (pre-existing warnings/errors on main are expected)
+- **Test:** `pnpm test` (runs root vitest config; builds `@tiltcheck/database` first)
+- **Trust engine smoke test:** `pnpm trust:start` (builds trust-engines then runs startup verification)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

## Description
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting non-obvious setup gotchas and service startup commands for future cloud agents working in this monorepo.

## Type of Change
- [x] Documentation update
- [x] Configuration change

## Changes Made
- Added service startup command table (web, api, discord-bot, user-dashboard, control-room, trust-rollup, game-arena) with default ports
- Documented environment setup gotchas: `VAULT_ENCRYPTION_KEY` format requirement, `SKIP_ENV_VALIDATION`/`SKIP_DISCORD_LOGIN` flags, PostgreSQL ECONNREFUSED being non-fatal, `pnpm -r build` failing on `apps/web`, and shared package rebuild workflow
- Added lint/test/trust-engine verification commands

## Module/Service Affected
- [x] Documentation

## Testing
- [x] Tests pass locally (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Manual testing completed

### Test Details
Verified the full development environment setup:
- `pnpm test` passes (4 passed, 4 skipped)
- `pnpm lint` runs successfully (pre-existing warnings on main)
- `pnpm trust:start` validates trust engine startup
- `pnpm -C apps/web dev` starts Next.js on port 3001
- `pnpm --filter @tiltcheck/api dev` starts API gateway on port 8080
- Casino trust lookup performed via the web UI (searched "stake.com", got B- / 72 score)

## Security Checklist
- [x] No secrets or sensitive data in code
- [x] No production secrets or credentials committed

## Performance Impact
- [x] No performance impact

## Documentation
- [x] Code comments added/updated

## Deployment Notes
- [x] No special deployment steps

## Screenshots/Videos
[casino-trust-lookup-demo.mp4](https://cursor.com/agents/bc-f800696b-b940-4f49-9dce-912e447617ae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcasino-trust-lookup-demo.mp4)
Casino trust lookup for stake.com showing B- grade (72/100).

[TiltCheck homepage](https://cursor.com/agents/bc-f800696b-b940-4f49-9dce-912e447617ae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Casino trust lookup result for stake.com](https://cursor.com/agents/bc-f800696b-b940-4f49-9dce-912e447617ae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcasino-trust-lookup.webp)
[API health endpoint returning ok](https://cursor.com/agents/bc-f800696b-b940-4f49-9dce-912e447617ae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi-health.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f800696b-b940-4f49-9dce-912e447617ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f800696b-b940-4f49-9dce-912e447617ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

