### PR TITLE
Fix payout retry state and tunnel placeholders

### DIFF
--- a/apps/activity/cloudflare-tunnel.yml
+++ b/apps/activity/cloudflare-tunnel.yml
@@ -1,3 +1,4 @@
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03
 # TiltCheck Discord Activity — Cloudflare Named Tunnel
 #
 # A Named Tunnel provides a STABLE URL that doesn't change when you restart.
@@ -9,11 +10,11 @@
 #    npx cloudflared tunnel create dev-activity
 #
 # 3. GET THE UUID
-#    The output of Step 2 will have a UUID. Replace {UUID} below:
+#    Replace the placeholder values below with the tunnel UUID and credentials path.
 #
 
-tunnel: d066ae5e-0a61-407d-8eaa-825eac967b1c
-credentials-file: C:\Users\jmeni\.cloudflared\d066ae5e-0a61-407d-8eaa-825eac967b1c.json
+tunnel: REPLACE_WITH_TUNNEL_UUID
+credentials-file: REPLACE_WITH_CREDENTIALS_PATH
 
 ingress:
   - hostname: dev-activity.tiltcheck.me

--- a/apps/degens-activity/cloudflare-tunnel.yml
+++ b/apps/degens-activity/cloudflare-tunnel.yml
@@ -10,11 +10,11 @@
 #    npx cloudflared tunnel create dev-degens
 #
 # 3. GET THE UUID
-#    Replace the values below with the UUID and matching credentials file path.
+#    Replace the placeholders below with the tunnel UUID and credentials file path.
 #
 
 tunnel: REPLACE_WITH_TUNNEL_UUID
-credentials-file: C:\Users\jmeni\.cloudflared\REPLACE_WITH_TUNNEL_UUID.json
+credentials-file: REPLACE_WITH_CREDENTIALS_PATH
 
 ingress:
   - hostname: dev-degens.tiltcheck.me

--- a/apps/tiltcheck-activity/cloudflare-tunnel.yml
+++ b/apps/tiltcheck-activity/cloudflare-tunnel.yml
@@ -10,11 +10,11 @@
 #    npx cloudflared tunnel create dev-tiltcheck-activity
 #
 # 3. GET THE UUID
-#    Replace the placeholder values below and update the credentials path.
+#    Replace the placeholder values below with the tunnel UUID and credentials path.
 #
 
 tunnel: REPLACE_WITH_TUNNEL_UUID
-credentials-file: C:\Users\jmeni\.cloudflared\REPLACE_WITH_TUNNEL_UUID.json
+credentials-file: REPLACE_WITH_CREDENTIALS_PATH
 
 ingress:
   - hostname: dev-tiltcheck-activity.tiltcheck.me

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -73,7 +73,7 @@ Public hostnames come from `.github/workflows/configure-tunnel.yml`, not from th
 - Local tunnel support is wired for Discord dev sessions:
   - `pnpm --filter @tiltcheck/degens-activity dev:tunnel` -> `dev-degens.tiltcheck.me`
   - `pnpm --filter @tiltcheck/tiltcheck-activity dev:tunnel` -> `dev-tiltcheck-activity.tiltcheck.me`
-  - Replace the placeholder tunnel UUID and credentials path in each app's `cloudflare-tunnel.yml` before use.
+- Replace the placeholder tunnel UUID and generic credentials path placeholder in each app's `cloudflare-tunnel.yml` before use.
 
 ### `chrome-extension`
 

--- a/packages/prize-payout/src/ledger.js
+++ b/packages/prize-payout/src/ledger.js
@@ -201,6 +201,10 @@ export function retryPayout(id, options = {}) {
     throw new Error(`Payout not found: ${id}`);
   }
 
+  if (payout.status === 'completed') {
+    throw new Error(`Cannot retry a completed payout: ${id}`);
+  }
+
   payout.status = 'pending';
   payout.updatedAt = new Date().toISOString();
   // Manual retry starts a fresh attempt budget for the same payout record.

