### PR TITLE
TIL-40: Email intake abuse controls, parse-failure alerting, ops runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-28
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 # ==============================================
 # TILTCHECK MONOREPO - MASTER ENVIRONMENT CONFIG (TEMPLATE)
 # ==============================================
@@ -57,6 +57,23 @@ MAGIC_PUBLISHABLE_KEY=
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=beta@yourdomain.com
 BETA_EMAIL_WEBHOOK_URL=
+
+# --- API / RGaaS: EMAIL INGEST (POST /rgaas/email-ingest) ---
+# Optional shared secret: require Authorization: Bearer <value> or X-Email-Ingest-Key.
+# Do not enable on public browser flows unless you proxy through a trusted backend.
+EMAIL_INGEST_SECRET=
+# Comma-separated sender domains to reject (subdomain match supported).
+EMAIL_INGEST_SENDER_DENYLIST=
+# When non-empty, only these sender domains may post (subdomain match supported).
+EMAIL_INGEST_SENDER_ALLOWLIST=
+# UTF-8 byte cap on raw_email (default 524288).
+EMAIL_INGEST_MAX_BYTES=
+# Per-IP rate limit for this route only (defaults: 40 requests / 900000 ms).
+EMAIL_INGEST_RATE_LIMIT_MAX=
+EMAIL_INGEST_RATE_LIMIT_WINDOW_MS=
+# In-process sliding window: alert after this many parse failures (default 5 / 600000 ms).
+EMAIL_INGEST_PARSE_FAILURE_ALERT_THRESHOLD=
+EMAIL_INGEST_PARSE_FAILURE_WINDOW_MS=
 
 # --- COOKIES ---
 COOKIE_DOMAIN=localhost

