### PR TITLE
fix(security,brand): close prize-admin allow-all + restore hero voice

### DIFF
--- a/apps/discord-bot/src/services/tipping/prize-distribution.ts
+++ b/apps/discord-bot/src/services/tipping/prize-distribution.ts
@@ -20,10 +20,23 @@ import { v4 as uuidv4 } from 'uuid';
 const FLAT_FEE_SOL = 0.0007; // ~$0.07 at $100/SOL
 const FEE_WALLET = process.env.JUSTTHETIP_FEE_WALLET || '';
 
-// Admin users who can trigger prize distributions (Discord user IDs)
-const ADMIN_USER_IDS = new Set(
-  (process.env.PRIZE_ADMIN_USER_IDS || '').split(',').filter(id => id.trim())
+// Admin users who can trigger prize distributions (Discord user IDs).
+// Founder fallback: if env is unset/empty, only the founder ID is admin.
+// This prevents the legacy "empty list ⇒ everyone is admin" footgun.
+const FOUNDER_ADMIN_ID = '1153034319271559328';
+const _envAdminIds = (process.env.PRIZE_ADMIN_USER_IDS || '')
+  .split(',')
+  .map(id => id.trim())
+  .filter(id => id.length > 0 && id !== 'REPLACE_ME');
+const ADMIN_USER_IDS = new Set<string>(
+  _envAdminIds.length > 0 ? _envAdminIds : [FOUNDER_ADMIN_ID]
 );
+if (_envAdminIds.length === 0) {
+  // Visible warning so we never silently rely on the founder fallback in prod.
+  console.warn(
+    `[prize-distribution] PRIZE_ADMIN_USER_IDS not set; falling back to founder ID ${FOUNDER_ADMIN_ID}. Set PRIZE_ADMIN_USER_IDS in env to override.`
+  );
+}
 
 // Prize distribution status tracking
 export interface PrizeDistribution {
@@ -62,13 +75,11 @@ export interface TransactionLog {
 const transactionLogs: TransactionLog[] = [];
 
 /**
- * Check if a user is an admin for prize distribution
+ * Check if a user is an admin for prize distribution.
+ * Fail-closed: only IDs in ADMIN_USER_IDS pass. If env is unset, the set
+ * already contains the founder ID (see initialization above).
  */
 export function isAdmin(userId: string): boolean {
-  // Allow all users if no admin list is configured (dev mode)
-  if (ADMIN_USER_IDS.size === 0) {
-    return true;
-  }
   return ADMIN_USER_IDS.has(userId);
 }
 

--- a/apps/justthetip-bot/src/services/tipping/prize-distribution.ts
+++ b/apps/justthetip-bot/src/services/tipping/prize-distribution.ts
@@ -20,10 +20,23 @@ import { v4 as uuidv4 } from 'uuid';
 const FLAT_FEE_SOL = 0.0007; // ~$0.07 at $100/SOL
 const FEE_WALLET = process.env.JUSTTHETIP_FEE_WALLET || '';
 
-// Admin users who can trigger prize distributions (Discord user IDs)
-const ADMIN_USER_IDS = new Set(
-  (process.env.PRIZE_ADMIN_USER_IDS || '').split(',').filter(id => id.trim())
+// Admin users who can trigger prize distributions (Discord user IDs).
+// Founder fallback: if env is unset/empty, only the founder ID is admin.
+// This prevents the legacy "empty list ⇒ everyone is admin" footgun.
+const FOUNDER_ADMIN_ID = '1153034319271559328';
+const _envAdminIds = (process.env.PRIZE_ADMIN_USER_IDS || '')
+  .split(',')
+  .map(id => id.trim())
+  .filter(id => id.length > 0 && id !== 'REPLACE_ME');
+const ADMIN_USER_IDS = new Set<string>(
+  _envAdminIds.length > 0 ? _envAdminIds : [FOUNDER_ADMIN_ID]
 );
+if (_envAdminIds.length === 0) {
+  // Visible warning so we never silently rely on the founder fallback in prod.
+  console.warn(
+    `[prize-distribution] PRIZE_ADMIN_USER_IDS not set; falling back to founder ID ${FOUNDER_ADMIN_ID}. Set PRIZE_ADMIN_USER_IDS in env to override.`
+  );
+}
 
 // Prize distribution status tracking
 export interface PrizeDistribution {
@@ -62,13 +75,11 @@ export interface TransactionLog {
 const transactionLogs: TransactionLog[] = [];
 
 /**
- * Check if a user is an admin for prize distribution
+ * Check if a user is an admin for prize distribution.
+ * Fail-closed: only IDs in ADMIN_USER_IDS pass. If env is unset, the set
+ * already contains the founder ID (see initialization above).
  */
 export function isAdmin(userId: string): boolean {
-  // Allow all users if no admin list is configured (dev mode)
-  if (ADMIN_USER_IDS.size === 0) {
-    return true;
-  }
   return ADMIN_USER_IDS.has(userId);
 }
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -31,13 +31,13 @@ export default function Home() {
           <span className="brand-eyebrow">Built for Degens. By Degens.</span>
 
           <h1 className="landing-hero-title landing-hero-title--centered">
-            The House has the math. You have a dopamine problem. We have The Brakes.
+            HOUSE ALWAYS WINS? FUCK THAT.
           </h1>
 
           <p className="landing-hero-subtitle landing-hero-subtitle--centered">
             TiltCheck is a read-only browser extension that watches live casino sessions,
             detects Auto-Pilot mode, and forces the exit before The Loop feeds your win
-            back to the machine.
+            back to the machine. The house has the math. Now you do too.
           </p>
 
           <div className="hero-actions">


### PR DESCRIPTION
## Summary

Two scoped fixes from the recent repo-wide audit:

- **Security (Critical):** Prize-distribution `isAdmin()` returned `true` for every user when `PRIZE_ADMIN_USER_IDS` was empty. In production with no env, anyone could trigger Solana Pay prize distributions. Now defaults to founder ID `1153034319271559328` only, with a startup `console.warn`. `isAdmin` is now strict set-membership (fail-closed).
- **Brand:** Restored the historical hero `HOUSE ALWAYS WINS? FUCK THAT.` per `BRAND_GUIDELINES.md`, `BRAND_VOICE.md`, `SESSION_LOG.md`. Subtitle keeps the read-only-extension explainer and folds in the audit-layer line.

## Files

- `apps/justthetip-bot/src/services/tipping/prize-distribution.ts`
- `apps/discord-bot/src/services/tipping/prize-distribution.ts`
- `apps/web/src/app/page.tsx`

## Risk / rollback

- Low. Diff is 40 insertions, 18 deletions across 3 files.
- Rollback: revert this commit. Note that reverting the security fix re-opens the allow-all hole — do not roll back without setting `PRIZE_ADMIN_USER_IDS` first.

## Validation

### Prize-admin (security)

- [ ] `pnpm --filter @tiltcheck/discord-bot build`
- [ ] `pnpm --filter @tiltcheck/justthetip-bot build`
- [ ] In dev: confirm warning logs when env unset; confirm only founder ID can run prize commands.
- [ ] In prod: set `PRIZE_ADMIN_USER_IDS` in Railway env to suppress the warning and add any co-admins.
- [ ] Smoke test: non-admin Discord user runs prize command → rejected.

### Hero (brand)

- [ ] `pnpm -C apps/web dev` → visit `/` → headline reads `HOUSE ALWAYS WINS? FUCK THAT.`
- [ ] Confirm subtitle still scans on mobile widths (375px).
- [ ] Re-take OG screenshot if pinned anywhere.

## Closes

- Closes #444
- Closes #445

## Follow-ups (separate issues)

- #448 — implement or delete `deploy-gcp.yml` (so this PR's deploy story is unambiguous)
- Marketing audit: unify `<title>` / OG with the restored hero (`apps/web/src/app/layout.tsx` still says "Degen Audit Layer")
- Pick one primary hero CTA (currently two equal-weight buttons)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authorization for prize distribution in both bots; misconfiguration could unintentionally lock out admins or, if wrong, reopen an access-control hole. Web change is low risk and copy-only.
> 
> **Overview**
> **Security:** Updates prize distribution admin gating in both `discord-bot` and `justthetip-bot` to be *fail-closed*: `isAdmin()` now only allows IDs explicitly configured via `PRIZE_ADMIN_USER_IDS`, with a founder-ID fallback when the env var is unset/empty and a startup `console.warn` to flag the fallback.
> 
> **Brand:** Tweaks `apps/web` landing hero copy by restoring the main headline text and adjusting the subtitle’s closing line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f059f5c4871dfa6d165859beb251ff93351a67a8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->