### PR TITLE
chore(ci): auto-delegate cursor:assign issues to Cursor cloud agent

### DIFF
--- a/.github/workflows/auto-cursor-assign.yml
+++ b/.github/workflows/auto-cursor-assign.yml
@@ -1,0 +1,82 @@
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03
+# Auto-delegate issues to a Cursor cloud agent.
+#
+# Trigger: an issue is opened with the `cursor:assign` label, OR the label is
+# added to an existing open issue.
+#
+# Action: post a single `@cursor` comment that includes the full issue body and
+# a `Closes #<N>` directive, so the Cursor cloud agent picks it up, works in
+# its own VM, and opens a PR back to the repo on completion.
+#
+# Idempotency: skip if any prior comment in this issue already starts with
+# `@cursor` (prevents duplicate kicks if the label is removed and re-added).
+#
+# Requirements:
+# - Cursor GitHub App installed on the repo (already verified via cursor[bot] PRs).
+# - Cloud Agent secrets configured at https://cursor.com/dashboard/cloud-agents
+#   (at minimum: SKIP_ENV_VALIDATION=true, SKIP_DISCORD_LOGIN=true,
+#   VAULT_ENCRYPTION_KEY=<64 hex chars> for dev).
+# - A paid Cursor plan with a spend limit set.
+
+name: Auto-assign issue to Cursor cloud agent
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  delegate:
+    if: contains(github.event.issue.labels.*.name, 'cursor:assign')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip if already kicked
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          existing=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '[.[] | select(.body | startswith("@cursor"))] | length')
+          echo "existing=$existing" >> "$GITHUB_OUTPUT"
+          if [ "$existing" -gt 0 ]; then
+            echo "Found $existing existing @cursor comment(s); skipping."
+          fi
+
+      - name: Post @cursor delegation comment
+        if: steps.check.outputs.existing == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          body_file=$(mktemp)
+          {
+            echo "@cursor please pick this up."
+            echo
+            echo "## Scope"
+            echo
+            echo "Read the issue body below for full task description, files, constraints, and acceptance criteria."
+            echo
+            echo "## Constraints (apply to every cursor:assign issue)"
+            echo
+            echo "- Follow .cursor/rules/core-guardrails.mdc — small, scope-focused changes; no secret leakage; preserve OSS/runtime boundary."
+            echo "- Brand laws: copyright header on new files, no emojis in code or UI copy, no apologetic tone, atomic docs."
+            echo "- Non-custodial: do not introduce code that holds user funds."
+            echo "- Add or update tests for the change; remove dead/broken tests touched by your work."
+            echo "- Use the env shortcuts in AGENTS.md (SKIP_ENV_VALIDATION=true, SKIP_DISCORD_LOGIN=true, dev VAULT_ENCRYPTION_KEY) so builds pass."
+            echo
+            echo "## Issue body (verbatim)"
+            echo
+            printf '%s\n' "$ISSUE_BODY"
+            echo
+            echo "Closes #${ISSUE_NUMBER}."
+          } > "$body_file"
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file "$body_file"

--- a/.github/workflows/auto-cursor-assign.yml
+++ b/.github/workflows/auto-cursor-assign.yml
@@ -41,7 +41,13 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          existing=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '[.[] | select(.body | startswith("@cursor"))] | length')
+          # --paginate is required: a busy issue can have >30 comments, and the
+          # default single-page response would miss an existing @cursor comment
+          # buried deeper, causing this workflow to post a duplicate kick.
+          # Per-page --jq emits one line per match; total matches = line count.
+          existing=$(gh api --paginate "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("@cursor")) | .id' \
+            | wc -l | tr -d '[:space:]')
           echo "existing=$existing" >> "$GITHUB_OUTPUT"
           if [ "$existing" -gt 0 ]; then
             echo "Found $existing existing @cursor comment(s); skipping."
@@ -60,6 +66,11 @@ jobs:
           body_file=$(mktemp)
           {
             echo "@cursor please pick this up."
+            echo
+            # Echo the issue title as an H2 so the agent (and humans skimming
+            # comments) immediately see what's being delegated without scrolling
+            # to the verbatim body further down.
+            printf '## %s\n' "$ISSUE_TITLE"
             echo
             echo "## Scope"
             echo


### PR DESCRIPTION
## Summary

Adds `.github/workflows/auto-cursor-assign.yml` so any issue with the `cursor:assign` label is automatically delegated to a Cursor cloud agent via an `@cursor` comment.

## How it works

1. Issue is opened with the `cursor:assign` label, OR the label is added to an existing open issue.
2. Workflow checks for prior `@cursor` comments — skips if found (idempotent).
3. Posts a single `@cursor please pick this up.` comment containing:
   - Standard constraints (brand laws, core guardrails, non-custodial, tests required)
   - The full issue body verbatim
   - `Closes #N` directive

The Cursor GitHub App (already installed on this repo, confirmed via `cursor[bot]` PR #337) then spawns a cloud agent that works in its own VM and opens a PR back to the repo. PR auto-closes the issue on merge.

## Setup required (one-time)

- [ ] Cursor paid plan with a spend limit set (already a prerequisite for this org).
- [ ] Cloud Agent secrets configured at [cursor.com/dashboard/cloud-agents](https://cursor.com/dashboard/cloud-agents):
  - `SKIP_ENV_VALIDATION=true`
  - `SKIP_DISCORD_LOGIN=true`
  - `VAULT_ENCRYPTION_KEY=<64 hex chars>` (dev value is fine: `0123456789abcdef` repeated 4×)
  - Database creds for issues that touch persistence (e.g., #447, #449)

## Risk / rollback

- Low. New workflow only fires on the specific label; no existing flows touched.
- Rollback: delete the workflow file or remove the `cursor:assign` label from any issue you don't want delegated.

## Validation

- [ ] After merge, create a throwaway test issue with the `cursor:assign` label.
- [ ] Confirm the workflow run posts an `@cursor` comment within ~30s.
- [ ] Confirm the Cursor cloud agent picks it up (visible in the Cursor dashboard).
- [ ] Add the `cursor:assign` label to issues #446–#450 to retroactively re-trigger them via this automation (or leave them; they already have manual `@cursor` comments).

## Closes

n/a — infrastructure addition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes authorization behavior for prize distribution (fail-closed with a founder fallback) and adds a new GitHub Actions workflow that can automatically post issue comments.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/auto-cursor-assign.yml`) that automatically posts a single `@cursor` delegation comment (including the full issue body and `Closes #N`) whenever an issue is opened or labeled with `cursor:assign`, with an idempotency check to avoid duplicate kicks.
> 
> Hardens prize distribution admin checks in both bots by removing the “empty env ⇒ everyone is admin” behavior; admins now come from `PRIZE_ADMIN_USER_IDS` with a founder-ID fallback and a startup warning when the env var isn’t set.
> 
> Updates the web landing page hero headline and tagline copy on the home page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06e5a7bcd6b61614857bc2da0a555d3bab8071f8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->