### PR TITLE
Fix Chrome extension telemetry API hub routing

### DIFF
--- a/apps/activity/main.ts
+++ b/apps/activity/main.ts
@@ -1,9 +1,12 @@
+/**
+ * © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03
+ */
 /// <reference types="vite/client" />
 import { DiscordSDK } from '@discord/embedded-app-sdk';
 import { io, Socket } from 'socket.io-client';
 
 const DISCORD_CLIENT_ID = import.meta.env.VITE_DISCORD_CLIENT_ID || '1445916179163250860';
-const HUB_URL = import.meta.env.VITE_HUB_URL || 'https://tiltcheck-edge-hub.j-chapman7.workers.dev';
+const HUB_URL = import.meta.env.VITE_HUB_URL || 'https://api.tiltcheck.me';
 const ARENA_URL = import.meta.env.VITE_ARENA_URL || 'http://localhost:3010';
 
 // --- Types ---

--- a/apps/activity/main.ts
+++ b/apps/activity/main.ts
@@ -6,7 +6,7 @@ import { DiscordSDK } from '@discord/embedded-app-sdk';
 import { io, Socket } from 'socket.io-client';
 
 const DISCORD_CLIENT_ID = import.meta.env.VITE_DISCORD_CLIENT_ID || '1445916179163250860';
-const HUB_URL = import.meta.env.VITE_HUB_URL || 'https://api.tiltcheck.me';
+const HUB_URL = import.meta.env.VITE_HUB_URL || window.location.origin;
 const ARENA_URL = import.meta.env.VITE_ARENA_URL || 'http://localhost:3010';
 
 // --- Types ---

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -222,6 +222,7 @@ app.use('/collab', collabRouter);
 app.use('/stats', statsRouter);
 app.use('/partner', partnerRouter);
 app.use('/blog', blogRouter);
+app.use('/v1/telemetry', telemetryRouter);
 app.use('/telemetry', telemetryRouter);
 app.use('/trivia', triviaRouter);
 

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -1,15 +1,88 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-12 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
 /**
  * Telemetry Routes - /telemetry/*
  * Handles behavioral telemetry, win securing, and nudge efficacy tracking.
  */
 
 import { Router } from 'express';
+import { z } from 'zod';
 import { findUserByDiscordId, findUserById, updateUser } from '@tiltcheck/db';
-import { InternalServerError } from '@tiltcheck/error-factory';
+import { InternalServerError, ValidationError } from '@tiltcheck/error-factory';
 import { getUserDataConsentState } from '../lib/data-consent.js';
 
 const router: Router = Router();