--- a/packages/prize-payout/src/ledger.js
+++ b/packages/prize-payout/src/ledger.js
@@ -203,6 +203,8 @@ export function retryPayout(id, options = {}) {
 
   payout.status = 'pending';
   payout.updatedAt = new Date().toISOString();
+  // Manual retry starts a fresh attempt budget for the same payout record.
+  payout.attempts = [];
   payout.lastError = null;
   payout.completedAt = null;
   saveState(state, options);

--- a/packages/prize-payout/src/ledger.js
+++ b/packages/prize-payout/src/ledger.js
@@ -204,6 +204,9 @@ export function retryPayout(id, options = {}) {
   payout.status = 'pending';
   payout.updatedAt = new Date().toISOString();
   // Manual retry starts a fresh attempt budget for the same payout record.
+  // Archive historical attempts to metadata to preserve audit trail before resetting budget.
+  payout.metadata.retryHistory = payout.metadata.retryHistory || [];
+  payout.metadata.retryHistory.push({ retriedAt: payout.updatedAt, attempts: [...payout.attempts] });
   payout.attempts = [];
   payout.lastError = null;
   payout.completedAt = null;

--- a/packages/prize-payout/tests/payout.test.js
+++ b/packages/prize-payout/tests/payout.test.js
@@ -42,4 +42,29 @@ describe('prize-payout ledger', () => {
     const retried = listPayouts({ dir: TEST_DIR }).find(x => x.id === p.id);
     expect(retried.status).toBe('pending');
   });
+
+  it('resets historical attempts on manual retry', () => {
+    initLedger({ dir: TEST_DIR });
+    const payload = { idempotencyKey: 'retry-2', distributionId: 'dist-retry-2', recipients: ['u1'], total: 1 };
+    const p = createPayout(payload, { dir: TEST_DIR });
+
+    for (let i = 0; i < 5; i++) {
+      markPayoutAttempt(p.id, { success: false, error: `transient-${i}` }, { dir: TEST_DIR, maxAttempts: 5 });
+    }
+
+    retryPayout(p.id, { dir: TEST_DIR });
+    const retried = listPayouts({ dir: TEST_DIR }).find(x => x.id === p.id);
+    expect(retried.status).toBe('pending');
+    expect(retried.attempts).toEqual([]);
+
+    const afterRetryFailure = markPayoutAttempt(
+      p.id,
+      { success: false, error: 'post-retry-failure' },
+      { dir: TEST_DIR, maxAttempts: 5 }
+    );
+
+    expect(afterRetryFailure.status).toBe('pending');
+    expect(afterRetryFailure.attempts).toHaveLength(1);
+    expect(afterRetryFailure.lastError).toBe('post-retry-failure');
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

## Description
Fix two regressions in the follow-up tunnel and payout work: `retryPayout` now resets the attempt budget correctly for manual retries, and Discord activity tunnel templates no longer hardcode a developer-specific Windows credentials path.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Security fix
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Configuration change
- [ ] Deployment change

## Related Issues
Fixes #
Related to #

## Decision Gates (Required for Ambiguous Changes)
- [x] No ambiguous production-impacting choices left unresolved
- [ ] Decision log updated (`docs/migration/decision-log.md`) when applicable
- [ ] Approver noted for any new migration decision (`DEC-*`)

### Decision Entries Added/Updated
- (none)

## Changes Made
- Cleared historical `attempts` inside `retryPayout` so a manual retry starts with a fresh failure budget.
- Added a regression test proving a payout does not immediately fail again after retry because of stale attempt history.
- Replaced developer-specific `credentials-file` values in activity tunnel templates with a generic `REPLACE_WITH_CREDENTIALS_PATH` placeholder.
- Updated deploy docs to match the generic placeholder guidance.

## Module/Service Affected
- [ ] Discord Bot
- [ ] JustTheTip
- [ ] SusLink
- [ ] CollectClock
- [ ] (Archived) FreeSpinScan
- [ ] (Archived) QualifyFirst
- [ ] TiltCheck Core
- [ ] Trust Engines
- [ ] Dashboard
- [ ] Event Router
- [x] Infrastructure/DevOps
- [x] Documentation

## Testing
- [ ] Tests pass locally (`pnpm test`)
- [ ] Linting passes (`pnpm lint`)
- [ ] Build succeeds (`pnpm build`)
- [x] Manual testing completed
- [ ] Accessibility audit passes (if UI changes)

### Test Details
- Parsed `apps/activity/cloudflare-tunnel.yml`, `apps/degens-activity/cloudflare-tunnel.yml`, and `apps/tiltcheck-activity/cloudflare-tunnel.yml` successfully with `python3` YAML loading.
- Ran `git diff --check` on the touched files with no whitespace issues.
- Added a targeted regression test for `retryPayout` attempt reset behavior.
- Could not execute Node/Vitest in Cursor Cloud because this image does not have `node`, `pnpm`, or `npx` installed.

## Security Checklist
- [x] No secrets or sensitive data in code
- [x] Non-custodial principles maintained (if applicable)
- [ ] Input validation added for user-provided data
- [ ] Dependencies checked for vulnerabilities
- [x] No new high/critical security warnings
- [x] No production secrets or credentials committed

## Performance Impact
- [x] No performance impact
- [ ] Performance improved
- [ ] Performance may be affected (details below)

**Details:**
State-management and template-only fix.

## Breaking Changes
None.

## Documentation
- [ ] Code comments added/updated
- [x] README updated
- [ ] Architecture docs updated
- [ ] API documentation updated
- [ ] No documentation needed

## Deployment Notes
- [ ] Requires environment variable changes
- [ ] Requires database migration
- [x] Requires configuration updates
- [ ] No special deployment steps

**Details:**
Developers using the local Discord activity tunnel templates should replace `REPLACE_WITH_TUNNEL_UUID` and `REPLACE_WITH_CREDENTIALS_PATH` with their own local Cloudflare tunnel values.

## Screenshots/Videos
Not applicable.

## Additional Context
This fixes two follow-up issues reported after the initial payout-package and tunnel scaffolding work.

---

## Reviewer Checklist
- [ ] Code follows TiltCheck architecture principles
- [ ] Changes are minimal and focused
- [ ] Security implications reviewed
- [ ] Tests are adequate
- [ ] Documentation is complete
- [ ] No unnecessary dependencies added
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7160605-699a-4a5f-be0b-fb4279131970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7160605-699a-4a5f-be0b-fb4279131970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

