### PR TITLE
fix(bots): use ActivityType enum in /launch (unblocks Railway build)

### DIFF
--- a/apps/dad-bot/src/commands/launch.ts
+++ b/apps/dad-bot/src/commands/launch.ts
@@ -11,6 +11,7 @@ import {
 } from 'discord.js';
 import { v4 as uuidv4 } from 'uuid';
 import type { Command } from '../types.js';
+import { ActivityType } from '@tiltcheck/discord-activities';
 
 let activityManager: any = null;
 
@@ -37,7 +38,7 @@ async function execute(interaction: ChatInputCommandInteraction): Promise<void> 
       userId,
       guildId,
       channelId,
-      activityType: 'trivia',
+      activityType: ActivityType.TRIVIA,
       instanceId,
       sessionToken,
       applicationId: interaction.client.application?.id || '',

--- a/apps/discord-bot/src/commands/launch.ts
+++ b/apps/discord-bot/src/commands/launch.ts
@@ -11,7 +11,7 @@ import {
 } from 'discord.js';
 import { v4 as uuidv4 } from 'uuid';
 import type { Command } from '../types.js';
-import { DiscordActivityManager } from '@tiltcheck/discord-activities';
+import { DiscordActivityManager, ActivityType } from '@tiltcheck/discord-activities';
 
 let activityManager: DiscordActivityManager | null = null;
 
@@ -38,7 +38,7 @@ async function execute(interaction: ChatInputCommandInteraction): Promise<void> 
       userId,
       guildId,
       channelId,
-      activityType: 'trivia',
+      activityType: ActivityType.TRIVIA,
       instanceId,
       sessionToken,
       applicationId: interaction.client.application?.id || '',


### PR DESCRIPTION
## Summary

Unblocks the Railway build that started failing on `apps/discord-bot` after PR #442 (trivia/activities) merged:

```
src/commands/launch.ts(41,7): error TS2322:
  Type '"trivia"' is not assignable to type 'ActivityType'.
```

`ActivityType` is an exported **enum** in `@tiltcheck/discord-activities` (`packages/discord-activities/src/types.ts` L7-12), not a string union. Both `apps/discord-bot/src/commands/launch.ts` and `apps/dad-bot/src/commands/launch.ts` were passing the raw string `'trivia'`. The discord-bot fail-fasts on this because its `activityManager` is properly typed; dad-bot uses `any` so TS hadn't caught it yet, but the same fix applies for consistency.

## Files

- `apps/discord-bot/src/commands/launch.ts` — import `ActivityType`, use `ActivityType.TRIVIA`
- `apps/dad-bot/src/commands/launch.ts` — same fix mirrored

## Validation

Verified locally on a clean checkout of this branch:

- `pnpm --filter @tiltcheck/discord-bot build` — PASSES
- `pnpm --filter @tiltcheck/dad-bot build` — PASSES

After merge, the next Railway run on `main` should succeed for `discord-bot`.

## Risk / rollback

- Trivial. 4-line change across 2 files. No runtime semantics change (the enum value `ActivityType.TRIVIA` resolves to the same string `'trivia'`).
- Rollback: revert this PR. Railway will fail again until #442's `launch.ts` is otherwise fixed.

## Note

This branch was produced by a Cursor cloud agent in response to the build failure. Diff verified byte-identical to a parallel manual fix; opening this PR to get it merged faster.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: swaps a string literal for the exported `ActivityType` enum in two `/launch` commands to satisfy TypeScript typing; no behavioral change beyond compile-time correctness.
> 
> **Overview**
> Updates both bots’ `/launch` command to pass `activityType: ActivityType.TRIVIA` (and import `ActivityType` from `@tiltcheck/discord-activities`) instead of the raw `'trivia'` string.
> 
> This aligns the call with the SDK’s `ActivityLaunchConfig` typing and fixes the TypeScript build failure in `apps/discord-bot` while keeping `apps/dad-bot` consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e98039254694516de18fdca8689c88d332db803. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->