### PR TITLE
Extension: Discord login (TIL-18)

### DIFF
--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -29,6 +29,10 @@ Two runtime modes:
 - **Demo / guest mode** (sidebar): no token; mock-friendly paths until the user logs in.
 - **Magic Link** (popup only): optional email sign-in stores the same `chrome.storage.local` keys; Discord-only tools stay gated until `userData.discordId` exists.
 
+### Marketing site (`tiltcheck.me`)
+
+When you visit **`https://tiltcheck.me`** (or `www.`) with the extension enabled, the content script copies the extension **`authToken`** into the page **`localStorage`** entry **`tc_token`** — the same key `apps/web` uses in `fetchAuthSession`. That keeps the public marketing Next.js app aligned with extension Discord login even if browser storage partitioning makes the API session cookie flaky for `fetch` from the page. Subdomains such as `dashboard.tiltcheck.me` are left alone (different app and token key). Extension **Log out** clears `authToken`; an active marketing tab gets `tc_token` removed via `chrome.storage.onChanged`, or the next full page load re-syncs from storage.
+
 ### Discord Developer Portal redirect URIs
 
 Register the callback URL that matches your API environment (same value the API uses for `redirect_uri` when `source=extension`):

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -1,4 +1,4 @@
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 -->
 
 # TiltCheck Chrome Extension (TiltGuard)
 
@@ -25,10 +25,24 @@ TiltGuard is a Manifest V3 Chrome extension that runs as a content script on cas
 
 Two runtime modes:
 
-- **Authenticated mode** (Discord OAuth): full API-backed flows with persisted account and session data.
-- **Demo mode** (no login): active automatically when no auth token is present. Mock responses are served for core sidebar interactions so users can explore the product before connecting Discord.
+- **Discord-linked account** (primary): user clicks **Log in with Discord** in the sidebar (toolbar icon on supported casino pages). OAuth runs in a small API-driven flow; the API callback page `postMessage`s a JWT plus user payload to `auth-bridge.html` (packaged inside the extension). The bridge writes **`chrome.storage.local`** (`authToken`, `userData`, and `tiltguard_user_id`). That storage is origin-scoped to the extension, persists across browser restarts, and is what the sidebar polls after login. The API also sets an **httpOnly session cookie** on `api.tiltcheck.me` during the OAuth round-trip in the browser; the extension does not read that cookie. API calls from the extension send **`Authorization: Bearer <authToken>`** where required. The built `popup.html` flow matches the same storage contract for builds that set `action.default_popup` in the manifest.
+- **Demo / guest mode** (sidebar): no token; mock-friendly paths until the user logs in.
+- **Magic Link** (popup only): optional email sign-in stores the same `chrome.storage.local` keys; Discord-only tools stay gated until `userData.discordId` exists.
 
-OAuth state integrity is validated server-side using signed state prefixes (extension origin vs web origin) during callback handling.
+### Discord Developer Portal redirect URIs
+
+Register the callback URL that matches your API environment (same value the API uses for `redirect_uri` when `source=extension`):
+
+| Environment | Redirect URI to register in Discord |
+| :--- | :--- |
+| Production (extension OAuth) | `https://api.tiltcheck.me/auth/discord/callback` |
+| Local API (`NODE_ENV` not production, host `localhost` / `127.0.0.1`) | Whatever your API `DISCORD_REDIRECT_URI` / `TILT_DISCORD_REDIRECT_URI` resolves to (often `http://localhost:8080/auth/discord/callback`). |
+
+The extension never uses `https://<extension-id>.chromiumapp.org/` for this flow; the auth bridge keeps `opener_origin` as `chrome-extension://<id>` so the callback can target the bridge tab safely.
+
+### Log out
+
+Sidebar header control and popup **Log out** call `POST /auth/logout` with the bearer token when present, then clear the same `chrome.storage.local` keys so UI returns to signed-out state everywhere.
 
 ---
 