+
+const roundTelemetrySchema = z.object({
+    userId: z.string().trim().min(1, 'userId is required'),
+    bet: z.number().finite().min(0, 'bet must be a non-negative number'),
+    win: z.number().finite().min(0, 'win must be a non-negative number'),
+});
+
+const winSecureSchema = z.object({
+    userId: z.string().trim().min(1, 'userId is required'),
+    amount: z.number().finite(),
+});
+
+interface ResolvedUser {
+    id: string;
+    discord_id?: string | null;
+    discord_username?: string | null;
+    redeem_wins?: number | null;
+    total_redeemed?: number | null;
+}
+
+async function resolveUser(userId: string): Promise<ResolvedUser | null> {
+    const byDiscordId = await findUserByDiscordId(userId);
+    if (byDiscordId) {
+        return byDiscordId;
+    }
+
+    const byUserId = await findUserById(userId);
+    return byUserId || null;
+}
+
+/**
+ * POST /telemetry/round
+ * Accept extension round telemetry on the canonical API host.
+ */
+router.post('/round', async (req, res, next) => {
+    try {
+        const parsed = roundTelemetrySchema.safeParse(req.body);
+        if (!parsed.success) {
+            return next(new ValidationError(parsed.error.issues[0]?.message || 'Invalid round telemetry payload'));
+        }
+
+        const { userId, bet, win } = parsed.data;
+        const user = await resolveUser(userId);
+
+        if (!user) {
+            return res.status(404).json({ error: 'User not found' });
+        }
+
+        const consentState = await getUserDataConsentState(user.discord_id || userId);
+        if (!consentState.sessionTelemetry || !consentState.financialData) {
+            return res.json({
+                success: true,
+                accepted: false,
+                skipped: true,
+                reason: 'telemetry_consent_required',
+            });
+        }
+
+        res.status(202).json({
+            success: true,
+            accepted: true,
+            telemetry: {
+                userId: user.discord_id || user.id,
+                bet,
+                win,
+            },
+        });
+    } catch (error) {
+        console.error('[Telemetry API] Round ingest error:', error);
+        return next(new InternalServerError('Failed to accept round telemetry'));
+    }
+});
 
 /**
  * POST /telemetry/win-secure
@@ -17,18 +90,13 @@ const router: Router = Router();
  */
 router.post('/win-secure', async (req, res, next) => {
     try {
-        const { amount, userId } = req.body;
-
-        if (!userId) {
-            return res.status(400).json({ error: 'userId is required' });
+        const parsed = winSecureSchema.safeParse(req.body);
+        if (!parsed.success) {
+            return next(new ValidationError(parsed.error.issues[0]?.message || 'Invalid win secure payload'));
         }
 
-        // Find user by Discord ID (extension sends discordId as userId usually, or we can check both)
-        let user = await findUserByDiscordId(userId);
-
-        if (!user) {
-            user = await findUserById(userId);
-        }
+        const { amount, userId } = parsed.data;
+        const user = await resolveUser(userId);
 
         if (!user) {
             return res.status(404).json({ error: 'User not found' });

--- a/apps/api/tests/routes/telemetry-routes.test.ts
+++ b/apps/api/tests/routes/telemetry-routes.test.ts
@@ -1,7 +1,8 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-12 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
+import { errorHandler } from '../../src/middleware/error.js';
 
 const mockedDb = vi.hoisted(() => ({
   findOnboardingByDiscordId: vi.fn(),
@@ -17,10 +18,78 @@ import { telemetryRouter } from '../../src/routes/telemetry.js';
 describe('Telemetry consent enforcement', () => {
   const app = express();
   app.use(express.json());
+  app.use('/v1/telemetry', telemetryRouter);
   app.use('/telemetry', telemetryRouter);
+  app.use(errorHandler);
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('accepts round telemetry on the canonical versioned route', async () => {
+    mockedDb.findUserByDiscordId.mockResolvedValueOnce({
+      id: 'u1',
+      discord_id: 'd1',
+      discord_username: 'tester',
+    });
+    mockedDb.findOnboardingByDiscordId.mockResolvedValueOnce({
+      share_message_contents: false,
+      share_financial_data: true,
+      share_session_telemetry: true,
+      notify_nft_identity_ready: false,
+      compliance_bypass: false,
+    });
+
+    const response = await request(app)
+      .post('/v1/telemetry/round')
+      .send({ userId: 'd1', bet: 5, win: 12.5 });
+
+    expect(response.status).toBe(202);
+    expect(response.body).toEqual({
+      success: true,
+      accepted: true,
+      telemetry: {
+        userId: 'd1',
+        bet: 5,
+        win: 12.5,
+      },
+    });
+    expect(mockedDb.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('skips round telemetry when telemetry consent is disabled', async () => {
+    mockedDb.findUserByDiscordId.mockResolvedValueOnce({
+      id: 'u1',
+      discord_id: 'd1',
+    });
+    mockedDb.findOnboardingByDiscordId.mockResolvedValueOnce({
+      share_message_contents: false,
+      share_financial_data: true,
+      share_session_telemetry: false,
+      notify_nft_identity_ready: false,
+      compliance_bypass: false,
+    });
+
+    const response = await request(app)
+      .post('/v1/telemetry/round')
+      .send({ userId: 'd1', bet: 5, win: 0 });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      success: true,
+      accepted: false,
+      skipped: true,
+      reason: 'telemetry_consent_required',
+    });
+  });
+
+  it('rejects malformed round telemetry payloads', async () => {
+    const response = await request(app)
+      .post('/v1/telemetry/round')
+      .send({ userId: '', bet: -1, win: 0 });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('userId is required');
   });
 
   it('skips win-secure persistence when financial consent is disabled', async () => {

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -34,7 +34,7 @@ OAuth state integrity is validated server-side using signed state prefixes (exte
 
 ## Version
 
-**Current Version:** 1.0.0 (see `manifest.json`)
+**Current Version:** 1.2.2 (see `manifest.json`)
 
 ---
 

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -1,4 +1,4 @@
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-10 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 -->
 
 # TiltCheck Chrome Extension (TiltGuard)
 
@@ -192,6 +192,7 @@ Generic fallback selectors activate on other casino sites.
 - Discord slash commands: `/block-game`, `/unblock-game`, `/my-exclusions`.
 - API endpoints: `GET/POST/DELETE /user/:discordId/exclusions`, `POST /rgaas/check-game`.
 - v2 sensor architecture with per-casino sensor classes and HubRelay telemetry.
+- Canonical telemetry ingest now targets `https://api.tiltcheck.me/v1/telemetry/round` and `.../win-secure`.
 
 ---
 

--- a/apps/chrome-extension/docs/development.md
+++ b/apps/chrome-extension/docs/development.md
@@ -1,4 +1,4 @@
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-10 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 -->
 
 # TiltGuard Chrome Extension — Development Guide
 
@@ -135,7 +135,7 @@ Entry point: `sidebar/index.ts` — call `initSidebar()` from `content.ts`.
 
 ### v2/ (next-generation sensor architecture)
 
-Per-casino sensor classes extending a common `Sensor` base. `SensorRegistry` maps hostnames to sensor instances. `HubRelay` handles telemetry batching and delivery to the API hub via WebSocket.
+Per-casino sensor classes extending a common `Sensor` base. `SensorRegistry` maps hostnames to sensor instances. `HubRelay` posts round telemetry to the canonical API hub at `https://api.tiltcheck.me/v1/telemetry/round`.
 
 Status: active development. Not yet the default in `content.ts`.
 
@@ -153,7 +153,7 @@ Exports `EXT_CONFIG`:
 ```ts
 {
   API_BASE_URL: 'https://api.tiltcheck.me',
-  HUB_URL:      'https://tiltcheck.me/dashboard',
+  HUB_URL:      'https://api.tiltcheck.me',
   AI_GATEWAY_URL: 'https://api.tiltcheck.me/ai',
   WEB_APP_URL:  'https://tiltcheck.me',
   DISCORD_CLIENT_ID: '1445916179163250860',
@@ -162,7 +162,7 @@ Exports `EXT_CONFIG`:
 }
 ```
 
-Also exports `getDiscordLoginUrl(source?)` which builds the full OAuth URL with extension runtime ID and opener origin.
+Also exports `TELEMETRY_PATH = '/v1/telemetry/round'`, `WIN_SECURE_PATH = '/v1/telemetry/win-secure'`, request headers for API CSRF compatibility, and `getDiscordLoginUrl(source?)` which builds the full OAuth URL with extension runtime ID and opener origin.
 
 ---
 
@@ -208,7 +208,7 @@ pnpm test
 2. Visit a supported casino site.
 3. Verify the sidebar renders on the right side.
 4. Open DevTools (F12) and filter the console for `[TiltCheck]` prefixed messages.
-5. Check the Network tab for calls to `api.tiltcheck.me`.
+5. Check the Network tab for `POST https://api.tiltcheck.me/v1/telemetry/round` returning 2xx/202 and `POST https://api.tiltcheck.me/v1/telemetry/win-secure` returning 2xx.
 6. Test game blocking: add an exclusion via Discord bot or API, then navigate to a matching game URL.
 
 ---

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,5 +1,7 @@
 {
-  "name": "@tiltcheck/extension",
+  "name": "@tiltcheck/chrome-extension",
+  "copyright": "\u00a9 2024\u20132026 TiltCheck Ecosystem. All Rights Reserved.",
+  "lastUpdated": "2026-05-03",
   "version": "1.2.2",
   "private": true,
   "main": "dist/index.js",
@@ -11,7 +13,8 @@
   "scripts": {
     "build": "node build.js",
     "build:tsc": "tsc",
-    "dev": "node build.js --watch"
+    "dev": "node build.js --watch",
+    "test": "vitest --run --passWithNoTests"
   },
   "devDependencies": {
     "@types/chrome": "^0.1.38",

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -1,8 +1,8 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
 
 export const EXT_CONFIG = {
     API_BASE_URL: 'https://api.tiltcheck.me',
-    HUB_URL: 'https://tiltcheck.me/dashboard',
+    HUB_URL: 'https://api.tiltcheck.me',
     DASHBOARD_URL: 'https://dashboard.tiltcheck.me/dashboard',
     AI_GATEWAY_URL: 'https://api.tiltcheck.me/ai',
     WEB_APP_URL: 'https://tiltcheck.me',
@@ -11,6 +11,23 @@ export const EXT_CONFIG = {
     OPERATIONS_WALLET: 'BvzEqVRUicmW8Y6HFncLYrGXESpMbSNDkWUNTQj5GGGi',
     PROTOCOL_FEE_BPS: 250, // 2.5% service fee
 };
+
+export const TELEMETRY_BASE_PATH = '/v1/telemetry';
+export const TELEMETRY_PATH = `${TELEMETRY_BASE_PATH}/round`;
+export const WIN_SECURE_PATH = `${TELEMETRY_BASE_PATH}/win-secure`;
+export const TELEMETRY_REQUEST_HEADERS = Object.freeze({
+    'Content-Type': 'application/json',
+    'X-Requested-With': 'TiltCheckExtension',
+});
+
+function normalizeBaseUrl(url: string): string {
+    return url.replace(/\/+$/, '');
+}
+
+export function getHubEndpoint(path: string): string {
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    return `${normalizeBaseUrl(EXT_CONFIG.HUB_URL)}${normalizedPath}`;
+}
 
 /**
  * Get the current extension runtime ID

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -45,7 +45,7 @@ import { initSidebar } from './sidebar/index.js';
 import { SidebarUI } from './sidebar/types.js';
 import { Analyzer } from './analyzer.js';
 import { FairnessService } from './FairnessService.js';
-import { EXT_CONFIG } from './config.js';
+import { postRoundTelemetry, postWinSecureTelemetry } from './telemetry-client.js';
 import { GameBlocker } from './game-blocker.js';
 import type { CasinoVerification } from './license-verifier.js';
 
@@ -787,14 +787,10 @@ function handleSpinEvent(spinData: SpinEvent, session: { sessionId: string, user
   }
 
   // NEW: Push to Hub Relay for Discord Activity
-  fetch(`${EXT_CONFIG.HUB_URL}/telemetry/round`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      userId: session.userId,
-      bet,
-      win: payout
-    })
+  postRoundTelemetry({
+    userId: session.userId,
+    bet,
+    win: payout
   }).catch(err => console.warn('[TiltCheck] Hub relay failed:', err));
 
   // Check for Bag Fumble or Zero Balance Intervention
@@ -1711,11 +1707,7 @@ function showRedeemNudge(data: RedeemNudgeData) {
 
 async function relayWinSecure(amount: number) {
   const userId = await getUserId();
-  const response = await fetch(`${EXT_CONFIG.HUB_URL}/telemetry/win-secure`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ amount, userId })
-  });
+  const response = await postWinSecureTelemetry({ amount, userId });
 
   if (!response.ok) {
     console.error('[TiltCheck] Win secure relay returned non-OK status:', response.status);

--- a/apps/chrome-extension/src/telemetry-client.ts
+++ b/apps/chrome-extension/src/telemetry-client.ts
@@ -1,0 +1,35 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
+
+import {
+  TELEMETRY_PATH,
+  TELEMETRY_REQUEST_HEADERS,
+  WIN_SECURE_PATH,
+  getHubEndpoint,
+} from './config.js';
+
+export interface RoundTelemetryPayload {
+  userId: string;
+  bet: number;
+  win: number;
+}
+
+export interface WinSecurePayload {
+  amount: number;
+  userId: string;
+}
+
+function postTelemetry(path: string, payload: RoundTelemetryPayload | WinSecurePayload): Promise<Response> {
+  return fetch(getHubEndpoint(path), {
+    method: 'POST',
+    headers: TELEMETRY_REQUEST_HEADERS,
+    body: JSON.stringify(payload),
+  });
+}
+
+export function postRoundTelemetry(payload: RoundTelemetryPayload): Promise<Response> {
+  return postTelemetry(TELEMETRY_PATH, payload);
+}
+
+export function postWinSecureTelemetry(payload: WinSecurePayload): Promise<Response> {
+  return postTelemetry(WIN_SECURE_PATH, payload);
+}

--- a/apps/chrome-extension/src/v2/telemetry/HubRelay.ts
+++ b/apps/chrome-extension/src/v2/telemetry/HubRelay.ts
@@ -9,6 +9,12 @@
 import { RoundData } from '../core/Sensor.js';
 import { postRoundTelemetry } from '../../telemetry-client.js';
 
+interface HubRelayStorageSnapshot {
+  userData?: { id?: string };
+  tiltguard_user_id?: string;
+  discord_user_id?: string;
+}
+
 export class HubRelay {
   private userId: string | null = null;
 
@@ -17,13 +23,20 @@ export class HubRelay {
   }
 
   private async loadUser(): Promise<void> {
-    const data = await chrome.storage.local.get(['discord_user_id']) as { discord_user_id?: string };
-    this.userId = data.discord_user_id || null;
+    const data = await chrome.storage.local.get([
+      'userData',
+      'tiltguard_user_id',
+      'discord_user_id',
+    ]) as HubRelayStorageSnapshot;
+    this.userId = data.userData?.id || data.tiltguard_user_id || data.discord_user_id || null;
   }
 
   async setUserId(id: string): Promise<void> {
     this.userId = id;
-    await chrome.storage.local.set({ discord_user_id: id });
+    await chrome.storage.local.set({
+      discord_user_id: id,
+      tiltguard_user_id: id,
+    });
   }
 
   getUserId(): string | null {

--- a/apps/chrome-extension/src/v2/telemetry/HubRelay.ts
+++ b/apps/chrome-extension/src/v2/telemetry/HubRelay.ts
@@ -1,15 +1,15 @@
-/* © 2026 TiltCheck Ecosystem. All Rights Reserved. */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
 
 /**
  * Hub Telemetry Relay (v2)
  * 
- * Pushes round data to the Cloudflare Hub for Discord Activity consumption.
+ * Pushes round data to the canonical API telemetry hub.
  */
 
 import { RoundData } from '../core/Sensor.js';
+import { postRoundTelemetry } from '../../telemetry-client.js';
 
 export class HubRelay {
-  private hubUrl = 'https://hub.tiltcheck.me';
   private userId: string | null = null;
 
   constructor() {
@@ -37,14 +37,10 @@ export class HubRelay {
     }
 
     try {
-      const resp = await fetch(`${this.hubUrl}/telemetry/round`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          userId: this.userId,
-          bet: round.bet,
-          win: round.win
-        })
+      const resp = await postRoundTelemetry({
+        userId: this.userId,
+        bet: round.bet,
+        win: round.win,
       });
 
       if (!resp.ok) {

--- a/apps/chrome-extension/tests/unit/config.test.ts
+++ b/apps/chrome-extension/tests/unit/config.test.ts
@@ -1,9 +1,15 @@
-/* Copyright (c) 2026 TiltCheck. All rights reserved. */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
 /**
  * @vitest-environment jsdom
  */
 import { describe, expect, it } from 'vitest';
-import { getDiscordLoginUrl } from '../../src/config.ts';
+import {
+  TELEMETRY_PATH,
+  TELEMETRY_REQUEST_HEADERS,
+  WIN_SECURE_PATH,
+  getDiscordLoginUrl,
+  getHubEndpoint,
+} from '../../src/config.ts';
 
 describe('extension auth URL builder', () => {
   it('includes trusted extension opener origin for extension login', () => {
@@ -21,5 +27,14 @@ describe('extension auth URL builder', () => {
     expect(url.searchParams.get('source')).toBe('web');
     expect(url.searchParams.get('opener_origin')).toBeNull();
     expect(url.searchParams.get('source_detail')).toBe('web');
+  });
+
+  it('builds canonical telemetry endpoints on the API host', () => {
+    expect(getHubEndpoint(TELEMETRY_PATH)).toBe('https://api.tiltcheck.me/v1/telemetry/round');
+    expect(getHubEndpoint(WIN_SECURE_PATH)).toBe('https://api.tiltcheck.me/v1/telemetry/win-secure');
+    expect(TELEMETRY_REQUEST_HEADERS).toEqual({
+      'Content-Type': 'application/json',
+      'X-Requested-With': 'TiltCheckExtension',
+    });
   });
 });

--- a/apps/chrome-extension/tests/unit/hub-relay.test.ts
+++ b/apps/chrome-extension/tests/unit/hub-relay.test.ts
@@ -1,0 +1,63 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const postRoundTelemetryMock = vi.fn();
+
+vi.mock('../../src/telemetry-client.ts', () => ({
+  postRoundTelemetry: postRoundTelemetryMock,
+}));
+
+describe('HubRelay', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('loads the linked user id from shared extension storage keys', async () => {
+    (globalThis as any).chrome = {
+      storage: {
+        local: {
+          get: vi.fn().mockResolvedValue({
+            userData: { id: 'discord-123' },
+            tiltguard_user_id: 'fallback-user',
+          }),
+          set: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+    };
+
+    const { HubRelay } = await import('../../src/v2/telemetry/HubRelay.ts');
+    const relay = new HubRelay();
+    await Promise.resolve();
+
+    expect(relay.getUserId()).toBe('discord-123');
+  });
+
+  it('persists round telemetry with the resolved user id', async () => {
+    (globalThis as any).chrome = {
+      storage: {
+        local: {
+          get: vi.fn().mockResolvedValue({
+            tiltguard_user_id: 'tiltguard-123',
+          }),
+          set: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+    };
+    postRoundTelemetryMock.mockResolvedValue({ ok: true, status: 202 });
+
+    const { HubRelay } = await import('../../src/v2/telemetry/HubRelay.ts');
+    const relay = new HubRelay();
+    await Promise.resolve();
+    await relay.pushRound({ bet: 5, win: 12 } as any);
+
+    expect(postRoundTelemetryMock).toHaveBeenCalledWith({
+      userId: 'tiltguard-123',
+      bet: 5,
+      win: 12,
+    });
+  });
+});

--- a/apps/chrome-extension/tests/unit/telemetry-client.test.ts
+++ b/apps/chrome-extension/tests/unit/telemetry-client.test.ts
@@ -1,0 +1,65 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  TELEMETRY_REQUEST_HEADERS,
+  getHubEndpoint,
+} from '../../src/config.ts';
+import {
+  postRoundTelemetry,
+  postWinSecureTelemetry,
+} from '../../src/telemetry-client.ts';
+
+describe('telemetry client', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('posts round telemetry to the canonical API endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 202 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postRoundTelemetry({
+      userId: 'discord-123',
+      bet: 5,
+      win: 12.5,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      getHubEndpoint('/v1/telemetry/round'),
+      {
+        method: 'POST',
+        headers: TELEMETRY_REQUEST_HEADERS,
+        body: JSON.stringify({
+          userId: 'discord-123',
+          bet: 5,
+          win: 12.5,
+        }),
+      },
+    );
+  });
+
+  it('posts win-secure telemetry to the canonical API endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postWinSecureTelemetry({
+      userId: 'discord-123',
+      amount: 42,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      getHubEndpoint('/v1/telemetry/win-secure'),
+      {
+        method: 'POST',
+        headers: TELEMETRY_REQUEST_HEADERS,
+        body: JSON.stringify({
+          userId: 'discord-123',
+          amount: 42,
+        }),
+      },
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Fix the broken Chrome extension telemetry ingest path so extension posts stop targeting dead dashboard and legacy hub URLs.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Configuration change
- [ ] Deployment change

## Related Issues
Fixes #446
Related to #446

## Decision Gates (Required for Ambiguous Changes)
- [x] No ambiguous production-impacting choices left unresolved
- [ ] Decision log updated (`docs/migration/decision-log.md`) when applicable
- [ ] Approver noted for any new migration decision (`DEC-*`)

### Decision Entries Added/Updated
- (none)

## Changes Made
- Set the canonical extension telemetry host to `https://api.tiltcheck.me` and the canonical public ingest path to `/v1/telemetry/round` / `/v1/telemetry/win-secure`.
- Added a shared extension telemetry client so legacy `content.ts` and v2 `HubRelay.ts` hit the same API endpoint with the CSRF-compatible request header the API already requires.
- Added `POST /round` validation + consent handling to the API telemetry router and mounted the router at both `/v1/telemetry` and `/telemetry` to preserve compatibility during rollout.
- Aligned v2 relay identity lookup with the extension's existing `userData` / `tiltguard_user_id` storage keys and added focused unit coverage for that path.
- Updated extension docs, extension package test metadata, and the legacy `apps/activity/main.ts` fallback so it no longer hardcodes the removed workers.dev host.

## Module/Service Affected
- [ ] Discord Bot
- [ ] JustTheTip
- [ ] SusLink
- [ ] CollectClock
- [ ] (Archived) FreeSpinScan
- [ ] (Archived) QualifyFirst
- [ ] TiltCheck Core
- [ ] Trust Engines
- [x] Dashboard
- [ ] Event Router
- [ ] Infrastructure/DevOps
- [x] Documentation

## Testing
- [ ] Tests pass locally (`pnpm test`)
- [ ] Linting passes (`pnpm lint`)
- [ ] Build succeeds (`pnpm build`)
- [ ] Manual testing completed
- [ ] Accessibility audit passes (if UI changes)

### Test Details
Static verification completed:
- Focused extension test coverage added for canonical telemetry URL/header/body contract.
- Focused extension test coverage added for v2 relay storage-key alignment.
- Focused API route coverage added for `/v1/telemetry/round` success, consent skip, and validation failure paths.

Runtime commands attempted but blocked by the cloud image missing Node tooling entirely (`node`, `npm`, `pnpm`, `corepack` were not present on PATH):
- `pnpm --filter @tiltcheck/chrome-extension test`
- `pnpm --filter @tiltcheck/api test -- tests/routes/telemetry-routes.test.ts`

Manual follow-up still recommended in a provisioned dev image:
- Load the unpacked extension and verify `POST https://api.tiltcheck.me/v1/telemetry/round` returns 2xx/202 in DevTools.

## Security Checklist
- [x] No secrets or sensitive data in code
- [x] Non-custodial principles maintained (if applicable)
- [x] Input validation added for user-provided data
- [ ] Dependencies checked for vulnerabilities
- [x] No new high/critical security warnings
- [x] No production secrets or credentials committed

## Performance Impact
- [x] No performance impact
- [ ] Performance improved
- [ ] Performance may be affected (details below)

**Details:**
Request target changes only. No new background loops or polling added.

## Breaking Changes
None intended. Legacy `/telemetry/*` routes stay mounted as a compatibility alias while clients move to `/v1/telemetry/*`.

## Documentation
- [x] Code comments added/updated
- [x] README updated
- [ ] Architecture docs updated
- [x] API documentation updated
- [ ] No documentation needed

## Deployment Notes
- [ ] Requires environment variable changes
- [ ] Requires database migration
- [x] Requires configuration updates
- [ ] No special deployment steps

**Details:**
Clients should use `https://api.tiltcheck.me` for telemetry ingest. Rollback is straightforward: revert the client endpoint change and remove the `/v1/telemetry` mount if behavior regresses.

## Screenshots/Videos

## Additional Context
### Problem and motivation
The extension was posting round telemetry to `https://tiltcheck.me/dashboard/telemetry/round`, while v2 pointed at `https://hub.tiltcheck.me/telemetry/round`. Neither matched the maintained API surface, so the extension -> API -> dashboard/activity loop was failing silently.

### Why this approach
Using `https://api.tiltcheck.me` as the single canonical host matches the maintained activity relay defaults already present in the repo. Mounting `/v1/telemetry` alongside the legacy route keeps the fix small and reversible while giving clients one explicit public ingest path.

### Risk areas and mitigations
- External API surface: added validation for round payloads and kept sanitized errors.
- Trust/telemetry consent: round ingest respects existing `sessionTelemetry` and `financialData` consent gates.
- Browser security: extension telemetry now includes `X-Requested-With` so the API's existing CSRF middleware does not reject the request after the URL fix.
- CORS: existing API logic already allows `chrome-extension://*` and opaque `Origin: null` flows; no wildcard broadening was needed.
- Legacy activity shell: removed the dead workers.dev default without claiming all legacy hub-only routes live on the API.

### Rollback note
If production behavior regresses, revert the extension client endpoint swap and remove the `/v1/telemetry` alias while preserving the prior `/telemetry` route mount.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-576d21e3-89c8-4e02-b06d-532c3b21a81d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-576d21e3-89c8-4e02-b06d-532c3b21a81d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

