### PR TITLE
TIL-30: Extension server tilt-detection E2E path and API /ai gateway

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@magic-sdk/admin": "^2.8.2",
     "@supabase/supabase-js": "^2.100.1",
+    "@tiltcheck/ai-client": "workspace:*",
     "@tiltcheck/auth": "workspace:*",
     "@tiltcheck/monitoring": "workspace:*",
     "@tiltcheck/config": "workspace:*",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,4 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-15
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -51,6 +51,7 @@ import { servicesRouter } from './routes/services.js';
 import { tipRouter } from './routes/tip.js';
 import { healthRouter } from './routes/health.js';
 import { rgaasRouter } from './routes/rgaas.js';
+import { aiGatewayRouter } from './routes/ai-gateway.js';
 import { affiliateRouter } from './routes/affiliate.js';
 import { safetyRouter } from './routes/safety.js';
 import { newsletterRouter } from './routes/newsletter.js';
@@ -215,7 +216,7 @@ app.use('/stripe', stripeRouter);
 app.use('/user', userRouter);
 
 // Consolidated Utility Routes
-app.use('/ai', (_req, res) => { res.status(410).json({ success: false, error: 'AI Gateway consolidated into discord-bot service.' }); });
+app.use('/ai', aiGatewayRouter);
 app.use('/pricing', pricingRouter);
 app.use('/casino', casinoRouter);
 app.use('/bonus', bonusRouter);

--- a/apps/api/src/routes/ai-gateway.ts
+++ b/apps/api/src/routes/ai-gateway.ts
@@ -41,7 +41,7 @@ function contextTooLarge(context: Record<string, unknown> | undefined): boolean 
   if (!context) return false;
   if (Object.keys(context).length > MAX_CONTEXT_KEYS) return true;
   try {
-    return JSON.stringify(context).length > MAX_CONTEXT_JSON_BYTES;
+    return Buffer.byteLength(JSON.stringify(context)) > MAX_CONTEXT_JSON_BYTES;
   } catch {
     return true;
   }

--- a/apps/api/src/routes/ai-gateway.ts
+++ b/apps/api/src/routes/ai-gateway.ts
@@ -1,0 +1,95 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
+/**
+ * Chrome extension and internal clients: POST /ai/api/ai
+ * Proxies to @tiltcheck/ai-client (multi-provider tilt-detection, moderation, etc.).
+ *
+ * Risk: authenticated relay to paid LLM providers — flexAuth required, body allowlist,
+ * bounded context size. Rollback: remove app.use('/ai', aiGatewayRouter) and restore 410 stub.
+ */
+
+import { Router } from 'express';
+import { z } from 'zod';
+import { flexAuth } from '@tiltcheck/auth/middleware/express.js';
+import { aiClient, type AIApplication } from '@tiltcheck/ai-client';
+import { getJWTConfig } from '../middleware/auth.js';
+
+const router = Router();
+
+const ALLOWED_APPLICATIONS = [
+  'tilt-detection',
+  'moderation',
+  'survey-matching',
+  'card-generation',
+  'nl-commands',
+  'recommendations',
+  'support',
+  'onboarding',
+] as const satisfies readonly AIApplication[];
+
+const applicationSchema = z.enum(ALLOWED_APPLICATIONS);
+
+const bodySchema = z.object({
+  application: applicationSchema,
+  prompt: z.string().max(8000).optional(),
+  context: z.record(z.string(), z.unknown()).optional(),
+});
+
+const MAX_CONTEXT_KEYS = 40;
+const MAX_CONTEXT_JSON_BYTES = 24_000;
+
+function contextTooLarge(context: Record<string, unknown> | undefined): boolean {
+  if (!context) return false;
+  if (Object.keys(context).length > MAX_CONTEXT_KEYS) return true;
+  try {
+    return JSON.stringify(context).length > MAX_CONTEXT_JSON_BYTES;
+  } catch {
+    return true;
+  }
+}
+
+const requireUser = flexAuth(getJWTConfig(), { required: true });
+
+/**
+ * POST /ai/api/ai
+ * Bearer or session cookie (flexAuth). Returns AIResponse JSON shape.
+ */
+router.post('/api/ai', requireUser, async (req, res) => {
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      success: false,
+      error: 'Invalid request body',
+      code: 'INVALID_BODY',
+    });
+    return;
+  }
+
+  const { application, prompt, context } = parsed.data;
+  if (contextTooLarge(context)) {
+    res.status(400).json({
+      success: false,
+      error: 'Context too large',
+      code: 'CONTEXT_LIMIT',
+    });
+    return;
+  }
+
+  try {
+    const result = await aiClient.request({
+      application,
+      prompt: prompt ?? '',
+      context: context ?? {},
+    });
+    const status = result.success ? 200 : 502;
+    res.status(status).json(result);
+  } catch (err) {
+    console.error('[ai-gateway] AI request failed:', err);
+    res.status(500).json({
+      success: false,
+      error: 'Tilt check service hiccupped. Try again.',
+      code: 'AI_GATEWAY_ERROR',
+    });
+  }
+});
+
+export { router as aiGatewayRouter };