@@ -40,7 +54,7 @@ OAuth state integrity is validated server-side using signed state prefixes (exte
 
 ## Known Gaps
 
-- `manifest.json` declares `"default_popup": "popup.html"` under the `action` key, but `popup.html` does not exist in the source tree or the `dist/` output. The extension currently operates in sidebar-only mode; the popup entry point is not implemented. Until this file is created, clicking the toolbar icon will show an error in Chrome. This is a tracked gap, not a regression.
+- Toolbar icon behavior follows `src/manifest.json`. Rebuild (`pnpm build` in this package) so `dist/` matches source before loading unpacked in Chrome.
 
 ---
 
@@ -49,7 +63,7 @@ OAuth state integrity is validated server-side using signed state prefixes (exte
 ```
 apps/chrome-extension/
 ├── README.md                     # This file
-├── manifest.json                 # Active Chrome extension manifest (MV3)
+├── manifest.json                 # Legacy / alternate manifest (see src/manifest.json for shipped MV3)
 ├── package.json                  # Extension dependencies
 ├── tsconfig.json                 # TypeScript configuration
 ├── build.js                      # esbuild-based build script

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tiltcheck/chrome-extension",
   "copyright": "© 2024–2026 TiltCheck Ecosystem. All Rights Reserved.",
-  "lastUpdated": "2026-05-03",
+  "lastUpdated": "2026-05-06",
   "version": "1.2.2",
   "private": true,
   "main": "dist/index.js",

--- a/apps/chrome-extension/src/auth-bridge.html
+++ b/apps/chrome-extension/src/auth-bridge.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 -->
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -69,6 +70,7 @@
         <button id="open-btn" type="button">Open Discord Auth</button>
         <button id="close-btn" type="button">Close</button>
       </div>
+      <p style="margin-top:18px;font-size:10px;opacity:0.45;text-align:center;text-transform:uppercase;letter-spacing:0.06em;">Made for Degens. By Degens.</p>
     </main>
     <script src="./auth-bridge.js"></script>
   </body>

--- a/apps/chrome-extension/src/auth-bridge.js
+++ b/apps/chrome-extension/src/auth-bridge.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2026 TiltCheck. All rights reserved. */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 (() => {
   const statusEl = document.getElementById('status');
   const openBtn = document.getElementById('open-btn');

--- a/apps/chrome-extension/src/background.js
+++ b/apps/chrome-extension/src/background.js
@@ -1,4 +1,4 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-09
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 /**
  * MV3 service worker.
  * Sidebar-first controls and shared tab actions.

--- a/apps/chrome-extension/src/config.ts
+++ b/apps/chrome-extension/src/config.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 
 export const EXT_CONFIG = {
     API_BASE_URL: 'https://api.tiltcheck.me',

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-24 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 
 /**
  * Enhanced Content Script - TiltCheck + License Verification
@@ -48,6 +48,10 @@ import { FairnessService } from './FairnessService.js';
 import { postRoundTelemetry, postWinSecureTelemetry } from './telemetry-client.js';
 import { GameBlocker } from './game-blocker.js';
 import type { CasinoVerification } from './license-verifier.js';
+import {
+  attachMarketingSiteStorageListener,
+  syncMarketingSiteTokenFromExtensionStorage,
+} from './web-app-session-sync.js';
 
 interface StoredUserData {
   id?: string;
@@ -500,6 +504,9 @@ class Highlighter {
  */
 function initialize() {
   if (process.env.NODE_ENV !== 'production') console.log('[TiltCheck] Initializing on:', window.location.hostname);
+
+  syncMarketingSiteTokenFromExtensionStorage();
+  attachMarketingSiteStorageListener();
 
   // Create sidebar UI
   sidebar = initSidebar();

--- a/apps/chrome-extension/src/manifest.json
+++ b/apps/chrome-extension/src/manifest.json
@@ -46,6 +46,7 @@
         "https://*.shuffle.com/*",
         "https://*.gamdom.com/*",
         "https://*.csgoempire.com/*",
+        "https://tiltcheck.me/*",
         "https://*.tiltcheck.me/*"
       ],
       "js": [
@@ -63,6 +64,7 @@
         "https://*.shuffle.com/*",
         "https://*.gamdom.com/*",
         "https://*.csgoempire.com/*",
+        "https://tiltcheck.me/*",
         "https://*.tiltcheck.me/*"
       ],
       "js": [

--- a/apps/chrome-extension/src/popup.html
+++ b/apps/chrome-extension/src/popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -593,7 +593,7 @@
       On your casino tab, click the TiltCheck icon in the page margin to open it.
     </div>
     <p>Use Discord to sync your vault, sessions, and community tools.</p>
-    <button class="btn btn-primary" id="btn-login">Connect with Discord</button>
+    <button class="btn btn-primary" id="btn-login">Log in with Discord</button>
     <div style="height:10px"></div>
     <input id="magic-email" type="email" placeholder="you@example.com" autocomplete="email" />
     <div style="height:10px"></div>
@@ -639,6 +639,7 @@
       </svg>
       Open Dashboard
     </button>
+    <button class="btn btn-danger-ghost" id="btn-logout" type="button" style="width:100%; margin-top:10px;">Log out</button>
     <div id="limited-auth-note" class="empty-state" style="display:none; margin-top:12px;">
       <strong>Site account connected.</strong>
       Discord-only tools stay hidden here until your account is linked. Dashboard inbox and approved beta access still work.

--- a/apps/chrome-extension/src/popup.ts
+++ b/apps/chrome-extension/src/popup.ts
@@ -1,4 +1,4 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-06-15
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 import { EXT_CONFIG, getDiscordLoginUrl } from './config.js';
 
 // ---------------------------------------------------------------------------
@@ -91,6 +91,9 @@ async function loadAuth(): Promise<void> {
         userData = data.userData;
       } else if (data.tiltguard_user_id) {
         userId = data.tiltguard_user_id;
+      } else {
+        userId = null;
+        userData = null;
       }
       resolve();
     });
@@ -116,8 +119,12 @@ async function checkOnboardingStatus(): Promise<void> {
   if (!linkedDiscordId) return;
 
   try {
+    const token = await getToken();
     const res = await fetch(`${EXT_CONFIG.API_BASE_URL}/me/onboarding-status`, {
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
       credentials: 'include',
     });
     if (!res.ok) return;
@@ -176,6 +183,63 @@ function getLinkedDiscordRouteId(): string | null {
   return userData?.discordId ?? null;
 }
 
+function attachAuthStorageSync(): void {
+  chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== 'local') return;
+    if (!changes.authToken && !changes.userData) return;
+
+    const hadDiscord = Boolean(userData?.discordId);
+    void loadAuth().then(() => {
+      renderAuthState();
+      loadFeed();
+      if (userData?.discordId) {
+        loadStatus();
+      }
+      if (!hadDiscord && userData?.discordId) {
+        toast('Discord sign-in complete.');
+      }
+    });
+  });
+}
+
+async function performLogout(): Promise<void> {
+  const token = await getToken();
+  let serverLogoutFailed = false;
+  try {
+    const response = await fetch(`${EXT_CONFIG.API_BASE_URL}/auth/logout`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!response.ok) {
+      serverLogoutFailed = true;
+    }
+  } catch {
+    serverLogoutFailed = true;
+  }
+
+  await new Promise<void>((resolve) => {
+    chrome.storage.local.set(
+      {
+        authToken: null,
+        userData: null,
+        tiltguard_user_id: null,
+      },
+      () => resolve(),
+    );
+  });
+
+  userId = null;
+  userData = null;
+  renderAuthState();
+  loadFeed();
+  toast(
+    serverLogoutFailed
+      ? 'Logged out locally. Shared session may still be active.'
+      : 'Logged out.',
+  );
+}
+
 function openDashboardTab(tab: 'safety' | 'vault' | 'buddies' | 'profile' = 'profile') {
   const dashboardUrl = new URL(EXT_CONFIG.DASHBOARD_URL);
   if (tab !== 'profile') {
@@ -193,8 +257,12 @@ async function loadStatus() {
   if (!linkedDiscordId) return;
 
   try {
+    const token = await getToken();
     const res = await fetch(`${EXT_CONFIG.API_BASE_URL}/user/${linkedDiscordId}/status`, {
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
     });
     if (!res.ok) return;
     const data = await res.json();
@@ -378,6 +446,7 @@ function loadFeed() {
 async function init() {
   await loadAuth();
   renderAuthState();
+  attachAuthStorageSync();
 
   if (userId && userData?.discordId) {
     loadStatus();
@@ -406,7 +475,9 @@ async function init() {
             chrome.tabs.sendMessage(tabs[0].id, { type: 'open_sidebar' }).catch(() => {});
           }
         });
-        toast('Open the sidebar on your casino tab to Connect Discord.', true);
+        toast('Open the sidebar on your casino tab to finish Discord sign-in.', true);
+      } else {
+        toast('Discord sign-in tab opened. Complete login there, then this popup updates automatically.');
       }
     });
   });
@@ -483,6 +554,10 @@ async function init() {
   // Dashboard
   $('btn-open-dashboard').addEventListener('click', () => {
     openDashboardTab('profile');
+  });
+
+  $('btn-logout').addEventListener('click', () => {
+    void performLogout();
   });
 
   // Activity refresh

--- a/apps/chrome-extension/src/sidebar/auth.ts
+++ b/apps/chrome-extension/src/sidebar/auth.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-07 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 import { getDiscordLoginUrl } from '../config.js';
 import { API_BASE } from './constants.js';
 import { SidebarUI } from './types.js';

--- a/apps/chrome-extension/src/sidebar/index.ts
+++ b/apps/chrome-extension/src/sidebar/index.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 import { SIDEBAR_TEMPLATE } from './template.js';
 import { getSidebarStyles } from './styles.js';
 import { AuthManager } from './auth.js';
@@ -437,7 +437,7 @@ export class SidebarController implements SidebarUI {
       if (connectBtn) {
         connectBtn.hidden = false;
         connectBtn.disabled = false;
-        connectBtn.textContent = 'Connect Discord';
+        connectBtn.textContent = 'Log in with Discord';
       }
     } else {
       if (accountText) accountText.textContent = `Connected as ${this.auth.userData?.username}`;
@@ -445,7 +445,7 @@ export class SidebarController implements SidebarUI {
       if (connectBtn) {
         connectBtn.hidden = true;
         connectBtn.disabled = false;
-        connectBtn.textContent = 'Connect Discord';
+        connectBtn.textContent = 'Log in with Discord';
       }
     }
   }

--- a/apps/chrome-extension/src/sidebar/template.ts
+++ b/apps/chrome-extension/src/sidebar/template.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 
 export const SIDEBAR_TEMPLATE = `
     <div class="tg-header">
@@ -24,7 +24,7 @@ export const SIDEBAR_TEMPLATE = `
         <div class="tg-auth-prompt">
           <h3>TILTCHECK ACTIVE</h3>
           <p>Connect Discord to sync vault history, live session signals, and casino telemetry across the ecosystem. No lectures, just math.</p>
-          <button class="tg-btn tg-btn-primary" id="tg-discord-login">Connect with Discord</button>
+          <button class="tg-btn tg-btn-primary" id="tg-discord-login">Log in with Discord</button>
           <button class="tg-btn tg-btn-secondary" id="tg-guest-login" style="margin-top: 8px;">Continue as Guest</button>
         </div>
       </div>
@@ -41,7 +41,7 @@ export const SIDEBAR_TEMPLATE = `
         </div>
         <div class="tg-account-strip">
           <span id="tg-account-text">Demo mode is live</span>
-          <button class="tg-btn tg-btn-primary tg-btn-inline" id="tg-connect-discord-inline">Connect Discord</button>
+          <button class="tg-btn tg-btn-primary tg-btn-inline" id="tg-connect-discord-inline">Log in with Discord</button>
         </div>
         <div class="tg-focus-note">Quick tip: keep this minimized while you play, then expand when you want a clean reality check.</div>
 

--- a/apps/chrome-extension/src/web-app-session-sync.ts
+++ b/apps/chrome-extension/src/web-app-session-sync.ts
@@ -1,0 +1,63 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
+/**
+ * Mirrors the extension JWT into the marketing site localStorage (`tc_token`),
+ * matching `apps/web/src/lib/auth-session.ts` so tiltcheck.me shows the same
+ * session as the extension after Discord OAuth. HttpOnly cookies from the API
+ * may also apply; this path covers cases where partitioned or cross-site cookie
+ * behavior would otherwise hide the session from fetchAuthSession.
+ */
+import { EXT_CONFIG } from './config.js';
+
+/** Same key as fetchAuthSession in apps/web (default tokenStorageKey). */
+export const WEB_TOKEN_STORAGE_KEY = 'tc_token';
+
+function marketingSiteHosts(): string[] {
+  try {
+    const host = new URL(EXT_CONFIG.WEB_APP_URL).hostname.toLowerCase();
+    const hosts = [host];
+    if (!host.startsWith('www.')) {
+      hosts.push(`www.${host}`);
+    }
+    return hosts;
+  } catch {
+    return ['tiltcheck.me', 'www.tiltcheck.me'];
+  }
+}
+
+export function isTiltCheckMarketingSite(hostname: string): boolean {
+  return marketingSiteHosts().includes(hostname.toLowerCase());
+}
+
+/**
+ * Runs in page context so tokens land in site localStorage (isolated world cannot).
+ */
+function injectLocalStorageSet(key: string, value: string | null): void {
+  const keyLit = JSON.stringify(key);
+  const valLit = value === null ? 'null' : JSON.stringify(value);
+  const script = document.createElement('script');
+  script.textContent = `(function(){try{var k=${keyLit};var v=${valLit};if(v===null){localStorage.removeItem(k);}else{localStorage.setItem(k,v);}window.dispatchEvent(new CustomEvent("tiltcheck-ext-session-sync"));}catch(_){}})();`;
+  (document.documentElement || document.head).appendChild(script);
+  script.remove();
+}
+
+export function syncMarketingSiteTokenFromExtensionStorage(): void {
+  if (typeof chrome === 'undefined' || !chrome.storage?.local) return;
+  if (!isTiltCheckMarketingSite(window.location.hostname)) return;
+
+  chrome.storage.local.get(['authToken'], (data: { authToken?: string | null }) => {
+    const token = typeof data.authToken === 'string' && data.authToken ? data.authToken : null;
+    injectLocalStorageSet(WEB_TOKEN_STORAGE_KEY, token);
+  });
+}
+
+export function attachMarketingSiteStorageListener(): void {
+  if (typeof chrome === 'undefined' || !chrome.storage?.onChanged) return;
+  if (!isTiltCheckMarketingSite(window.location.hostname)) return;
+
+  chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== 'local' || !changes.authToken) return;
+    const raw = changes.authToken.newValue;
+    const token = typeof raw === 'string' && raw ? raw : null;
+    injectLocalStorageSet(WEB_TOKEN_STORAGE_KEY, token);
+  });
+}