--- a/apps/api/src/lib/email-ingest-controls.ts
+++ b/apps/api/src/lib/email-ingest-controls.ts
@@ -1,0 +1,117 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+/**
+ * Abuse controls for POST /rgaas/email-ingest: optional shared secret, payload
+ * size cap, sender allow/deny lists (domain-level), and structured log helpers.
+ *
+ * Risk: misconfigured allowlists block legitimate mail; keep lists short and
+ * test in staging. Rollback: unset EMAIL_INGEST_* env vars and redeploy.
+ */
+
+import type { Request } from 'express';
+
+export const DEFAULT_EMAIL_INGEST_MAX_BYTES = 512 * 1024;
+
+function parseDomainList(raw: string | undefined): string[] {
+  if (!raw?.trim()) return [];
+  return raw
+    .split(/[,;\s]+/)
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function getEmailIngestDenyDomains(): Set<string> {
+  return new Set(parseDomainList(process.env.EMAIL_INGEST_SENDER_DENYLIST));
+}
+
+/** Returns null when allowlist is disabled (empty env). */
+export function getEmailIngestAllowDomains(): Set<string> | null {
+  const list = parseDomainList(process.env.EMAIL_INGEST_SENDER_ALLOWLIST);
+  if (list.length === 0) return null;
+  return new Set(list);
+}
+
+export function getEmailIngestMaxBytes(): number {
+  const raw = process.env.EMAIL_INGEST_MAX_BYTES?.trim();
+  if (!raw) return DEFAULT_EMAIL_INGEST_MAX_BYTES;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_EMAIL_INGEST_MAX_BYTES;
+}
+
+/**
+ * Cheap sender-domain extraction from the first chunk of raw mail (From header).
+ * Used for early deny hits; post-parse policy still merges intel.senderDomain.
+ */
+export function extractQuickSenderDomain(raw: string): string | null {
+  const slice = raw.slice(0, Math.min(raw.length, 12_288));
+  const angle =
+    slice.match(/^From:\s*.+?<([a-zA-Z0-9._%+-]+@([a-zA-Z0-9.-]+\.[a-zA-Z]{2,}))>/im) ||
+    slice.match(/^From:\s*.*?([a-zA-Z0-9._%+-]+@([a-zA-Z0-9.-]+\.[a-zA-Z]{2,}))/im);
+  const domain = angle?.[2]?.toLowerCase() ?? null;
+  return domain;
+}
+
+function domainMatchesEntry(domain: string, entry: string): boolean {
+  const d = domain.toLowerCase();
+  const e = entry.toLowerCase();
+  return d === e || d.endsWith(`.${e}`);
+}
+
+export function isSenderDomainDenied(domain: string | null, deny: Set<string>): boolean {
+  if (!domain || deny.size === 0) return false;
+  for (const entry of deny) {
+    if (domainMatchesEntry(domain, entry)) return true;
+  }
+  return false;
+}
+
+export function isSenderDomainAllowed(domain: string | null, allow: Set<string> | null): boolean {
+  if (allow === null) return true;
+  if (!domain) return false;
+  for (const entry of allow) {
+    if (domainMatchesEntry(domain, entry)) return true;
+  }
+  return false;
+}
+
+export function mergeSenderDomainsForPolicy(
+  intelSender: string | null,
+  quickSender: string | null,
+): string[] {
+  const out = new Set<string>();
+  if (intelSender) out.add(intelSender.toLowerCase());
+  if (quickSender) out.add(quickSender.toLowerCase());
+  return [...out];
+}
+
+export function evaluateEmailIngestSenderPolicy(
+  domains: string[],
+  deny: Set<string>,
+  allow: Set<string> | null,
+): 'ok' | 'denied' | 'allowlist_block' {
+  for (const d of domains) {
+    if (isSenderDomainDenied(d, deny)) return 'denied';
+  }
+  if (allow === null) return 'ok';
+  if (domains.length === 0) return 'allowlist_block';
+  for (const d of domains) {
+    if (isSenderDomainAllowed(d, allow)) return 'ok';
+  }
+  return 'allowlist_block';
+}
+
+export function assertEmailIngestSecret(req: Request): { ok: true } | { ok: false } {
+  const secret = process.env.EMAIL_INGEST_SECRET?.trim();
+  if (!secret) return { ok: true };
+  const auth = req.get('authorization');
+  const bearer = auth?.toLowerCase().startsWith('bearer ') ? auth.slice(7).trim() : '';
+  const headerKey = req.get('x-email-ingest-key')?.trim() ?? '';
+  if (bearer === secret || headerKey === secret) return { ok: true };
+  return { ok: false };
+}
+
+export function logEmailIngestEvent(event: string, fields: Record<string, unknown>): void {
+  console.warn(
+    '[email-ingest]',
+    JSON.stringify({ event, ts: new Date().toISOString(), ...fields }),
+  );
+}

--- a/apps/api/src/lib/email-ingest-parse-health.ts
+++ b/apps/api/src/lib/email-ingest-parse-health.ts
@@ -1,0 +1,57 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+/**
+ * Sliding-window counter for email-ingest parse failures. Triggers
+ * ALERT_RULES.EMAIL_INGEST_SUSTAINED_PARSE_FAILURES when the threshold is hit.
+ *
+ * In-process only (resets on deploy). Pair with log/metrics scraping for HA.
+ */
+
+import { ALERT_RULES, resetAlertCooldown, triggerAlert } from '@tiltcheck/monitoring';
+
+const failureTimestamps: number[] = [];
+
+function getWindowMs(): number {
+  const raw = process.env.EMAIL_INGEST_PARSE_FAILURE_WINDOW_MS?.trim();
+  const n = raw ? Number.parseInt(raw, 10) : 600_000;
+  return Number.isFinite(n) && n > 0 ? n : 600_000;
+}
+
+function getThreshold(): number {
+  const raw = process.env.EMAIL_INGEST_PARSE_FAILURE_ALERT_THRESHOLD?.trim();
+  const n = raw ? Number.parseInt(raw, 10) : 5;
+  return Number.isFinite(n) && n >= 2 ? n : 5;
+}
+
+function prune(now: number): void {
+  const windowMs = getWindowMs();
+  while (failureTimestamps.length > 0 && now - (failureTimestamps[0] ?? 0) > windowMs) {
+    failureTimestamps.shift();
+  }
+}
+
+/**
+ * Record a parse failure and fire a cooled-down alert if the window is saturated.
+ */
+export async function recordEmailIngestParseFailure(context: Record<string, unknown>): Promise<void> {
+  const now = Date.now();
+  prune(now);
+  failureTimestamps.push(now);
+  prune(now);
+
+  const threshold = getThreshold();
+  if (failureTimestamps.length < threshold) return;
+
+  await triggerAlert(ALERT_RULES.EMAIL_INGEST_SUSTAINED_PARSE_FAILURES, {
+    service: 'api',
+    route: '/rgaas/email-ingest',
+    failureCount: failureTimestamps.length,
+    windowMs: getWindowMs(),
+    threshold,
+    ...context,
+  });
+}
+
+export function resetEmailIngestParseHealthForTests(): void {
+  failureTimestamps.length = 0;
+  resetAlertCooldown(ALERT_RULES.EMAIL_INGEST_SUSTAINED_PARSE_FAILURES.id);
+}

--- a/apps/api/src/lib/email-ingest-parse-health.ts
+++ b/apps/api/src/lib/email-ingest-parse-health.ts
@@ -36,7 +36,6 @@ export async function recordEmailIngestParseFailure(context: Record<string, unkn
   const now = Date.now();
   prune(now);
   failureTimestamps.push(now);
-  prune(now);
 
   const threshold = getThreshold();
   if (failureTimestamps.length < threshold) return;

--- a/apps/api/src/lib/email-parser.ts
+++ b/apps/api/src/lib/email-parser.ts
@@ -1,4 +1,4 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-17
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 
 /**
  * Email Intel Parser

--- a/apps/api/src/routes/rgaas.ts
+++ b/apps/api/src/routes/rgaas.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 /**
  * RGaaS Routes - /rgaas/*
  * Responsible Gaming as a Service.
@@ -6,6 +6,8 @@
  */
 
 import { Router } from 'express';
+import { rateLimit, ipKeyGenerator } from 'express-rate-limit';
+import { SentryMonitor } from '@tiltcheck/monitoring';
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import {
@@ -31,10 +33,39 @@ import {
   markEmailBonusEntriesPublished,
   persistEmailBonusIntel,
 } from '../lib/email-bonus-feed.js';
-import type { EmailIntelData } from '../lib/email-parser.js';
+import { parseEmailIntel, type EmailIntelData } from '../lib/email-parser.js';
+import {
+  assertEmailIngestSecret,
+  evaluateEmailIngestSenderPolicy,
+  extractQuickSenderDomain,
+  getEmailIngestAllowDomains,
+  getEmailIngestDenyDomains,
+  getEmailIngestMaxBytes,
+  isSenderDomainDenied,
+  logEmailIngestEvent,
+  mergeSenderDomainsForPolicy,
+} from '../lib/email-ingest-controls.js';
+import { recordEmailIngestParseFailure } from '../lib/email-ingest-parse-health.js';
 import { resolveExclusionProfileForRequest, suppressBonusEntries } from '../services/bonus-suppression.js';
 
 const router: Router = Router();
+
+const emailIngestRateWindowMs =
+  Number.parseInt(process.env.EMAIL_INGEST_RATE_LIMIT_WINDOW_MS ?? '900000', 10) || 15 * 60 * 1000;
+const emailIngestRateMax =
+  Number.parseInt(process.env.EMAIL_INGEST_RATE_LIMIT_MAX ?? '40', 10) || 40;
+
+const emailIngestLimiter = rateLimit({
+  windowMs: emailIngestRateWindowMs,
+  max: emailIngestRateMax,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => {
+    const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() || req.ip || 'unknown';
+    return ipKeyGenerator(ip);
+  },
+  message: { error: 'Too many email intake requests', code: 'EMAIL_INGEST_RATE_LIMIT' },
+});
 
 // ─── License registry ─────────────────────────────────────────────────────────
 const licenseRegistry: {
@@ -859,161 +890,218 @@ router.get('/license-check', (req, res) => {
  *   POST /rgaas/email-ingest
  *   { "raw_email": "From: promo@chumbacasino.com\nSubject: ...\n\n..." }
  */
-router.post('/email-ingest', async (req, res) => {
+router.post('/email-ingest', emailIngestLimiter, async (req, res) => {
+  const auth = assertEmailIngestSecret(req);
+  if (!auth.ok) {
+    logEmailIngestEvent('auth_failed', { code: 'EMAIL_INGEST_AUTH_FAILED' });
+    res.status(401).json({ error: 'Email intake authentication required', code: 'EMAIL_INGEST_AUTH_FAILED' });
+    return;
+  }
+
   const rawEmail = (req.body?.raw_email as string | undefined)?.trim();
   if (!rawEmail || rawEmail.length < 20) {
+    logEmailIngestEvent('validation_failed', { code: 'INVALID_INPUT', reason: 'raw_email_required_or_short' });
     res.status(400).json({ error: 'raw_email is required (min 20 chars)', code: 'INVALID_INPUT' });
     return;
   }
 
-  const { parseEmailIntel } = await import('../lib/email-parser.js');
-  const intel = parseEmailIntel(rawEmail);
-
-  // Run domain check on sender domain
-  let domainScan = null;
-  if (intel.senderDomain) {
-    try {
-      const urlToScan = `https://${intel.senderDomain}`;
-      domainScan = await suslink.scanUrl(urlToScan);
-    } catch {
-      domainScan = null;
-    }
+  const maxBytes = getEmailIngestMaxBytes();
+  if (Buffer.byteLength(rawEmail, 'utf8') > maxBytes) {
+    logEmailIngestEvent('validation_failed', { code: 'PAYLOAD_TOO_LARGE', maxBytes });
+    res.status(413).json({ error: 'raw_email exceeds maximum size', code: 'PAYLOAD_TOO_LARGE' });
+    return;
   }
 
-  // License check on sender domain
-  let licenseInfo = null;
-  if (intel.senderDomain) {
-    const domain = intel.senderDomain.toLowerCase();
-    const match = licenseRegistry.operators.find((op) =>
-      op.domains.some((d) => d === domain || domain.endsWith(`.${d}`) || d.endsWith(`.${domain}`))
-    );
-    if (match) {
-      const regulator = licenseRegistry.regulators[match.regulator as keyof typeof licenseRegistry.regulators] ?? null;
-      licenseInfo = {
-        found: true,
-        brand: match.brand,
-        regulator: match.regulator,
-        regulatorName: regulator?.name ?? match.regulator,
-        regulatorTier: regulator?.tier ?? null,
-        licenseId: match.licenseId,
-        type: match.type,
+  const deny = getEmailIngestDenyDomains();
+  const allow = getEmailIngestAllowDomains();
+  const quickDomain = extractQuickSenderDomain(rawEmail);
+  if (quickDomain && isSenderDomainDenied(quickDomain, deny)) {
+    logEmailIngestEvent('policy_reject', { code: 'SENDER_NOT_ALLOWED', stage: 'quick', reason: 'denylist' });
+    res.status(403).json({ error: 'Sender domain is not permitted', code: 'SENDER_NOT_ALLOWED' });
+    return;
+  }
+
+  let intel: EmailIntelData;
+  try {
+    intel = parseEmailIntel(rawEmail);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logEmailIngestEvent('parse_failed', { code: 'EMAIL_PARSE_FAILED', message });
+    SentryMonitor.captureException(err instanceof Error ? err : new Error(message), {
+      route: 'email-ingest',
+    });
+    await recordEmailIngestParseFailure({ stage: 'parseEmailIntel', message });
+    res.status(422).json({ error: 'Email parse failed', code: 'EMAIL_PARSE_FAILED' });
+    return;
+  }
+
+  const policyDomains = mergeSenderDomainsForPolicy(intel.senderDomain, quickDomain);
+  const policy = evaluateEmailIngestSenderPolicy(policyDomains, deny, allow);
+  if (policy === 'denied') {
+    logEmailIngestEvent('policy_reject', { code: 'SENDER_NOT_ALLOWED', reason: 'denylist' });
+    res.status(403).json({ error: 'Sender domain is not permitted', code: 'SENDER_NOT_ALLOWED' });
+    return;
+  }
+  if (policy === 'allowlist_block') {
+    logEmailIngestEvent('policy_reject', { code: 'SENDER_NOT_ALLOWED', reason: 'allowlist' });
+    res.status(403).json({ error: 'Sender domain is not permitted', code: 'SENDER_NOT_ALLOWED' });
+    return;
+  }
+
+  try {
+    // Run domain check on sender domain
+    let domainScan = null;
+    if (intel.senderDomain) {
+      try {
+        const urlToScan = `https://${intel.senderDomain}`;
+        domainScan = await suslink.scanUrl(urlToScan);
+      } catch {
+        domainScan = null;
+      }
+    }
+
+    // License check on sender domain
+    let licenseInfo = null;
+    if (intel.senderDomain) {
+      const domain = intel.senderDomain.toLowerCase();
+      const match = licenseRegistry.operators.find((op) =>
+        op.domains.some((d) => d === domain || domain.endsWith(`.${d}`) || d.endsWith(`.${domain}`))
+      );
+      if (match) {
+        const regulator = licenseRegistry.regulators[match.regulator as keyof typeof licenseRegistry.regulators] ?? null;
+        licenseInfo = {
+          found: true,
+          brand: match.brand,
+          regulator: match.regulator,
+          regulatorName: regulator?.name ?? match.regulator,
+          regulatorTier: regulator?.tier ?? null,
+          licenseId: match.licenseId,
+          type: match.type,
+        };
+      } else {
+        licenseInfo = { found: false };
+      }
+    }
+
+    // Scan up to 5 embedded URLs (avoid hammering external services)
+    const linkScans: Array<{ url: string; riskLevel: string; reason: string }> = [];
+    for (const url of intel.embeddedUrls.slice(0, 5)) {
+      try {
+        const scan = await suslink.scanUrl(url);
+        linkScans.push({ url, riskLevel: scan.riskLevel, reason: scan.reason || '' });
+      } catch {
+        linkScans.push({ url, riskLevel: 'unknown', reason: 'scan failed' });
+      }
+    }
+
+    // Append to trust signals log
+    if (intel.bonusSignals.length > 0 || intel.senderDomain) {
+      const trustSignalEntry = {
+        ingestedAt: new Date().toISOString(),
+        senderDomain: intel.senderDomain,
+        casinoBrand: intel.casinoBrand,
+        subject: intel.subject,
+        bonusSignals: intel.bonusSignals,
+        urgencyFlags: intel.urgencyFlags,
+        hasUnsubscribeLink: intel.hasUnsubscribeLink,
+        source: 'email-ingest',
       };
-    } else {
-      licenseInfo = { found: false };
+      try {
+        const trustSignalsPath = getTrustSignalsLogPath();
+        const dataDir = path.dirname(trustSignalsPath);
+        if (!existsSync(dataDir)) mkdirSync(dataDir, { recursive: true });
+        appendFileSync(
+          trustSignalsPath,
+          JSON.stringify(trustSignalEntry) + '\n',
+          'utf8'
+        );
+      } catch {
+        logEmailIngestEvent('trust_signal_write_failed', { code: 'TRUST_SIGNAL_WRITE_FAILED' });
+      }
     }
-  }
 
-  // Scan up to 5 embedded URLs (avoid hammering external services)
-  const linkScans: Array<{ url: string; riskLevel: string; reason: string }> = [];
-  for (const url of intel.embeddedUrls.slice(0, 5)) {
-    try {
-      const scan = await suslink.scanUrl(url);
-      linkScans.push({ url, riskLevel: scan.riskLevel, reason: scan.reason || '' });
-    } catch {
-      linkScans.push({ url, riskLevel: 'unknown', reason: 'scan failed' });
+    const persistedBonuses = persistEmailBonusIntel(rawEmail, intel, new Date());
+    const publishedBonusEvents: string[] = [];
+    for (const bonus of persistedBonuses.toPublish) {
+      try {
+        await eventRouter.publish(
+          'bonus.discovered',
+          'rgaas-api',
+          {
+            casino_name: bonus.brand,
+            bonus_type: bonus.bonusType,
+            value: bonus.bonusValue,
+            terms: bonus.terms,
+            expiry_message: bonus.expiryMessage,
+            is_expired: bonus.isExpired,
+            bonus_url: bonus.url,
+            image_url: bonus.imageUrl,
+            code: bonus.code,
+            source: bonus.source,
+          },
+          undefined,
+          {
+            discoveredVia: 'email-ingest',
+            senderDomain: bonus.senderDomain ?? undefined,
+          }
+        );
+        publishedBonusEvents.push(bonus.id);
+      } catch (error) {
+        logEmailIngestEvent('bonus_publish_failed', { code: 'BONUS_PUBLISH_FAILED' });
+      }
     }
-  }
 
-  // Append to trust signals log
-  if (intel.bonusSignals.length > 0 || intel.senderDomain) {
-    const trustSignalEntry = {
-      ingestedAt: new Date().toISOString(),
-      senderDomain: intel.senderDomain,
-      casinoBrand: intel.casinoBrand,
-      subject: intel.subject,
-      bonusSignals: intel.bonusSignals,
-      urgencyFlags: intel.urgencyFlags,
-      hasUnsubscribeLink: intel.hasUnsubscribeLink,
-      source: 'email-ingest',
-    };
-    try {
-      const trustSignalsPath = getTrustSignalsLogPath();
-      const dataDir = path.dirname(trustSignalsPath);
-      if (!existsSync(dataDir)) mkdirSync(dataDir, { recursive: true });
-      appendFileSync(
-        trustSignalsPath,
-        JSON.stringify(trustSignalEntry) + '\n',
-        'utf8'
-      );
-    } catch {
-      // Non-fatal — log but continue
-      console.warn('[email-ingest] Could not write trust signal entry');
+    if (publishedBonusEvents.length > 0) {
+      markEmailBonusEntriesPublished(publishedBonusEvents);
     }
-  }
 
-  const persistedBonuses = persistEmailBonusIntel(rawEmail, intel, new Date());
-  const publishedBonusEvents: string[] = [];
-  for (const bonus of persistedBonuses.toPublish) {
-    try {
-      await eventRouter.publish(
-        'bonus.discovered',
-        'rgaas-api',
-        {
-          casino_name: bonus.brand,
-          bonus_type: bonus.bonusType,
-          value: bonus.bonusValue,
-          terms: bonus.terms,
-          expiry_message: bonus.expiryMessage,
-          is_expired: bonus.isExpired,
-          bonus_url: bonus.url,
-          image_url: bonus.imageUrl,
-          code: bonus.code,
-          source: bonus.source,
-        },
-        undefined,
-        {
-          discoveredVia: 'email-ingest',
-          senderDomain: bonus.senderDomain ?? undefined,
-        }
-      );
-      publishedBonusEvents.push(bonus.id);
-    } catch (error) {
-      console.warn('[email-ingest] Could not publish bonus.discovered event', error);
-    }
-  }
-
-  if (publishedBonusEvents.length > 0) {
-    markEmailBonusEntriesPublished(publishedBonusEvents);
-  }
-
-  const emailGradeEvidence = buildEmailGradeEvidence(intel, linkScans, new Date());
-  if (emailGradeEvidence && intel.casinoBrand) {
-    try {
-      await eventRouter.publish('trust.casino.rollup', 'rgaas-api', {
-        source: 'email-intel',
-        casinos: {
-          [intel.casinoBrand]: {
-            totalDelta: (emailGradeEvidence.bonusDelta ?? 0) + (emailGradeEvidence.complianceDelta ?? 0),
-            events: emailGradeEvidence.reasons.length,
-            externalData: {
-              bonusDelta: emailGradeEvidence.bonusDelta,
-              complianceDelta: emailGradeEvidence.complianceDelta,
+    const emailGradeEvidence = buildEmailGradeEvidence(intel, linkScans, new Date());
+    if (emailGradeEvidence && intel.casinoBrand) {
+      try {
+        await eventRouter.publish('trust.casino.rollup', 'rgaas-api', {
+          source: 'email-intel',
+          casinos: {
+            [intel.casinoBrand]: {
+              totalDelta: (emailGradeEvidence.bonusDelta ?? 0) + (emailGradeEvidence.complianceDelta ?? 0),
+              events: emailGradeEvidence.reasons.length,
+              externalData: {
+                bonusDelta: emailGradeEvidence.bonusDelta,
+                complianceDelta: emailGradeEvidence.complianceDelta,
+              },
             },
           },
-        },
-      });
-    } catch (error) {
-      console.warn('[email-ingest] Could not publish trust.casino.rollup evidence', error);
+        });
+      } catch {
+        logEmailIngestEvent('rollup_publish_failed', { code: 'ROLLUP_PUBLISH_FAILED' });
+      }
     }
-  }
 
-  res.json({
-    success: true,
-    intel,
-    bonusFeed: {
-      file: getEmailBonusFeedPath(),
-      detected: persistedBonuses.entries.length,
-      added: persistedBonuses.added.length,
-      updated: persistedBonuses.updated.length,
-      publishedEvents: publishedBonusEvents.length,
-    },
-    domainScan: domainScan
-      ? { riskLevel: domainScan.riskLevel, reason: domainScan.reason }
-      : null,
-    gradeEvidence: emailGradeEvidence,
-    licenseInfo,
-    linkScans,
-  });
+    res.json({
+      success: true,
+      intel,
+      bonusFeed: {
+        file: getEmailBonusFeedPath(),
+        detected: persistedBonuses.entries.length,
+        added: persistedBonuses.added.length,
+        updated: persistedBonuses.updated.length,
+        publishedEvents: publishedBonusEvents.length,
+      },
+      domainScan: domainScan
+        ? { riskLevel: domainScan.riskLevel, reason: domainScan.reason }
+        : null,
+      gradeEvidence: emailGradeEvidence,
+      licenseInfo,
+      linkScans,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logEmailIngestEvent('processing_failed', { code: 'EMAIL_INGEST_PROCESSING_FAILED', message });
+    SentryMonitor.captureException(err instanceof Error ? err : new Error(message), {
+      route: 'email-ingest',
+      stage: 'post_parse',
+    });
+    res.status(500).json({ error: 'Email intake processing failed', code: 'EMAIL_INGEST_PROCESSING_FAILED' });
+  }
 });
 
 /**

--- a/apps/api/tests/lib/email-ingest-controls.test.ts
+++ b/apps/api/tests/lib/email-ingest-controls.test.ts
@@ -1,0 +1,39 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateEmailIngestSenderPolicy,
+  extractQuickSenderDomain,
+  isSenderDomainDenied,
+  mergeSenderDomainsForPolicy,
+} from '../../src/lib/email-ingest-controls.js';
+
+describe('email-ingest-controls', () => {
+  it('extractQuickSenderDomain reads From header', () => {
+    const raw = 'From: Promo <promo@chumba.example>\nSubject: Hi\n\nBody';
+    expect(extractQuickSenderDomain(raw)).toBe('chumba.example');
+  });
+
+  it('isSenderDomainDenied matches subdomains', () => {
+    const deny = new Set(['bad.com']);
+    expect(isSenderDomainDenied('evil.bad.com', deny)).toBe(true);
+    expect(isSenderDomainDenied('good.com', deny)).toBe(false);
+  });
+
+  it('evaluateEmailIngestSenderPolicy enforces allowlist when set', () => {
+    const deny = new Set<string>();
+    const allow = new Set(['trusted.example']);
+    expect(
+      evaluateEmailIngestSenderPolicy(mergeSenderDomainsForPolicy('trusted.example', null), deny, allow),
+    ).toBe('ok');
+    expect(
+      evaluateEmailIngestSenderPolicy(mergeSenderDomainsForPolicy('other.com', null), deny, allow),
+    ).toBe('allowlist_block');
+  });
+
+  it('evaluateEmailIngestSenderPolicy blocks empty domains under allowlist', () => {
+    const deny = new Set<string>();
+    const allow = new Set(['trusted.example']);
+    expect(evaluateEmailIngestSenderPolicy([], deny, allow)).toBe('allowlist_block');
+  });
+});

--- a/apps/api/tests/lib/email-ingest-parse-health.test.ts
+++ b/apps/api/tests/lib/email-ingest-parse-health.test.ts
@@ -1,0 +1,46 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tiltcheck/monitoring', () => ({
+  ALERT_RULES: {
+    EMAIL_INGEST_SUSTAINED_PARSE_FAILURES: {
+      id: 'EMAIL_INGEST_SUSTAINED_PARSE_FAILURES',
+      name: 'Email intake sustained parse failures',
+      threshold: 5,
+      cooldownMs: 15 * 60 * 1000,
+      notificationChannel: 'log' as const,
+    },
+  },
+  triggerAlert: vi.fn().mockResolvedValue(undefined),
+  resetAlertCooldown: vi.fn(),
+}));
+
+import { triggerAlert } from '@tiltcheck/monitoring';
+import {
+  recordEmailIngestParseFailure,
+  resetEmailIngestParseHealthForTests,
+} from '../../src/lib/email-ingest-parse-health.js';
+
+describe('email-ingest-parse-health', () => {
+  beforeEach(() => {
+    vi.mocked(triggerAlert).mockClear();
+    resetEmailIngestParseHealthForTests();
+    process.env.EMAIL_INGEST_PARSE_FAILURE_ALERT_THRESHOLD = '3';
+    process.env.EMAIL_INGEST_PARSE_FAILURE_WINDOW_MS = '600000';
+  });
+
+  afterEach(() => {
+    delete process.env.EMAIL_INGEST_PARSE_FAILURE_ALERT_THRESHOLD;
+    delete process.env.EMAIL_INGEST_PARSE_FAILURE_WINDOW_MS;
+    resetEmailIngestParseHealthForTests();
+  });
+
+  it('calls triggerAlert once the failure threshold is reached', async () => {
+    await recordEmailIngestParseFailure({ reason: 'a' });
+    await recordEmailIngestParseFailure({ reason: 'b' });
+    expect(triggerAlert).not.toHaveBeenCalled();
+    await recordEmailIngestParseFailure({ reason: 'c' });
+    expect(triggerAlert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/tests/routes/rgaas-email-feed.test.ts
+++ b/apps/api/tests/routes/rgaas-email-feed.test.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-17 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import { existsSync, readFileSync, rmSync } from 'node:fs';
@@ -92,7 +92,7 @@ describe('RGaaS email bonus feed routes', () => {
             `Date: ${new Date().toUTCString()}`,
             'Subject: Match bonus drop',
             '',
-            'Get a 100% match bonus up to $500 expires in 2 days.',
+            'Get a 100% match bonus up to $500 expires in 45 days.',
             'Use code DROP500 at https://mcluck.com/promos/claim',
             '<img src="https://cdn.discordapp.com/ephemeral-attachments/1234/5678/bad.png" />',
             '<img src="https://mcluck.com/assets/promo-banner.png" />',

--- a/apps/api/tests/routes/rgaas.test.ts
+++ b/apps/api/tests/routes/rgaas.test.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-17 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
@@ -12,6 +12,7 @@ import { trustEngines } from '@tiltcheck/trust-engines';
 import { suslink } from '@tiltcheck/suslink';
 import * as tiltcheckCore from '@tiltcheck/tiltcheck-core';
 import { eventRouter } from '@tiltcheck/event-router';
+import { resetEmailIngestParseHealthForTests } from '../../src/lib/email-ingest-parse-health.js';
 
 vi.mock('@tiltcheck/event-types', () => ({
     createEvent: vi.fn(),
@@ -368,15 +369,19 @@ describe('RGaaS Routes', () => {
                 .mockResolvedValueOnce({ riskLevel: 'low', reason: 'sender clean' } as any)
                 .mockResolvedValueOnce({ riskLevel: 'low', reason: 'claim link clean' } as any);
 
+            const futureDate = new Date();
+            futureDate.setUTCDate(futureDate.getUTCDate() + 30);
+            const dateHeader = futureDate.toUTCString();
+
             const response = await request(app)
                 .post('/rgaas/email-ingest')
                 .send({
                     raw_email: [
                         'From: promos@mcluck.com',
-                        'Date: Thu, 16 Apr 2026 12:00:00 +0000',
+                        `Date: ${dateHeader}`,
                         'Subject: Match bonus drop',
                         '',
-                        'Get a 100% match bonus up to $500 expires in 2 days.',
+                        'Get a 100% match bonus up to $500 expires in 45 days.',
                         'Use code DROP500 at https://mcluck.com/promos/claim',
                         '<img src="https://cdn.discordapp.com/ephemeral-attachments/1234/5678/bad.png" />',
                         '<img src="https://mcluck.com/assets/promo-banner.png" />',
@@ -461,6 +466,91 @@ describe('RGaaS Routes', () => {
                 isExpired: true,
                 code: 'OLD500',
             });
+        });
+    });
+
+    describe('POST /rgaas/email-ingest abuse controls', () => {
+        afterEach(() => {
+            delete process.env.EMAIL_INGEST_SECRET;
+            delete process.env.EMAIL_INGEST_SENDER_DENYLIST;
+            delete process.env.EMAIL_INGEST_SENDER_ALLOWLIST;
+            delete process.env.EMAIL_INGEST_MAX_BYTES;
+            delete process.env.EMAIL_INGEST_PARSE_FAILURE_ALERT_THRESHOLD;
+            delete process.env.EMAIL_INGEST_PARSE_FAILURE_WINDOW_MS;
+            resetEmailIngestParseHealthForTests();
+        });
+
+        it('returns 401 when EMAIL_INGEST_SECRET is set and no credential is sent', async () => {
+            process.env.EMAIL_INGEST_SECRET = 'supersecret';
+            const response = await request(app)
+                .post('/rgaas/email-ingest')
+                .send({
+                    raw_email: ['From: promos@mcluck.com', '', 'match bonus body text xxxxxxxxxxxxxxx'].join('\n'),
+                });
+            expect(response.status).toBe(401);
+            expect(response.body.code).toBe('EMAIL_INGEST_AUTH_FAILED');
+        });
+
+        it('accepts valid X-Email-Ingest-Key when secret is configured', async () => {
+            process.env.EMAIL_INGEST_SECRET = 'supersecret';
+            vi.mocked(suslink.scanUrl)
+                .mockResolvedValueOnce({ riskLevel: 'low', reason: 'sender clean' } as any)
+                .mockResolvedValueOnce({ riskLevel: 'low', reason: 'claim link clean' } as any);
+
+            const futureDate = new Date();
+            futureDate.setUTCDate(futureDate.getUTCDate() + 30);
+            const dateHeader = futureDate.toUTCString();
+
+            const response = await request(app)
+                .post('/rgaas/email-ingest')
+                .set('X-Email-Ingest-Key', 'supersecret')
+                .send({
+                    raw_email: [
+                        'From: promos@mcluck.com',
+                        `Date: ${dateHeader}`,
+                        'Subject: Match bonus drop',
+                        '',
+                        'Get a 100% match bonus up to $500 expires in 45 days.',
+                        'Use code KEY500 at https://mcluck.com/promos/claim',
+                    ].join('\n'),
+                });
+
+            expect(response.status).toBe(200);
+        });
+
+        it('returns 413 when raw_email exceeds EMAIL_INGEST_MAX_BYTES', async () => {
+            process.env.EMAIL_INGEST_MAX_BYTES = '60';
+            const huge = `From: promos@mcluck.com\n\n${'x'.repeat(80)}`;
+            const response = await request(app).post('/rgaas/email-ingest').send({ raw_email: huge });
+            expect(response.status).toBe(413);
+            expect(response.body.code).toBe('PAYLOAD_TOO_LARGE');
+        });
+
+        it('returns 403 when sender domain is on EMAIL_INGEST_SENDER_DENYLIST', async () => {
+            process.env.EMAIL_INGEST_SENDER_DENYLIST = 'evil.com';
+            const response = await request(app)
+                .post('/rgaas/email-ingest')
+                .send({
+                    raw_email: ['From: spam@evil.com', '', 'bonus text xxxxxxxxxxxxxxxxx'].join('\n'),
+                });
+            expect(response.status).toBe(403);
+        });
+
+        it('returns 403 when EMAIL_INGEST_SENDER_ALLOWLIST excludes the sender', async () => {
+            process.env.EMAIL_INGEST_SENDER_ALLOWLIST = 'only-good.com';
+            const response = await request(app)
+                .post('/rgaas/email-ingest')
+                .send({
+                    raw_email: [
+                        'From: promos@mcluck.com',
+                        'Subject: Offer',
+                        '',
+                        '100% match bonus up to $500',
+                        'https://mcluck.com/promo',
+                    ].join('\n'),
+                });
+            expect(response.status).toBe(403);
+            expect(response.body.code).toBe('SENDER_NOT_ALLOWED');
         });
     });
 });

--- a/apps/api/tests/setup.ts
+++ b/apps/api/tests/setup.ts
@@ -1,10 +1,13 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-06
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 import { vi } from 'vitest';
 
 process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://test:test@127.0.0.1:5432/test';
 process.env.NEON_DATABASE_URL = process.env.NEON_DATABASE_URL || process.env.DATABASE_URL;
 process.env.GEMINI_API_KEY = process.env.GEMINI_API_KEY || 'test-gemini-api-key';
 process.env.GOOGLE_GENAI_API_KEY = process.env.GOOGLE_GENAI_API_KEY || process.env.GEMINI_API_KEY;
+
+// Email ingest: avoid 429 flakes on RGaaS route tests (production default is stricter).
+process.env.EMAIL_INGEST_RATE_LIMIT_MAX = process.env.EMAIL_INGEST_RATE_LIMIT_MAX || '10000';
 
 // Global test setup for API tests
 // Suppress console output in tests unless debugging

--- a/docs/ops/rgaas-email-ingest-runbook.md
+++ b/docs/ops/rgaas-email-ingest-runbook.md
@@ -1,0 +1,35 @@
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+
+# RGaaS email ingest runbook (`POST /rgaas/email-ingest`)
+
+## What it does
+
+Accepts `raw_email` (full RFC822-ish text), parses marketing signals, runs SusLink on the sender domain and a few embedded links, appends trust-signal lines, persists inbox bonuses, and publishes events. Abuse controls and failure telemetry are env-driven.
+
+## When intake is broken
+
+1. **Check API logs** for JSON lines prefixed with `[email-ingest]`. Events include `validation_failed`, `auth_failed`, `policy_reject`, `parse_failed`, `trust_signal_write_failed`, `bonus_publish_failed`, `rollup_publish_failed`, `processing_failed`.
+2. **HTTP codes**: `400` invalid body, `401` missing secret when `EMAIL_INGEST_SECRET` is set, `403` allow/deny policy, `413` payload over `EMAIL_INGEST_MAX_BYTES`, `422` parse exception, `429` per-route rate limit, `500` unexpected post-parse failure.
+3. **Sentry** (if `SENTRY_DSN` is set): exceptions from parse and post-parse paths include `route: email-ingest`.
+4. **Discord / webhook alerts**: sustained parse failures hit `ALERT_RULES.EMAIL_INGEST_SUSTAINED_PARSE_FAILURES` via `triggerAlert` when failures exceed `EMAIL_INGEST_PARSE_FAILURE_ALERT_THRESHOLD` inside `EMAIL_INGEST_PARSE_FAILURE_WINDOW_MS` (in-process counter; resets on deploy).
+5. **Disk / paths**: trust log (`TRUST_SIGNALS_LOG_PATH` or `data/trust-signals.jsonl`) and bonus feed (`EMAIL_BONUS_FEED_PATH` or `data/email-bonus-feed.json`) must be writable.
+
+## Operational knobs
+
+| Variable | Purpose |
+| --- | --- |
+| `EMAIL_INGEST_SECRET` | Optional; requires `Authorization: Bearer` or `X-Email-Ingest-Key`. Do not set if the public web domain verifier must call intake directly from the browser. |
+| `EMAIL_INGEST_SENDER_DENYLIST` | Comma-separated domains to hard-reject. |
+| `EMAIL_INGEST_SENDER_ALLOWLIST` | When non-empty, only listed sender domains pass. |
+| `EMAIL_INGEST_MAX_BYTES` | UTF-8 cap on `raw_email` (default 524288). |
+| `EMAIL_INGEST_RATE_LIMIT_MAX` / `EMAIL_INGEST_RATE_LIMIT_WINDOW_MS` | Per-IP cap for this route only. |
+| `EMAIL_INGEST_PARSE_FAILURE_ALERT_THRESHOLD` / `EMAIL_INGEST_PARSE_FAILURE_WINDOW_MS` | Burst parse-failure alerting. |
+| `DISCORD_ALERT_WEBHOOK_URL` / `ALERT_WEBHOOK_URL` | Standard alert dispatch targets from `@tiltcheck/monitoring`. |
+
+## Rollback
+
+Unset the `EMAIL_INGEST_*` variables you changed and redeploy the API. No schema migrations.
+
+## Risk notes
+
+Allowlists misconfigured block real mail. Secrets leaked in client-side JS defeat the control. The parse-failure counter is single-process; multi-instance APIs see partial counts unless you add external metrics later.

--- a/packages/monitoring/src/alerts.ts
+++ b/packages/monitoring/src/alerts.ts
@@ -99,6 +99,19 @@ export const ALERT_RULES = {
     cooldownMs: 2 * 60 * 1000,
     notificationChannel: 'webhook',
   } satisfies AlertRule,
+
+  /**
+   * Fires when the API records multiple email-ingest parse failures inside a
+   * sliding window (threshold is enforced by the caller, not this preset).
+   * Routed to Discord. Cooldown: 15 minutes.
+   */
+  EMAIL_INGEST_SUSTAINED_PARSE_FAILURES: {
+    id: 'EMAIL_INGEST_SUSTAINED_PARSE_FAILURES',
+    name: 'Email intake sustained parse failures',
+    threshold: 5,
+    cooldownMs: 15 * 60 * 1000,
+    notificationChannel: 'discord',
+  } satisfies AlertRule,
 } as const satisfies Record<string, AlertRule>;
 
 // ============================================================================

--- a/scripts/email-crawler.ts
+++ b/scripts/email-crawler.ts
@@ -1,4 +1,4 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-18
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 /**
  * Casino Email Crawler
  *
@@ -208,6 +208,9 @@ async function ingestEmail(rawEmail: string): Promise<{ success: boolean; brand?
     headers: {
       'Content-Type': 'application/json',
       'X-Requested-With': 'TiltCheck-Email-Crawler',
+      ...(process.env.EMAIL_INGEST_SECRET?.trim()
+        ? { 'X-Email-Ingest-Key': process.env.EMAIL_INGEST_SECRET.trim() }
+        : {}),
     },
     body: JSON.stringify({ raw_email: rawEmail }),
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Linear **TIL-40** acceptance criteria for `POST /rgaas/email-ingest`: minimal anti-abuse (dedicated rate limit, optional secret, payload cap, sender allow/deny lists), structured validation and policy logs, sustained parse-failure notifications via existing `triggerAlert` / `DISCORD_ALERT_WEBHOOK_URL`, and an operations runbook.

## Changes

- **Abuse / spam**: `express-rate-limit` middleware on the route (env: `EMAIL_INGEST_RATE_LIMIT_MAX`, `EMAIL_INGEST_RATE_LIMIT_WINDOW_MS`; tests default to a high ceiling via `tests/setup.ts`). Optional `EMAIL_INGEST_SECRET` (`Authorization: Bearer` or `X-Email-Ingest-Key`). `EMAIL_INGEST_MAX_BYTES` caps body size. `EMAIL_INGEST_SENDER_DENYLIST` / `EMAIL_INGEST_SENDER_ALLOWLIST` (comma-separated domains, subdomain match).
- **Observability**: JSON `console.warn('[email-ingest]', ...)` events; `SentryMonitor.captureException` on parse failures; non-fatal publish/write paths log `bonus_publish_failed` / `rollup_publish_failed` / `trust_signal_write_failed` without leaking raw email bodies in responses.
- **Alerting**: New `ALERT_RULES.EMAIL_INGEST_SUSTAINED_PARSE_FAILURES` in `@tiltcheck/monitoring`; sliding-window counter in `email-ingest-parse-health.ts` (env: `EMAIL_INGEST_PARSE_FAILURE_ALERT_THRESHOLD`, `EMAIL_INGEST_PARSE_FAILURE_WINDOW_MS`). In-process only; documented limitation in runbook.
- **Docs**: `docs/ops/rgaas-email-ingest-runbook.md` plus `.env.example` entries. `scripts/email-crawler.ts` forwards `X-Email-Ingest-Key` when `EMAIL_INGEST_SECRET` is set.
- **Tests**: Abuse cases in `rgaas.test.ts`, unit tests for controls and parse-health, future-relative expiry in fixtures so `publishedEvents` assertions do not rot as wall-clock time passes.

## Risk / rollback

- **Misconfiguration**: Wrong allowlist or forgotten secret blocks clients; unset offending `EMAIL_INGEST_*` vars and redeploy.
- **Multi-instance**: Parse-failure burst counter is per process; sustained abuse across replicas may under-count until central metrics exist.

## Validation

- `pnpm --filter @tiltcheck/monitoring build`
- `pnpm vitest --run tests/routes/rgaas.test.ts tests/lib/email-ingest-controls.test.ts tests/lib/email-ingest-parse-health.test.ts tests/routes/rgaas-email-feed.test.ts`
- `pnpm exec tsc --noEmit` (in `apps/api`)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TIL-40](https://linear.app/tiltcheck/issue/TIL-40/email-intake-abusespam-controls-alerting-on-parse-failures)

<div><a href="https://cursor.com/agents/bc-19dfcb3f-ef46-41b1-91a4-f769064f2000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19dfcb3f-ef46-41b1-91a4-f769064f2000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