--- a/apps/api/tests/routes/ai-gateway.test.ts
+++ b/apps/api/tests/routes/ai-gateway.test.ts
@@ -1,0 +1,128 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const flexAuthMock = vi.hoisted(() =>
+  vi.fn(() => {
+    return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+      if (req.headers.authorization === 'Bearer ok-token') {
+        (req as express.Request & { auth?: { userId: string } }).auth = { userId: 'user-1' };
+        next();
+        return;
+      }
+      res.status(401).json({ success: false, code: 'UNAUTHORIZED', error: 'Authentication required' });
+    };
+  })
+);
+
+const aiRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@tiltcheck/auth/middleware/express.js', () => ({
+  flexAuth: flexAuthMock,
+}));
+
+vi.mock('@tiltcheck/ai-client', () => ({
+  aiClient: {
+    request: aiRequestMock,
+  },
+}));
+
+import { aiGatewayRouter } from '../../src/routes/ai-gateway.js';
+
+const app = express();
+app.use(express.json());
+app.use('/ai', aiGatewayRouter);
+
+describe('AI Gateway Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-for-ai-gateway';
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POST /ai/api/ai returns 401 without bearer token', async () => {
+    const response = await request(app)
+      .post('/ai/api/ai')
+      .send({ application: 'tilt-detection', context: {} });
+
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+  });
+
+  it('POST /ai/api/ai returns 400 for unknown application', async () => {
+    const response = await request(app)
+      .post('/ai/api/ai')
+      .set('Authorization', 'Bearer ok-token')
+      .send({ application: 'not-real', context: {} });
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('INVALID_BODY');
+  });
+
+  it('POST /ai/api/ai returns 400 when context exceeds size limit', async () => {
+    const huge: Record<string, unknown> = {};
+    for (let i = 0; i < 50; i += 1) {
+      huge[`k${i}`] = i;
+    }
+    const response = await request(app)
+      .post('/ai/api/ai')
+      .set('Authorization', 'Bearer ok-token')
+      .send({ application: 'tilt-detection', context: huge });
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('CONTEXT_LIMIT');
+  });
+
+  it('POST /ai/api/ai proxies tilt-detection for authenticated user', async () => {
+    aiRequestMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        tiltScore: 55,
+        riskLevel: 'moderate',
+        indicators: ['velocity'],
+        patterns: {},
+        interventionSuggestions: ['Touch grass'],
+        cooldownRecommended: false,
+        cooldownDuration: 0,
+      },
+    });
+
+    const response = await request(app)
+      .post('/ai/api/ai')
+      .set('Authorization', 'Bearer ok-token')
+      .send({
+        application: 'tilt-detection',
+        context: { sessionDuration: 12, losses: 40 },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data.tiltScore).toBe(55);
+    expect(aiRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        application: 'tilt-detection',
+        context: { sessionDuration: 12, losses: 40 },
+      })
+    );
+  });
+
+  it('POST /ai/api/ai returns 502 when upstream AI returns success false', async () => {
+    aiRequestMock.mockResolvedValueOnce({
+      success: false,
+      error: 'All providers unavailable',
+    });
+
+    const response = await request(app)
+      .post('/ai/api/ai')
+      .set('Authorization', 'Bearer ok-token')
+      .send({ application: 'tilt-detection', context: {} });
+
+    expect(response.status).toBe(502);
+    expect(response.body.success).toBe(false);
+  });
+});