--- a/apps/chrome-extension/tests/unit/web-app-session-sync.test.ts
+++ b/apps/chrome-extension/tests/unit/web-app-session-sync.test.ts
@@ -1,0 +1,22 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest';
+import { isTiltCheckMarketingSite, WEB_TOKEN_STORAGE_KEY } from '../../src/web-app-session-sync.ts';
+
+describe('web-app-session-sync', () => {
+  it('uses the same localStorage key as apps/web fetchAuthSession default', () => {
+    expect(WEB_TOKEN_STORAGE_KEY).toBe('tc_token');
+  });
+
+  it('treats apex and www marketing hosts as web app pages', () => {
+    expect(isTiltCheckMarketingSite('tiltcheck.me')).toBe(true);
+    expect(isTiltCheckMarketingSite('www.tiltcheck.me')).toBe(true);
+  });
+
+  it('does not treat other TiltCheck subdomains as the marketing site shell', () => {
+    expect(isTiltCheckMarketingSite('dashboard.tiltcheck.me')).toBe(false);
+    expect(isTiltCheckMarketingSite('api.tiltcheck.me')).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-11
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 'use client';
 import { useEffect, useState } from 'react';
 import { fetchAuthSession, type AuthSession } from '@/lib/auth-session';
@@ -10,12 +10,38 @@ export function useAuth() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchAuthSession()
-      .then((data) => {
-        if (data?.userId) setUser(data);
-      })
-      .catch(() => {})
-      .finally(() => setLoading(false));
+    let alive = true;
+
+    const applySession = () => {
+      fetchAuthSession()
+        .then((data) => {
+          if (!alive) return;
+          if (data?.userId) setUser(data);
+          else setUser(null);
+        })
+        .catch(() => {})
+        .finally(() => {
+          if (alive) setLoading(false);
+        });
+    };
+
+    applySession();
+
+    const onExtensionSessionSync = () => {
+      fetchAuthSession()
+        .then((data) => {
+          if (!alive) return;
+          if (data?.userId) setUser(data);
+          else setUser(null);
+        })
+        .catch(() => {});
+    };
+
+    window.addEventListener('tiltcheck-ext-session-sync', onExtensionSessionSync);
+    return () => {
+      alive = false;
+      window.removeEventListener('tiltcheck-ext-session-sync', onExtensionSessionSync);
+    };
   }, []);
 
   return { user, loading };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Linear TIL-18 required a clear end-to-end Discord OAuth path in the extension UI, durable session handling, logged-in UI feedback, logout, documented redirect URI plus token storage, and **shared recognition on tiltcheck.me** when the user signed in from the extension.

## Approach

**Extension + API (previous commits):** OAuth via `auth-bridge`, `chrome.storage.local`, README.

**Web parity (this update):** On `tiltcheck.me` / `www`, the content script injects a page-context snippet that writes the same JWT the web app already expects in **`localStorage['tc_token']`** (see `apps/web/src/lib/auth-session.ts`). A `chrome.storage.onChanged` listener clears that key when the extension logs out. **`useAuth`** listens for `tiltcheck-ext-session-sync` and refetches so the UI flips without a manual reload.

The API may still set **`Domain=.tiltcheck.me`** session cookies during OAuth; mirroring **`tc_token`** covers browsers where partitioned third-party cookie behavior would otherwise make `fetch(..., credentials: 'include')` miss the cookie on first paint.

## Risk / rollback

- **XSS:** `tc_token` in `localStorage` is the same tradeoff as Discord/Magic login on the web (already true for web-only users).
- Roll back by reverting this commit; no API contract change.

## Validation

- `pnpm --filter @tiltcheck/chrome-extension test` && `build`
- Lint clean on touched TS files

## Redirect URIs and storage (summary)

| Item | Detail |
| :--- | :--- |
| Discord redirect (production extension OAuth) | `https://api.tiltcheck.me/auth/discord/callback` |
| Extension | `chrome.storage.local`: `authToken`, `userData`, `tiltguard_user_id` |
| Marketing web (`tiltcheck.me`) | Mirrored JWT: `localStorage['tc_token']` |
| API cookie | httpOnly session on `.tiltcheck.me` when OAuth completes in the browser |
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TIL-18](https://linear.app/tiltcheck/issue/TIL-18/extension-discord-login)

<div><a href="https://cursor.com/agents/bc-50d749fa-f720-41a0-9785-360c2e68044e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50d749fa-f720-41a0-9785-360c2e68044e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