--- a/apps/chrome-extension/README.md
+++ b/apps/chrome-extension/README.md
@@ -1,4 +1,4 @@
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 -->
 
 # TiltCheck Chrome Extension (TiltGuard)
 
@@ -29,6 +29,18 @@ Two runtime modes:
 - **Demo mode** (no login): active automatically when no auth token is present. Mock responses are served for core sidebar interactions so users can explore the product before connecting Discord.
 
 OAuth state integrity is validated server-side using signed state prefixes (extension origin vs web origin) during callback handling.
+
+---
+
+## Server tilt detection (manual E2E)
+
+The sidebar **Server Tilt Check** block calls the central API AI gateway:
+
+- **HTTP:** `POST {AI_GATEWAY_URL}/api/ai` (from `src/config.ts`, production resolves to `https://api.tiltcheck.me/ai/api/ai`).
+- **Auth:** `Authorization: Bearer <JWT>` from Discord OAuth. Demo tabs without a token get `NO_SESSION` in the result panel instead of burning provider quota.
+- **Body:** `{ "application": "tilt-detection", "context": { "sessionDuration", "losses", "recentBets" } }` (matches `@tiltcheck/ai-client` tilt-detection contract).
+- **API env (server):** `JWT_SECRET` plus whichever LLM keys your `AI_PROVIDER_PROFILE` allows (`GEMINI_API_KEY`, `GROQ_API_KEY`, `HF_TOKEN`, etc.). Inspect readiness via `GET /health/ai` on the API host.
+- **Failure UX:** Network errors (`NETWORK`), client abort at 55s (`TIMEOUT`), HTTP 401 from bad/expired JWT, and non-2xx bodies are surfaced as JSON in the panel plus a line in **Live Signals**.
 
 ---
 

--- a/apps/chrome-extension/src/sidebar.ts
+++ b/apps/chrome-extension/src/sidebar.ts
@@ -1,9 +1,8 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-23 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 /**
  * TiltCheck Sidebar - Fully Functional UI
  * Features: Discord auth, vault, dashboard, wallet, session export, premium upgrades
  * Integrates with backend AI services for intelligent tilt detection
- * Last Updated: 2026-04-17
  */
 
 import { EXT_CONFIG, getDiscordLoginUrl } from './config.js';
@@ -500,9 +499,13 @@ function enableDemoMode() {
 }
 
 /**
- * Call backend AI service for intelligent analysis
+ * Call backend AI service for intelligent analysis (POST /ai/api/ai on API host).
  */
-async function callAIGateway(application: string, data: any = {}) {
+async function callAIGateway(
+  application: string,
+  data: Record<string, unknown> = {},
+  options?: { signal?: AbortSignal }
+) {
   try {
     const response = await fetch(`${AI_GATEWAY_URL}/api/ai`, {
       method: 'POST',
@@ -512,19 +515,114 @@ async function callAIGateway(application: string, data: any = {}) {
       },
       body: JSON.stringify({
         application,
-        prompt: data.prompt || '',
-        context: data.context || {},
+        prompt: (data.prompt as string) || '',
+        context: (data.context as Record<string, unknown>) || {},
       }),
+      signal: options?.signal,
     });
 
-    if (response && response.ok) {
-      return await response.json();
+    let body: Record<string, unknown> = {};
+    try {
+      body = (await response.json()) as Record<string, unknown>;
+    } catch {
+      body = {};
     }
-    console.log('[TiltCheck] Backend AI request failed');
-    return { success: false, error: 'Request did not complete. Try again.' };
-  } catch (err) {
+
+    if (response.ok) {
+      return body;
+    }
+
+    const errMsg =
+      typeof body.error === 'string'
+        ? body.error
+        : typeof body.message === 'string'
+          ? body.message
+          : 'Request did not complete. Try again.';
+    return {
+      success: false,
+      error: errMsg,
+      code: body.code,
+      status: response.status,
+    };
+  } catch (err: unknown) {
+    const name = err instanceof Error ? err.name : '';
+    if (name === 'AbortError') {
+      return { success: false, error: 'Timed out waiting for the tilt engine.', code: 'TIMEOUT' };
+    }
     console.log('[TiltCheck] Backend AI offline or error:', err);
-    return { success: false, error: 'Network issue. Try again.' };
+    return { success: false, error: 'Network issue. Try again.', code: 'NETWORK' };
+  }
+}
+
+const TILT_TEST_CLIENT_MS = 55_000;
+
+async function runTiltDetectionServerTest(): Promise<void> {
+  const out = document.getElementById('tg-tilt-test-result');
+  const btn = document.getElementById('tg-tilt-test-run') as HTMLButtonElement | null;
+  if (!out || !btn) return;
+
+  btn.disabled = true;
+  out.textContent = 'Running...';
+
+  try {
+    if (!authToken) {
+      out.textContent = JSON.stringify(
+        {
+          success: false,
+          code: 'NO_SESSION',
+          error:
+            'No Discord JWT on this session. Connect Discord in the header before running the server tilt check.',
+        },
+        null,
+        2
+      );
+      addFeedMessage('Tilt test blocked: no bearer session (link Discord for the live path).');
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => controller.abort(), TILT_TEST_CLIENT_MS);
+
+    const aiResult = (await callAIGateway(
+      'tilt-detection',
+      {
+        context: {
+          recentBets: [],
+          sessionDuration: Math.floor(
+            (Date.now() - (sessionStats.startTime || Date.now())) / 60000
+          ),
+          losses: Math.max(0, (sessionStats.totalWagered || 0) - (sessionStats.totalWon || 0)),
+        },
+      },
+      { signal: controller.signal }
+    )) as Record<string, unknown>;
+
+    window.clearTimeout(timer);
+    out.textContent = JSON.stringify(aiResult, null, 2);
+
+    if (aiResult.success) {
+      addFeedMessage('Server tilt check returned a verdict. Peep the JSON panel.');
+    } else if (aiResult.code === 'TIMEOUT') {
+      addFeedMessage('Tilt test timed out. API or LLM chain is slow; retry when the pipe is less clogged.');
+    } else if (aiResult.status === 401) {
+      addFeedMessage('Tilt test got a 401. Reconnect Discord — that session token is invalid or expired.');
+    } else if (aiResult.code === 'NETWORK') {
+      addFeedMessage('Tilt test could not reach the API. Check network, DNS, or adblock picking a fight with the host.');
+    } else {
+      addFeedMessage(`Tilt test ended rough: ${String(aiResult.error || 'unknown')}`);
+    }
+  } catch (e: unknown) {
+    out.textContent = JSON.stringify(
+      {
+        success: false,
+        code: 'CLIENT',
+        error: e instanceof Error ? e.message : String(e),
+      },
+      null,
+      2
+    );
+  } finally {
+    btn.disabled = false;
   }
 }
 
@@ -723,6 +821,15 @@ function createSidebar() {
               <span class="tg-metric-value tg-tilt-value" id="tg-score-value">0</span>
             </div>
           </div>
+        </div>
+
+        <div class="tg-section" id="tg-tilt-test-section">
+          <h4>Server Tilt Check</h4>
+          <p style="font-size: 11px; opacity: 0.78; margin: 0 0 8px; line-height: 1.35;">
+            One-shot call to the API tilt-detection stack using your sidebar session stats. Needs a linked Discord JWT; demo-only tabs get a hard NO_SESSION until you connect.
+          </p>
+          <button class="tg-btn tg-btn-secondary" type="button" id="tg-tilt-test-run">Run tilt detection test</button>
+          <pre id="tg-tilt-test-result" style="display: block; margin-top: 10px; max-height: 200px; overflow: auto; padding: 8px; background: rgba(0,0,0,0.35); border-radius: 6px; font-size: 10px; line-height: 1.35; white-space: pre-wrap; word-break: break-word;"></pre>
         </div>
 
         <!-- P/L Graph -->
@@ -1888,6 +1995,10 @@ function setupEventListeners() {
   });
 
   // Emergency lock: 15 min break
+  document.getElementById('tg-tilt-test-run')?.addEventListener('click', () => {
+    void runTiltDetectionServerTest();
+  });
+
   document.getElementById('tg-emergency-lock')?.addEventListener('click', () => {
     const minsInput = document.getElementById('lock-timer-mins') as HTMLInputElement;
     const agreeCheckbox = document.getElementById('lock-agree') as HTMLInputElement;
@@ -2722,13 +2833,16 @@ async function updateTilt(score: number, _indicators: string[]) {
     addFeedMessage(`Tilt spike detected: ${Math.round(score)}`);
 
     // Get AI-powered intervention suggestions
-    const aiResult = await callAIGateway('tilt-detection', {
+    const aiResult = (await callAIGateway('tilt-detection', {
       context: {
         recentBets: [],
         sessionDuration: Math.floor((Date.now() - sessionStats.startTime) / 60000),
         losses: Math.max(0, sessionStats.totalWagered - sessionStats.totalWon),
       },
-    });
+    })) as {
+      success?: boolean;
+      data?: { interventionSuggestions?: string[] };
+    };
 
     if (aiResult.success && aiResult.data?.interventionSuggestions) {
       aiResult.data.interventionSuggestions.forEach((suggestion: string) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.100.1
         version: 2.100.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@tiltcheck/ai-client':
+        specifier: workspace:*
+        version: link:../../packages/ai-client
       '@tiltcheck/auth':
         specifier: workspace:*
         version: link:../../packages/auth
@@ -15733,7 +15736,7 @@ snapshots:
     dependencies:
       '@mikro-orm/core': 6.6.10
       fs-extra: 11.3.3
-      knex: 3.1.0(pg@8.19.0)(sqlite3@5.1.7)
+      knex: 3.1.0(mysql2@3.19.0(@types/node@25.5.0))(pg@8.19.0)
       sqlstring: 2.3.3
     optionalDependencies:
       mariadb: 3.4.5


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Linear TIL-30 asked for an end-to-end proof that tilt-detection works through the Chrome extension: trigger, successful result in UI, and basic failure handling. The API had replaced `/ai` with a 410 stub while the extension still called `POST {AI_GATEWAY_URL}/api/ai` (i.e. `/ai/api/ai`), so the server path could never succeed.

## Approach

- Add `apps/api/src/routes/ai-gateway.ts`: authenticated `POST /ai/api/ai` using `flexAuth` + `getJWTConfig()`, zod body validation, bounded `context` size, and `@tiltcheck/ai-client` `aiClient.request()` (same stack as health diagnostics).
- Wire `app.use('/ai', aiGatewayRouter)` in place of the 410 handler.
- Extension: new **Server Tilt Check** sidebar section with **Run tilt detection test**, JSON result panel, and hardened `callAIGateway` (JSON on non-OK, `AbortError` as `TIMEOUT`, explicit `NO_SESSION` when no JWT).
- Document URL, auth, and env expectations in `apps/chrome-extension/README.md`.
- Declare `@tiltcheck/ai-client` on `@tiltcheck/api` (health route already imported it; dependency was missing).

## Risk / rollback

- **Risk:** Authenticated relay to LLM providers; mitigated with required auth, application allowlist, and context caps. Abuse still burns quota for valid users — same class as any authenticated AI surface.
- **Rollback:** Restore the one-line 410 handler for `/ai` and remove the sidebar block if the gateway must go dark again.

## Validation

- `pnpm --filter @tiltcheck/api exec vitest --run tests/routes/ai-gateway.test.ts`
- `pnpm --filter @tiltcheck/api build`
- `pnpm --filter @tiltcheck/chrome-extension test`

Refs: TIL-30
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TIL-30](https://linear.app/tiltcheck/issue/TIL-30/tiltdetection-test-with-chrome-extension-end-to-end)

<div><a href="https://cursor.com/agents/bc-0f96948d-1419-4199-a660-8c9433f2bf09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f96948d-1419-4199-a660-8c9433f2bf09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

