### PR TITLE
TIL-36: Monetization — game add-ons only, retire platform pay surfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-28
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 # ==============================================
 # TILTCHECK MONOREPO - MASTER ENVIRONMENT CONFIG (TEMPLATE)
 # ==============================================
@@ -149,6 +149,13 @@ DISCORD_ROLE_OG_LIFETIME_ID=REPLACE_ME
 DISCORD_ROLE_PRO_ID=REPLACE_ME
 
 # --- DISCORD: SKU IDs (Monetization) ---
+# Game add-ons (Discord Activity SKUs) — sole SKUs exposed via /upgrade (TIL-36).
+DISCORD_SKU_GAME_ADDON_IDS=REPLACE_ME
+# Optional single Discord role ID granted on game add-on entitlement (must match a SKU in DISCORD_SKU_GAME_ADDON_IDS).
+DISCORD_SKU_GAME_ADDON_ROLE_ID=REPLACE_ME
+# JustTheTip fee waiver: comma-separated SKU IDs checked via Discord entitlements API (GET /user/:id/elite).
+DISCORD_SKU_JTT_FEE_WAIVER_IDS=REPLACE_ME
+# Retired platform passes — keep IDs only if you still need legacy webhook logging; no auto-role fulfillment.
 DISCORD_SKU_ELITE_ID=REPLACE_ME
 DISCORD_SKU_LIFETIME_ID=REPLACE_ME
 DISCORD_SKU_OG_LIFETIME_ID=REPLACE_ME

--- a/apps/activity/src/views/TipView.ts
+++ b/apps/activity/src/views/TipView.ts
@@ -1,4 +1,4 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-20
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 
 import type { SessionState, TipRain, TipEntry } from '../state/SessionState.js';
 import type { HubRelay } from '../sdk/HubRelay.js';
@@ -264,7 +264,7 @@ export class TipView {
         <span class="elite-status">${isElite ? 'ELITE — 0% FEES' : 'FREE TIER — 2.5% FEE'}</span>
         ${isElite
           ? `<span class="elite-saved">You've saved ${feeSaved.toFixed(4)} SOL in fees</span>`
-          : `<span class="elite-cta">Upgrade to Elite — stop feeding the protocol</span>`
+          : `<span class="elite-cta">Fee waiver: founders, or Discord SKUs in DISCORD_SKU_JTT_FEE_WAIVER_IDS — platform passes are retired.</span>`
         }
       </div>
 

--- a/apps/activity/src/views/TipView.ts
+++ b/apps/activity/src/views/TipView.ts
@@ -264,7 +264,7 @@ export class TipView {
         <span class="elite-status">${isElite ? 'ELITE — 0% FEES' : 'FREE TIER — 2.5% FEE'}</span>
         ${isElite
           ? `<span class="elite-saved">You've saved ${feeSaved.toFixed(4)} SOL in fees</span>`
-          : `<span class="elite-cta">Fee waiver: founders, or Discord SKUs in DISCORD_SKU_JTT_FEE_WAIVER_IDS — platform passes are retired.</span>`
+          : `<span class="elite-cta">Fee waiver: founders or active Discord game add-on entitlements — platform passes are retired.</span>`
         }
       </div>
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "@tiltcheck/monitoring": "workspace:*",
     "@tiltcheck/config": "workspace:*",
     "@tiltcheck/db": "workspace:*",
+    "@tiltcheck/discord-monetization": "workspace:*",
     "@tiltcheck/error-factory": "workspace:*",
     "@tiltcheck/event-router": "workspace:*",
     "@tiltcheck/event-types": "workspace:*",

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 /**
  * User Routes - /user/*
  * Handles user profile, onboarding status, and preferences
@@ -24,8 +24,8 @@ import {
     createVaultRule,
     updateVaultRule,
     deleteVaultRule,
-    findOneBy,
 } from '@tiltcheck/db';
+import { DiscordShopManager, getJitFeeWaiverSkuIds } from '@tiltcheck/discord-monetization';
 import { ApplicationError, ValidationError, InternalServerError } from '@tiltcheck/error-factory';
 import { invalidateExclusionCache, getForbiddenGamesProfile } from '../services/exclusion-cache.js';
 import {
@@ -570,8 +570,11 @@ router.get('/:discordId', async (req: Request, res: Response, next: NextFunction
 
 /**
  * GET /user/:id/elite
- * Returns Elite tier status and fees saved for a user.
- * Used by the Activity Tip tab to show 0% fee badge.
+ * Returns fee-waiver (legacy "elite") status for JustTheTip display.
+ * Platform subscription rows are ignored (TIL-36). Waiver comes from founders
+ * or active Discord entitlements for SKUs listed in DISCORD_SKU_JTT_FEE_WAIVER_IDS.
+ *
+ * Rollback: restore subscriptions lookup if platform billing returns.
  */
 router.get('/:id/elite', async (req: Request, res, next: NextFunction) => {
     try {
@@ -586,12 +589,6 @@ router.get('/:id/elite', async (req: Request, res, next: NextFunction) => {
 
         const totalFees = balance?.total_fees_lamports ?? 0;
 
-        // Check subscriptions table for an active Elite tier
-        interface Subscription { user_id: string; status: string; plan: string; }
-        const sub = await findOneBy<Subscription>('subscriptions', 'user_id', id).catch(() => null);
-        const isElite = sub?.status === 'active' && sub?.plan?.toLowerCase().includes('elite');
-
-        // Founders also get Elite benefits
         const FOUNDER_USERNAMES = (process.env.FOUNDER_USERNAMES || 'jmenichole')
             .split(',')
             .map((u) => u.trim().toLowerCase());
@@ -600,10 +597,34 @@ router.get('/:id/elite', async (req: Request, res, next: NextFunction) => {
             ? FOUNDER_USERNAMES.includes(user.discord_username.toLowerCase())
             : false;
 
-        const feeSavedSol = isElite || isFounder ? (totalFees * 1e-9) * 0.01 : 0;
+        let hasDiscordFeeWaiver = false;
+        const feeWaiverSkuIds = getJitFeeWaiverSkuIds();
+        const botToken =
+            process.env.DISCORD_BOT_TOKEN?.trim() ||
+            process.env.TILT_DISCORD_BOT_TOKEN?.trim();
+        const applicationId =
+            process.env.TILT_DISCORD_CLIENT_ID?.trim() ||
+            process.env.DISCORD_CLIENT_ID?.trim();
+
+        if (feeWaiverSkuIds.length > 0 && botToken && applicationId) {
+            const shop = new DiscordShopManager({
+                applicationId,
+                botToken,
+            });
+            const entitlements = await shop.getEntitlements(id, feeWaiverSkuIds);
+            hasDiscordFeeWaiver = entitlements.some(
+                (e) =>
+                    feeWaiverSkuIds.includes(e.sku_id) &&
+                    !e.consumed &&
+                    !e.deleted
+            );
+        }
+
+        const isElite = isFounder || hasDiscordFeeWaiver;
+        const feeSavedSol = isElite ? (totalFees * 1e-9) * 0.01 : 0;
 
         res.json({
-            isElite: isElite || isFounder,
+            isElite,
             feeSavedSol,
             totalFeesPaidSol: totalFees * 1e-9,
         });

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -611,7 +611,7 @@ router.get('/:id/elite', async (req: Request, res, next: NextFunction) => {
                 applicationId,
                 botToken,
             });
-            const entitlements = await shop.getEntitlements(id, feeWaiverSkuIds);
+            const entitlements = await shop.getEntitlements(id, feeWaiverSkuIds).catch(() => []);
             hasDiscordFeeWaiver = entitlements.some(
                 (e) =>
                     feeWaiverSkuIds.includes(e.sku_id) &&

--- a/apps/api/tests/routes/user-routes.test.ts
+++ b/apps/api/tests/routes/user-routes.test.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
@@ -23,6 +23,10 @@ const mockedExclusionCache = vi.hoisted(() => ({
   getForbiddenGamesProfile: vi.fn(),
   invalidateExclusionCache: vi.fn(),
 }));
+const mockJttGetBalance = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ total_fees_lamports: 0 }),
+);
+const mockDiscordGetEntitlements = vi.hoisted(() => vi.fn().mockResolvedValue([]));
 const mockAuthUser = vi.hoisted(() => ({
   id: 'user-1',
   discordId: 'discord-self',
@@ -31,6 +35,26 @@ const mockAuthUser = vi.hoisted(() => ({
 
 vi.mock('@tiltcheck/db', () => mockedDb);
 vi.mock('../../src/services/exclusion-cache.js', () => mockedExclusionCache);
+vi.mock('@tiltcheck/justthetip', () => ({
+  justthetip: {
+    credits: {
+      getBalance: (...args: unknown[]) => mockJttGetBalance(...args),
+    },
+  },
+}));
+vi.mock('@tiltcheck/discord-monetization', async () => {
+  const actual = await vi.importActual<typeof import('@tiltcheck/discord-monetization')>(
+    '@tiltcheck/discord-monetization',
+  );
+  return {
+    ...actual,
+    DiscordShopManager: class {
+      getEntitlements(...args: unknown[]) {
+        return mockDiscordGetEntitlements(...args);
+      }
+    },
+  };
+});
 vi.mock('../../src/middleware/auth.js', () => ({
   authMiddleware: (req: any, _res: any, next: any) => {
     if (!req.user) {
@@ -55,6 +79,8 @@ describe('User route ordering and shape', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
+    mockJttGetBalance.mockResolvedValue({ total_fees_lamports: 0 });
+    mockDiscordGetEntitlements.mockResolvedValue([]);
   });
 
   it('resolves /onboarding before dynamic /:discordId route', async () => {
@@ -118,6 +144,54 @@ describe('User route ordering and shape', () => {
       complianceBypass: false,
     });
     expect(mockedDb.findOnboardingByDiscordId).toHaveBeenCalledWith('d1');
+  });
+
+  it('GET /user/:id/elite treats founders as fee-waived without Discord entitlements', async () => {
+    vi.stubEnv('FOUNDER_USERNAMES', 'whale');
+    mockJttGetBalance.mockResolvedValueOnce({ total_fees_lamports: 2_000_000_000 });
+    mockedDb.findUserByDiscordId.mockResolvedValueOnce({
+      discord_username: 'Whale',
+    });
+
+    const response = await request(app).get('/user/discord-123/elite');
+
+    expect(response.status).toBe(200);
+    expect(response.body.isElite).toBe(true);
+    expect(response.body.feeSavedSol).toBeGreaterThan(0);
+    expect(mockDiscordGetEntitlements).not.toHaveBeenCalled();
+  });
+
+  it('GET /user/:id/elite uses Discord entitlements when fee waiver SKUs are configured', async () => {
+    vi.stubEnv('DISCORD_SKU_JTT_FEE_WAIVER_IDS', 'fee-sku-9');
+    vi.stubEnv('DISCORD_BOT_TOKEN', 'bot-test');
+    vi.stubEnv('DISCORD_CLIENT_ID', 'app-test');
+    mockJttGetBalance.mockResolvedValueOnce({ total_fees_lamports: 1_000_000_000 });
+    mockedDb.findUserByDiscordId.mockResolvedValueOnce({
+      discord_username: 'normie',
+    });
+    mockDiscordGetEntitlements.mockResolvedValueOnce([
+      { sku_id: 'fee-sku-9', consumed: false, deleted: false },
+    ]);
+
+    const response = await request(app).get('/user/discord-456/elite');
+
+    expect(response.status).toBe(200);
+    expect(response.body.isElite).toBe(true);
+    expect(mockDiscordGetEntitlements).toHaveBeenCalled();
+  });
+
+  it('GET /user/:id/elite returns free tier when no founder and no entitlement', async () => {
+    vi.stubEnv('FOUNDER_USERNAMES', 'someone_else');
+    mockJttGetBalance.mockResolvedValueOnce({ total_fees_lamports: 500_000_000 });
+    mockedDb.findUserByDiscordId.mockResolvedValueOnce({
+      discord_username: 'normie',
+    });
+
+    const response = await request(app).get('/user/discord-789/elite');
+
+    expect(response.status).toBe(200);
+    expect(response.body.isElite).toBe(false);
+    expect(response.body.feeSavedSol).toBe(0);
   });
 
   it('gates /upgrade until live payment validation exists', async () => {

--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -26,6 +26,7 @@
     "@tiltcheck/dad": "workspace:*",
     "@tiltcheck/database": "workspace:*",
     "@tiltcheck/discord-activities": "workspace:*",
+    "@tiltcheck/discord-monetization": "workspace:*",
     "@tiltcheck/discord-utils": "workspace:*",
     "@tiltcheck/esm-utils": "workspace:*",
     "@tiltcheck/event-router": "workspace:*",

--- a/apps/discord-bot/src/commands/upgrade.ts
+++ b/apps/discord-bot/src/commands/upgrade.ts
@@ -1,9 +1,9 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-17
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 /**
  * Upgrade Command
  *
- * Shows available premium tiers, SOL payment instructions,
- * and Discord SKU subscription buttons.
+ * Surfaces Discord game add-on SKUs only (TIL-36). Retired platform passes
+ * and SOL claim flows are not advertised from this command.
  */
 
 import {
@@ -14,130 +14,66 @@ import {
   ButtonBuilder,
   ButtonStyle,
 } from 'discord.js';
+import { getConfiguredGameAddonSkuIds } from '@tiltcheck/discord-monetization';
 import type { Command } from '../types.js';
 
 const TEAL = 0x22d3a6;
-const SOL_WALLET = 'BvzEqVRUicmW8Y6HFncLYrGXESpMbSNDkWUNTQj5GGGi';
-const PREMIUM_URL = `https://discord.com/application-directory/${process.env.DISCORD_CLIENT_ID || 'PENDING'}/premium`;
-const CLAIM_URL = 'https://dashboard.tiltcheck.me/premium';
+const APP_DIR_BASE = `https://discord.com/application-directory/${process.env.DISCORD_CLIENT_ID || 'PENDING'}`;
 
 export const upgrade: Command = {
   data: new SlashCommandBuilder()
     .setName('upgrade')
-    .setDescription('See the paid tiers if you want more tools and less rate-limit pain.'),
+    .setDescription('Buy Discord game add-ons for TiltCheck Activities (platform passes are retired).'),
 
   async execute(interaction: ChatInputCommandInteraction) {
     await interaction.deferReply({ ephemeral: true });
 
-    const tierEmbed = new EmbedBuilder()
+    const gameAddonSkuIds = getConfiguredGameAddonSkuIds();
+
+    const policyEmbed = new EmbedBuilder()
       .setColor(TEAL)
-      .setTitle('UPGRADE YOUR DEGEN STATUS')
+      .setTitle('GAME ADD-ONS ONLY')
       .setDescription(
         [
-          '**DEGEN PASS** -- $4.99/mo',
-          '- Unlimited scans, no daily cap',
-          '- Full SusLink threat analysis',
-          '- Casino trust scores (full detail)',
-          '- Priority bot alerts',
-          '- Degen Pass Discord role',
+          'Non-game-add-on passes (Degen / Platinum / Lifetime / SOL claim ladder) are retired. No cap, that lane was platform monetization.',
           '',
-          '**PLATINUM PASS** -- $14.99/mo',
-          '- Everything in Degen Pass',
-          '- Full API access',
-          '- Custom nudge thresholds',
-          '- Beta feature access',
-          '- Platinum Discord role',
+          '**What still bills:** Discord **game add-ons** tied to the embedded Activity — consumables, rounds, cosmetics, whatever you actually ship as an add-on SKU.',
           '',
-          '**LIFETIME PASS** -- $199.99 one-time',
-          '- Platinum tier forever, no renewals',
-          '- Every current Platinum perk',
-          '- Early access to all new modules',
-          '- Lifetime Pass Discord role',
-          '',
-          '**OG LIFETIME PASS** -- $99.99 one-time (beta price)',
-          '- Everything in Lifetime Pass',
-          '- Locked in at beta price forever',
-          '- OG Lifetime Discord role',
-          '- Beta tester credit in release notes',
-          '',
-          '**SUPPORT THE PROJECT** -- $9.99 one-time',
-          '- No tier. No role. No perks.',
-          '- Just fuel for the team keeping this thing alive.',
+          '**What you do:** open the TiltCheck Activity in Discord and buy from the in-app shelf, or use the buttons below when SKUs are configured.',
         ].join('\n')
       )
       .setFooter({ text: 'Made for Degens. By Degens.' });
 
-    const solEmbed = new EmbedBuilder()
-      .setColor(TEAL)
-      .setTitle('PAY WITH SOLANA')
-      .setDescription(
-        [
-           'Prefer crypto over Discord billing? Fine. Send SOL directly.',
-          '',
-          `**Wallet:** \`${SOL_WALLET}\``,
-          '',
-          '**Amounts:**',
-          '- Degen Pass (monthly): `0.05 SOL`',
-          '- Platinum Pass (monthly): `0.15 SOL`',
-          '- Lifetime Pass (one-time): `1.00 SOL`',
-          '- OG Lifetime Pass / Beta (one-time): `0.65 SOL`',
-          '',
-          `After paying, submit your tx hash at:\n${CLAIM_URL}`,
-          '',
-           'Roles are granted manually within 24 hours after on-chain verification.',
-           'No partial payments. Send the exact amount or you just created paperwork.',
-        ].join('\n')
-      )
-      .setFooter({ text: 'Made for Degens. By Degens.' });
+    const rows: ActionRowBuilder<ButtonBuilder>[] = [];
 
-    // Build action row with premium SKU buttons or link fallbacks
-    const row = new ActionRowBuilder<ButtonBuilder>();
-
-    try {
-      const skuProId = process.env.DISCORD_SKU_PRO_ID;
-      const skuEliteId = process.env.DISCORD_SKU_ELITE_ID;
-      const skuLifetimeId = process.env.DISCORD_SKU_LIFETIME_ID;
-      const skuOgLifetimeId = process.env.DISCORD_SKU_OG_LIFETIME_ID;
-      const skuSupportId = process.env.DISCORD_SKU_SUPPORT_ID;
-
-      if (skuProId && skuEliteId && skuLifetimeId && skuOgLifetimeId && skuSupportId) {
-        row.addComponents(
-          new ButtonBuilder().setStyle(ButtonStyle.Premium).setSKUId(skuProId),
-          new ButtonBuilder().setStyle(ButtonStyle.Premium).setSKUId(skuEliteId),
-          new ButtonBuilder().setStyle(ButtonStyle.Premium).setSKUId(skuLifetimeId),
-          new ButtonBuilder().setStyle(ButtonStyle.Premium).setSKUId(skuOgLifetimeId),
-          new ButtonBuilder().setStyle(ButtonStyle.Premium).setSKUId(skuSupportId),
-        );
-      } else {
-        // Fallback: link button to app directory premium page
-        row.addComponents(
-          new ButtonBuilder()
-            .setStyle(ButtonStyle.Link)
-            .setLabel('Subscribe via Discord')
-            .setURL(PREMIUM_URL),
-          new ButtonBuilder()
-            .setStyle(ButtonStyle.Link)
-            .setLabel('Pay with SOL')
-            .setURL(CLAIM_URL),
-        );
+    if (gameAddonSkuIds.length > 0) {
+      try {
+        for (let i = 0; i < gameAddonSkuIds.length; i += 5) {
+          const chunk = gameAddonSkuIds.slice(i, i + 5);
+          const row = new ActionRowBuilder<ButtonBuilder>();
+          for (const skuId of chunk) {
+            row.addComponents(new ButtonBuilder().setStyle(ButtonStyle.Premium).setSKUId(skuId));
+          }
+          rows.push(row);
+        }
+      } catch (_err) {
+        rows.length = 0;
       }
-    } catch (_err) {
-      // If ButtonStyle.Premium is unavailable in this environment, fall back to links
-      row.addComponents(
+    }
+
+    if (rows.length === 0) {
+      const fallback = new ActionRowBuilder<ButtonBuilder>().addComponents(
         new ButtonBuilder()
           .setStyle(ButtonStyle.Link)
-          .setLabel('Subscribe via Discord')
-          .setURL(PREMIUM_URL),
-        new ButtonBuilder()
-          .setStyle(ButtonStyle.Link)
-          .setLabel('Pay with SOL')
-          .setURL(CLAIM_URL),
+          .setLabel('Open app directory')
+          .setURL(APP_DIR_BASE),
       );
+      rows.push(fallback);
     }
 
     await interaction.editReply({
-      embeds: [tierEmbed, solEmbed],
-      components: [row],
+      embeds: [policyEmbed],
+      components: rows,
     });
   },
 };

--- a/apps/discord-bot/src/handlers/events.ts
+++ b/apps/discord-bot/src/handlers/events.ts
@@ -287,7 +287,7 @@ export class EventHandler {
       const gameAddonRoleId = (process.env.DISCORD_SKU_GAME_ADDON_ROLE_ID || '').trim();
       if (userId && isConfiguredGameAddonSku(skuId) && gameAddonRoleId) {
         try {
-          const guild = await this.client.guilds.fetch('1488253239643078787');
+          const guild = await this.client.guilds.fetch(process.env.DISCORD_GUILD_ID || '');
           const member = await guild.members.fetch(userId);
           await member.roles.add([gameAddonRoleId]);
           console.log(`[Payments] Auto-granted game add-on role ${gameAddonRoleId} to user ${userId}`);

--- a/apps/discord-bot/src/handlers/events.ts
+++ b/apps/discord-bot/src/handlers/events.ts
@@ -1,4 +1,4 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 /**
  * Event Handler
  *
@@ -34,6 +34,10 @@ import { trackMessageEvent, trackCommandEvent } from '../services/elastic-teleme
 import { markUserActive, type TiltAgentContext } from '../services/tilt-agent.js';
 import { handleCommandError } from './error.js';
 import { dispatchButtonInteraction } from './button-handlers.js';
+import {
+  isConfiguredGameAddonSku,
+  isLegacyPlatformMonetizationSku,
+} from '@tiltcheck/discord-monetization';
 import { detectIntent, formatNlpResponse, getFallbackReply } from '../services/nlp-intent.js';
 import { handleSafetyIntervention } from '../services/intervention-service.js';
 import { hasMessageContentConsent } from '../services/data-consent.js';
@@ -234,14 +238,20 @@ export class EventHandler {
       const userId = entitlement.userId;
       console.log(`[Payments] Entitlement created: SKU ${skuId} for user ${userId}`);
 
-      const skuMap: Record<string, string> = {
-        [process.env.DISCORD_SKU_PRO_ID || '']:        'Degen Pass',
-        [process.env.DISCORD_SKU_ELITE_ID || '']:      'Platinum Pass',
-        [process.env.DISCORD_SKU_LIFETIME_ID || '']:   'Lifetime Pass',
-        [process.env.DISCORD_SKU_OG_LIFETIME_ID || '']: 'OG Lifetime Pass (Beta)',
-        [process.env.DISCORD_SKU_SUPPORT_ID || '']:    'Support the Project',
+      const legacyNameMap: Record<string, string> = {
+        [process.env.DISCORD_SKU_PRO_ID || '']: 'Degen Pass (retired)',
+        [process.env.DISCORD_SKU_ELITE_ID || '']: 'Platinum Pass (retired)',
+        [process.env.DISCORD_SKU_LIFETIME_ID || '']: 'Lifetime Pass (retired)',
+        [process.env.DISCORD_SKU_OG_LIFETIME_ID || '']: 'OG Lifetime Pass (retired)',
+        [process.env.DISCORD_SKU_SUPPORT_ID || '']: 'Support SKU (retired)',
       };
-      const tierName = skuMap[skuId] || `Unknown SKU: ${skuId}`;
+      const tierLabel = legacyNameMap[skuId] || (isConfiguredGameAddonSku(skuId) ? 'Game add-on' : `SKU ${skuId}`);
+
+      const embedTitle = isLegacyPlatformMonetizationSku(skuId)
+        ? 'RETIRED PLATFORM SKU (log only; no auto-role)'
+        : isConfiguredGameAddonSku(skuId)
+          ? 'GAME ADD-ON PURCHASE'
+          : 'DISCORD SKU PURCHASE (unmapped)';
 
       // Notify MOD_LOG channel
       try {
@@ -252,11 +262,17 @@ export class EventHandler {
             embeds: [
               new EmbedBuilder()
                 .setColor(0x22d3a6)
-                .setTitle('DISCORD PREMIUM PURCHASE')
-                .setDescription('Auto-grant role or verify manually.')
+                .setTitle(embedTitle)
+                .setDescription(
+                  isLegacyPlatformMonetizationSku(skuId)
+                    ? 'Legacy platform monetization SKU fired. Roles are not auto-granted (TIL-36). Handle manually if Discord still renewed an old listing.'
+                    : isConfiguredGameAddonSku(skuId)
+                      ? 'Game add-on fulfillment — optional Discord role below if DISCORD_SKU_GAME_ADDON_ROLE_ID is set.'
+                      : 'SKU is not in DISCORD_SKU_GAME_ADDON_IDS or legacy map. Verify in Developer Portal.'
+                )
                 .addFields(
                   { name: 'User ID', value: userId || 'unknown', inline: true },
-                  { name: 'Tier', value: tierName, inline: true },
+                  { name: 'Label', value: tierLabel, inline: true },
                   { name: 'SKU ID', value: skuId, inline: false },
                 )
                 .setFooter({ text: 'Made for Degens. By Degens.' })
@@ -268,31 +284,15 @@ export class EventHandler {
         console.error('[Payments] Failed to notify MOD_LOG:', err);
       }
 
-      // Primary role per SKU
-      const roleMap: Record<string, string> = {
-        [process.env.DISCORD_SKU_PRO_ID || '']:        process.env.DISCORD_ROLE_PRO_ID || '',
-        [process.env.DISCORD_SKU_ELITE_ID || '']:      process.env.DISCORD_ROLE_ELITE_ID || '',
-        [process.env.DISCORD_SKU_LIFETIME_ID || '']:   process.env.DISCORD_ROLE_LIFETIME_ID || '',
-        [process.env.DISCORD_SKU_OG_LIFETIME_ID || '']: process.env.DISCORD_ROLE_OG_LIFETIME_ID || '',
-      };
-
-      // OG Lifetime also grants beta tester role
-      const extraRoleMap: Record<string, string> = {
-        [process.env.DISCORD_SKU_OG_LIFETIME_ID || '']: process.env.DISCORD_ROLE_BETA_ID || '',
-      };
-
-      const roleId = roleMap[skuId];
-      if (roleId && userId) {
+      const gameAddonRoleId = (process.env.DISCORD_SKU_GAME_ADDON_ROLE_ID || '').trim();
+      if (userId && isConfiguredGameAddonSku(skuId) && gameAddonRoleId) {
         try {
           const guild = await this.client.guilds.fetch('1488253239643078787');
           const member = await guild.members.fetch(userId);
-          const rolesToAdd = [roleId];
-          const extraRole = extraRoleMap[skuId];
-          if (extraRole) rolesToAdd.push(extraRole);
-          await member.roles.add(rolesToAdd);
-          console.log(`[Payments] Auto-granted roles [${rolesToAdd.join(', ')}] to user ${userId}`);
+          await member.roles.add([gameAddonRoleId]);
+          console.log(`[Payments] Auto-granted game add-on role ${gameAddonRoleId} to user ${userId}`);
         } catch (err) {
-          console.error(`[Payments] Failed to auto-grant role for ${userId}:`, err);
+          console.error(`[Payments] Failed to auto-grant game add-on role for ${userId}:`, err);
         }
       }
     });

--- a/apps/discord-bot/tsconfig.json
+++ b/apps/discord-bot/tsconfig.json
@@ -19,7 +19,7 @@
       "path": "../../modules/dad"
     },
     {
-      "path": "../../packages/discord-activities"
+      "path": "../../packages/discord-monetization"
     },
     {
       "path": "../../packages/database"

--- a/apps/user-dashboard/public/premium.html
+++ b/apps/user-dashboard/public/premium.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-12 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>TiltCheck | Premium Tiers</title>
+  <title>TiltCheck | Monetization policy</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" />
   <link rel="stylesheet" href="/css/style.css" />
@@ -429,225 +429,28 @@
     <a href="/" class="header-logo">TILTCHECK</a>
     <nav class="header-nav">
       <a href="/dashboard">Dashboard</a>
-      <a href="/premium" aria-current="page" style="color:#22d3a6;">Premium</a>
+      <a href="/premium" aria-current="page" style="color:#22d3a6;">Billing</a>
     </nav>
   </header>
 
   <main class="page-main">
 
-    <h1 class="page-title">Upgrade Your Degen Status</h1>
+    <h1 class="page-title">Platform passes are retired</h1>
     <p class="page-subtitle">
-      No paywalls on safety features. Paying gives you more signal, more tools, and faster access.
-      Pick the tier that fits. No recurring bullshit unless you want it.
+      Degen / Platinum / Lifetime / SOL claim ladder for Discord roles is disabled (TIL-36).
+      TiltCheck only surfaces paid <strong>game add-ons</strong> (Discord Activity SKUs). Buy those inside the embedded Activity or via <code>/upgrade</code> in Discord when SKUs are configured.
     </p>
 
-    <!-- TIER CARDS -->
-    <div class="tier-grid">
-
-      <!-- Degen Pro -->
-      <div class="tier-card">
-        <div class="tier-name">Degen Pass</div>
-        <div class="tier-price">$4.99</div>
-        <div class="tier-price-sub">per month, recurring via Discord</div>
-        <span class="tier-sol">~0.05 SOL/mo via crypto</span>
-        <ul class="tier-perks">
-          <li>Unlimited scans, no daily cap</li>
-          <li>Full SusLink threat analysis</li>
-          <li>Casino trust scores (full detail)</li>
-          <li>Priority bot alerts and DMs</li>
-          <li>Degen Pass Discord role</li>
-        </ul>
-        <a id="btn-discord-pro" href="https://discord.com/application-directory/1445916179163250860/premium" target="_blank" rel="noopener" class="btn btn-discord">
-          Subscribe via Discord
-        </a>
-      </div>
-
-      <!-- Elite -->
-      <div class="tier-card featured">
-        <div class="tier-badge">MOST VALUE</div>
-        <div class="tier-name">Platinum Pass</div>
-        <div class="tier-price">$14.99</div>
-        <div class="tier-price-sub">per month, recurring via Discord</div>
-        <span class="tier-sol">~0.15 SOL/mo via crypto</span>
-        <ul class="tier-perks">
-          <li>Everything in Degen Pass</li>
-          <li>Full API access (rate-limited to fair use)</li>
-          <li>Custom nudge thresholds</li>
-          <li>Beta feature access</li>
-          <li>OG Discord role</li>
-          <li>Early access to new modules</li>
-        </ul>
-        <a id="btn-discord-elite" href="https://discord.com/application-directory/1445916179163250860/premium" target="_blank" rel="noopener" class="btn btn-discord">
-          Subscribe via Discord
-        </a>
-      </div>
-
-      <!-- Lifetime Pass -->
-      <div class="tier-card">
-        <div class="tier-name">Lifetime Pass</div>
-        <div class="tier-price">$199.99</div>
-        <div class="tier-price-sub">one-time payment</div>
-        <span class="tier-sol">~1 SOL one-time via crypto</span>
-        <ul class="tier-perks">
-          <li>Lifetime Pass forever, no renewals</li>
-          <li>Every current Platinum perk</li>
-          <li>Early access to all new modules</li>
-          <li>Lifetime Pass Discord role</li>
-          <li>Priority support queue</li>
-        </ul>
-        <a id="btn-discord-lifetime" href="https://discord.com/application-directory/1445916179163250860/premium" target="_blank" rel="noopener" class="btn btn-discord">
-          Purchase via Discord
-        </a>
-      </div>
-
-      <!-- OG Lifetime Pass (beta price) -->
-      <div class="tier-card" style="border-color: #f59e0b;">
-        <div class="tier-name" style="color: #f59e0b;">OG Lifetime Pass</div>
-        <div class="tier-price">$99.99</div>
-        <div class="tier-price-sub">beta tester price &mdash; one-time</div>
-        <span class="tier-sol">~0.65 SOL one-time via crypto</span>
-        <ul class="tier-perks">
-          <li>Everything in Lifetime Pass</li>
-          <li>Locked in at beta price forever</li>
-          <li>OG Lifetime Discord role</li>
-          <li>Beta tester credit in release notes</li>
-        </ul>
-        <a id="btn-discord-og-lifetime" href="https://discord.com/application-directory/1445916179163250860/premium" target="_blank" rel="noopener" class="btn btn-discord" style="background: #f59e0b; color: #000;">
-          Purchase via Discord
-        </a>
-      </div>
-
-      <!-- Support the Project -->
-      <div class="tier-card" style="border-color: #6b7280;">
-        <div class="tier-name" style="color: #9ca3af;">Support the Project</div>
-        <div class="tier-price">$9.99</div>
-        <div class="tier-price-sub">one-time &mdash; no perks</div>
-        <ul class="tier-perks">
-          <li>No tier. No role. No perks.</li>
-          <li>Just fuel for the team building this.</li>
-          <li>If TiltCheck saved you from a bad session, this is how you return the favor.</li>
-        </ul>
-        <a id="btn-discord-support" href="https://discord.com/application-directory/1445916179163250860/premium" target="_blank" rel="noopener" class="btn btn-discord" style="background: #374151; color: #d1d5db;">
-          Support via Discord
-        </a>
-      </div>
-
-    </div>
-
-    <hr class="divider" />
-
-    <!-- SOL PAYMENT SECTION -->
-    <div class="sol-section">
-      <div class="section-title">Pay with Solana (SOL)</div>
-      <p class="section-desc">
-        Prefer crypto? Send SOL directly to the wallet below.
-        After your transaction confirms, submit your tx hash in the form below.
-        Roles are granted manually within 24 hours after verification.
-        No automated confirmation on-chain -- do not send without submitting the claim form.
+    <div class="tier-card" style="max-width: 640px;">
+      <div class="tier-name">What still works</div>
+      <ul class="tier-perks">
+        <li>Discord game add-on purchases and entitlement webhooks</li>
+        <li>Optional role grant via <code>DISCORD_SKU_GAME_ADDON_ROLE_ID</code> when a purchase maps to Discord</li>
+        <li>JustTheTip fee waiver only when <code>DISCORD_SKU_JTT_FEE_WAIVER_IDS</code> matches a live entitlement (plus founders)</li>
+      </ul>
+      <p class="section-desc" style="margin-top: 1rem;">
+        This page intentionally does not collect SOL or tier claims for retired products.
       </p>
-
-      <div class="sol-layout">
-        <div class="sol-qr">
-          <img
-            src="https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=solana:BvzEqVRUicmW8Y6HFncLYrGXESpMbSNDkWUNTQj5GGGi"
-            alt="Solana payment QR code"
-            width="150"
-            height="150"
-          />
-        </div>
-
-        <div class="sol-details">
-          <div class="sol-address-label">Payment Wallet Address</div>
-          <div class="sol-address-row">
-            <code class="sol-address" id="sol-wallet-addr">BvzEqVRUicmW8Y6HFncLYrGXESpMbSNDkWUNTQj5GGGi</code>
-            <button class="btn-copy" id="copy-wallet-btn" onclick="copyWallet()">Copy</button>
-          </div>
-
-          <div class="sol-amounts">
-            <div class="sol-amount-row">
-              <span class="sol-amount-tier">Degen Pass (monthly)</span>
-              <span class="sol-amount-val">0.05 SOL</span>
-            </div>
-            <div class="sol-amount-row">
-              <span class="sol-amount-tier">Platinum Pass (monthly)</span>
-              <span class="sol-amount-val">0.15 SOL</span>
-            </div>
-            <div class="sol-amount-row">
-              <span class="sol-amount-tier">Lifetime Pass (one-time)</span>
-              <span class="sol-amount-val">1.00 SOL</span>
-            </div>
-            <div class="sol-amount-row" style="color: #f59e0b;">
-              <span class="sol-amount-tier">OG Lifetime Pass (beta price, one-time)</span>
-              <span class="sol-amount-val">0.65 SOL</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- CLAIM FORM -->
-    <div class="claim-section">
-      <div class="section-title">Claim Crypto Payment</div>
-      <p class="claim-note">
-        Paid via SOL? Fill this out. We verify the transaction on-chain and grant your role within 24 hours.
-        Make sure the tx hash is the confirmed Solana transaction ID from your wallet.
-        If the amount does not match the tier, it gets rejected. No partial payments.
-      </p>
-
-      <form id="claim-form" onsubmit="submitClaim(event)">
-        <div class="form-group">
-          <label class="form-label" for="discord-username">Discord Username</label>
-          <input
-            type="text"
-            id="discord-username"
-            class="form-input"
-            placeholder="yourname or yourname#0000"
-            required
-            autocomplete="off"
-          />
-        </div>
-
-        <div class="form-group">
-          <label class="form-label" for="tx-hash">Transaction Hash</label>
-          <input
-            type="text"
-            id="tx-hash"
-            class="form-input"
-            placeholder="Solana tx signature (88 characters)"
-            required
-            autocomplete="off"
-            style="font-family: 'JetBrains Mono', monospace; font-size: 0.8rem;"
-          />
-        </div>
-
-        <div class="form-group">
-          <label class="form-label" for="tier-select">Tier</label>
-          <select id="tier-select" class="form-select" required>
-            <option value="">Select tier</option>
-            <option value="degen-pass">Degen Pass (0.05 SOL/mo)</option>
-            <option value="platinum-pass">Platinum Pass (0.15 SOL/mo)</option>
-            <option value="lifetime-pass">Lifetime Pass (1.00 SOL)</option>
-            <option value="og-lifetime-pass">OG Lifetime Pass / Beta (0.65 SOL)</option>
-          </select>
-        </div>
-
-        <div class="form-group">
-          <label class="form-label" for="amount-sent">Amount Sent (SOL)</label>
-          <input
-            type="number"
-            id="amount-sent"
-            class="form-input"
-            placeholder="e.g. 0.05"
-            step="0.001"
-            min="0.001"
-            required
-          />
-        </div>
-
-        <button type="submit" class="btn btn-primary" id="claim-submit-btn">Submit Claim</button>
-      </form>
-
-      <div id="claim-result" class="claim-result"></div>
     </div>
 
   </main>
@@ -657,95 +460,7 @@
     <div class="footer-copy">© 2024–2026 TiltCheck Ecosystem. All Rights Reserved.</div>
   </footer>
 
-  <script>
-    // Load Discord client ID and update subscription links
-    (async function () {
-      try {
-        const res = await fetch('/api/config/public');
-        if (res.ok) {
-          const data = await res.json();
-          const clientId = data.client_id || data.clientId || '';
-          if (clientId) {
-            const premiumUrl = 'https://discord.com/application-directory/' + clientId + '/premium';
-            [
-              'btn-discord-pro',
-              'btn-discord-elite',
-              'btn-discord-lifetime',
-              'btn-discord-og-lifetime',
-              'btn-discord-support'
-            ].forEach(function (id) {
-              const link = document.getElementById(id);
-              if (link) link.href = premiumUrl;
-            });
-          }
-        }
-      } catch (_e) {
-        // Links stay at /PENDING path -- visible indicator to user
-      }
-    })();
-
-    function copyWallet() {
-      const addr = document.getElementById('sol-wallet-addr').textContent;
-      const btn = document.getElementById('copy-wallet-btn');
-      navigator.clipboard.writeText(addr).then(function () {
-        btn.textContent = 'Copied';
-        btn.classList.add('copied');
-        setTimeout(function () {
-          btn.textContent = 'Copy';
-          btn.classList.remove('copied');
-        }, 2000);
-      }).catch(function () {
-        btn.textContent = 'Failed';
-        setTimeout(function () { btn.textContent = 'Copy'; }, 2000);
-      });
-    }
-
-    async function submitClaim(event) {
-      event.preventDefault();
-      const btn = document.getElementById('claim-submit-btn');
-      const resultEl = document.getElementById('claim-result');
-      const discordUsername = document.getElementById('discord-username').value.trim();
-      const txHash = document.getElementById('tx-hash').value.trim();
-      const tier = document.getElementById('tier-select').value;
-      const amount = document.getElementById('amount-sent').value.trim();
-
-      if (!discordUsername || !txHash || !tier || !amount) {
-        resultEl.className = 'claim-result error';
-        resultEl.textContent = 'All fields required. Fill them out.';
-        return;
-      }
-
-      btn.disabled = true;
-      btn.textContent = 'Submitting...';
-      resultEl.className = 'claim-result';
-      resultEl.textContent = '';
-
-      try {
-        const res = await fetch('/api/payments/claim-crypto', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ discordUsername, txHash, tier, amount })
-        });
-
-        const data = await res.json();
-
-        if (res.ok && data.success) {
-          resultEl.className = 'claim-result success';
-          resultEl.textContent = data.message || 'Claim received. We will verify and grant your role within 24 hours.';
-          document.getElementById('claim-form').reset();
-        } else {
-          resultEl.className = 'claim-result error';
-          resultEl.textContent = data.error || 'Submission failed. Try again.';
-        }
-      } catch (_e) {
-        resultEl.className = 'claim-result error';
-        resultEl.textContent = 'Network error. Check your connection and try again.';
-      } finally {
-        btn.disabled = false;
-        btn.textContent = 'Submit Claim';
-      }
-    }
-  </script>
+  <script></script>
 
 </body>
 </html>

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 import PublicPageHero from "@/components/PublicPageHero";
 
 const sections = [
@@ -25,7 +25,7 @@ const sections = [
   {
     title: "05. Tips and payments",
     body:
-      "SOL tips sent through JustTheTip are final once confirmed on-chain. Premium subscriptions billed through Discord or SOL are final sale. Billing disputes should be raised within 48 hours.",
+      "SOL tips sent through JustTheTip are final once confirmed on-chain. Discord game add-on purchases are final once Discord confirms entitlement. Retired platform pass billing is not offered on current surfaces. Billing disputes should be raised within 48 hours.",
   },
   {
     title: "06. Prohibited uses",

--- a/docs/qa/TIL-36-monetization-policy-qa.md
+++ b/docs/qa/TIL-36-monetization-policy-qa.md
@@ -1,0 +1,37 @@
+© 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+
+# TIL-36 Monetization policy — QA checklist
+
+Quick pass after deploy. Goal: non-game-add-on charges are gone; game add-ons still clear Discord entitlements.
+
+## Discord bot
+
+- [ ] Run `/upgrade` with `DISCORD_SKU_GAME_ADDON_IDS` unset: reply explains retired passes and shows only app-directory link (no platform tier embed, no SOL instructions).
+- [ ] Run `/upgrade` with one or more real add-on SKU IDs set: Premium buttons appear (max five per row) and open Discord checkout for those SKUs only.
+- [ ] Trigger `EntitlementCreate` for a SKU listed in `DISCORD_SKU_GAME_ADDON_IDS`: mod log embed title is `GAME ADD-ON PURCHASE`; if `DISCORD_SKU_GAME_ADDON_ROLE_ID` is set, user receives that role.
+- [ ] Trigger `EntitlementCreate` for a legacy platform SKU (`DISCORD_SKU_PRO_ID` etc.): mod log shows `RETIRED PLATFORM SKU` and **no** auto-role grant.
+
+## API (JustTheTip fee display)
+
+- [ ] `GET /user/:discordId/elite` with founder username in `FOUNDER_USERNAMES`: `isElite` true, `feeSavedSol` computed from lamports.
+- [ ] Same route with `DISCORD_SKU_JTT_FEE_WAIVER_IDS` plus bot token + app id + mocked/live entitlement: `isElite` true when Discord returns an active unconsumed entitlement for one of those SKUs.
+- [ ] Same route for normal user with no SKUs configured and not founder: `isElite` false, `feeSavedSol` 0.
+- [ ] Confirm `subscriptions` table rows no longer flip `isElite` (legacy Stripe/DB path removed).
+
+## Dashboard
+
+- [ ] Open `/premium` on user-dashboard: shows retirement copy only; no tier cards, SOL QR, or claim form.
+
+## Activity overlay
+
+- [ ] Tip tab shows updated free-tier line (no “Upgrade to Elite” paywall CTA).
+
+## Docs / legal
+
+- [ ] Terms “Tips and payments” section matches current billing story (game add-ons only for paid Discord SKUs).
+
+## Rollback notes
+
+- Restore `subscriptions` lookup in `GET /user/:id/elite` and legacy role maps in `EntitlementCreate` if platform billing returns; revert `/upgrade` embeds from git history.
+
+Made for Degens. By Degens.

--- a/packages/discord-monetization/package.json
+++ b/packages/discord-monetization/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "vitest run"
+    "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
     "@tiltcheck/config": "workspace:*",
@@ -14,6 +14,7 @@
     "axios": "^1.15.0"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"
   }

--- a/packages/discord-monetization/src/index.ts
+++ b/packages/discord-monetization/src/index.ts
@@ -1,7 +1,18 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 /* Copyright (c) 2026 TiltCheck. All rights reserved. */
 
 import axios from 'axios';
 import { DISCORD_API_BASE, type DiscordEntitlement, type ShopConfig } from './types.js';
+
+export {
+  normalizeSkuEnv,
+  parseCommaSkuList,
+  getLegacyPlatformMonetizationSkuIds,
+  getConfiguredGameAddonSkuIds,
+  getJitFeeWaiverSkuIds,
+  isLegacyPlatformMonetizationSku,
+  isConfiguredGameAddonSku,
+} from './sku-policy.js';
 
 /**
  * Discord Monetization Manager

--- a/packages/discord-monetization/src/sku-policy.ts
+++ b/packages/discord-monetization/src/sku-policy.ts
@@ -1,0 +1,58 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+/**
+ * Central SKU env parsing for Discord monetization policy (TIL-36).
+ * Platform subscription SKUs are retired from sale/fulfillment hooks;
+ * game add-on SKUs remain configurable via DISCORD_SKU_GAME_ADDON_IDS.
+ */
+
+const REPLACE_SENTINEL = 'REPLACE_ME';
+
+export function normalizeSkuEnv(value: string | undefined): string | undefined {
+  const v = value?.trim();
+  if (!v || v === REPLACE_SENTINEL) return undefined;
+  return v;
+}
+
+export function parseCommaSkuList(raw: string | undefined): string[] {
+  if (!raw?.trim()) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && s !== REPLACE_SENTINEL);
+}
+
+/**
+ * Retired non-game-add-on SKUs (Degen/Platinum/Lifetime/Support style).
+ * Used to suppress auto-role fulfillment while still logging purchases.
+ */
+export function getLegacyPlatformMonetizationSkuIds(): string[] {
+  const singles = [
+    normalizeSkuEnv(process.env.DISCORD_SKU_PRO_ID),
+    normalizeSkuEnv(process.env.DISCORD_SKU_ELITE_ID),
+    normalizeSkuEnv(process.env.DISCORD_SKU_LIFETIME_ID),
+    normalizeSkuEnv(process.env.DISCORD_SKU_OG_LIFETIME_ID),
+    normalizeSkuEnv(process.env.DISCORD_SKU_SUPPORT_ID),
+  ].filter((v): v is string => Boolean(v));
+  return [...new Set(singles)];
+}
+
+/** Game add-on SKU IDs (comma-separated) — sole SKUs exposed via /upgrade. */
+export function getConfiguredGameAddonSkuIds(): string[] {
+  return [...new Set(parseCommaSkuList(process.env.DISCORD_SKU_GAME_ADDON_IDS))];
+}
+
+/**
+ * SKUs that grant JustTheTip protocol fee waiver (checked via Discord entitlements API).
+ * Must be set explicitly; do not implicitly reuse game add-on IDs.
+ */
+export function getJitFeeWaiverSkuIds(): string[] {
+  return [...new Set(parseCommaSkuList(process.env.DISCORD_SKU_JTT_FEE_WAIVER_IDS))];
+}
+
+export function isLegacyPlatformMonetizationSku(skuId: string): boolean {
+  return getLegacyPlatformMonetizationSkuIds().includes(skuId);
+}
+
+export function isConfiguredGameAddonSku(skuId: string): boolean {
+  return getConfiguredGameAddonSkuIds().includes(skuId);
+}

--- a/packages/discord-monetization/tests/sku-policy.test.ts
+++ b/packages/discord-monetization/tests/sku-policy.test.ts
@@ -1,0 +1,40 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getConfiguredGameAddonSkuIds,
+  getJitFeeWaiverSkuIds,
+  getLegacyPlatformMonetizationSkuIds,
+  isConfiguredGameAddonSku,
+  isLegacyPlatformMonetizationSku,
+  parseCommaSkuList,
+} from '../src/sku-policy.js';
+
+describe('sku-policy', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('parses comma SKU lists and drops REPLACE_ME', () => {
+    expect(parseCommaSkuList('a, b ,c')).toEqual(['a', 'b', 'c']);
+    expect(parseCommaSkuList('x,REPLACE_ME,y')).toEqual(['x', 'y']);
+  });
+
+  it('classifies legacy vs game add-on SKUs from env', () => {
+    vi.stubEnv('DISCORD_SKU_PRO_ID', 'pro-1');
+    vi.stubEnv('DISCORD_SKU_ELITE_ID', 'REPLACE_ME');
+    vi.stubEnv('DISCORD_SKU_GAME_ADDON_IDS', 'game-a,game-b');
+
+    expect(getLegacyPlatformMonetizationSkuIds()).toEqual(['pro-1']);
+    expect(getConfiguredGameAddonSkuIds()).toEqual(['game-a', 'game-b']);
+    expect(isLegacyPlatformMonetizationSku('pro-1')).toBe(true);
+    expect(isConfiguredGameAddonSku('game-a')).toBe(true);
+    expect(isLegacyPlatformMonetizationSku('game-a')).toBe(false);
+  });
+
+  it('exposes JTT fee waiver SKUs independently', () => {
+    vi.stubEnv('DISCORD_SKU_JTT_FEE_WAIVER_IDS', 'fee-1,fee-2');
+    vi.stubEnv('DISCORD_SKU_GAME_ADDON_IDS', 'game-only');
+
+    expect(getJitFeeWaiverSkuIds()).toEqual(['fee-1', 'fee-2']);
+  });
+});

--- a/packages/discord-monetization/tsconfig.json
+++ b/packages/discord-monetization/tsconfig.json
@@ -7,5 +7,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/packages/discord-monetization/vitest.config.ts
+++ b/packages/discord-monetization/vitest.config.ts
@@ -1,0 +1,9 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       '@tiltcheck/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@tiltcheck/discord-monetization':
+        specifier: workspace:*
+        version: link:../../packages/discord-monetization
       '@tiltcheck/error-factory':
         specifier: workspace:*
         version: link:../../packages/error-factory
@@ -475,6 +478,9 @@ importers:
       '@tiltcheck/discord-activities':
         specifier: workspace:*
         version: link:../../packages/discord-activities
+      '@tiltcheck/discord-monetization':
+        specifier: workspace:*
+        version: link:../../packages/discord-monetization
       '@tiltcheck/discord-utils':
         specifier: workspace:*
         version: link:../../packages/discord-utils
@@ -1439,6 +1445,9 @@ importers:
         specifier: '>=1.15.0'
         version: 1.15.0
     devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.6.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -20262,7 +20271,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
 
   '@types/bs58@5.0.0':
     dependencies:
@@ -20401,7 +20410,7 @@ snapshots:
 
   '@types/jsdom@28.0.1':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
       undici-types: 7.24.6
@@ -20539,7 +20548,7 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
 
   '@types/serve-static@1.15.10':
     dependencies:
@@ -20550,7 +20559,7 @@ snapshots:
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
 
   '@types/shimmer@1.2.0': {}
 
@@ -20560,7 +20569,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
       form-data: 4.0.5
 
   '@types/supertest@7.2.0':
@@ -22399,7 +22408,7 @@ snapshots:
 
   chrome-launcher@1.2.1:
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
@@ -28123,7 +28132,7 @@ snapshots:
 
   speedline-core@1.4.3:
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
       image-ssim: 0.2.0
       jpeg-js: 0.4.4
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

TIL-36: enforce monetization policy — disable non-game-add-on paywalls while keeping Discord **game add-on** purchases and entitlement plumbing working.

## Approach

- Added `packages/discord-monetization/src/sku-policy.ts` and exports for env-driven SKU lists (`DISCORD_SKU_GAME_ADDON_IDS`, legacy platform IDs, `DISCORD_SKU_JTT_FEE_WAIVER_IDS`).
- **`/upgrade` (discord-bot):** only Premium buttons for game add-on SKUs; copy explains retired platform passes; no SOL ladder.
- **`EntitlementCreate`:** mod-log labels by policy; auto-role only for configured game add-ons via optional `DISCORD_SKU_GAME_ADDON_ROLE_ID`; legacy platform SKUs log only (no auto-role).
- **`GET /user/:id/elite` (api):** removed `subscriptions` table path; fee waiver = founders OR live Discord entitlements for `DISCORD_SKU_JTT_FEE_WAIVER_IDS` when bot token + application id are set.
- **Dashboard `premium.html`:** removed tier cards, SOL QR, and claim form — policy notice only.
- **Activity TipView + web terms:** copy aligned with new billing story.
- **Docs:** `docs/qa/TIL-36-monetization-policy-qa.md` checklist.
- **`.env.example`:** documents new variables.

## Risk / rollback

- **Discord:** If legacy platform SKUs still exist in the Developer Portal, renewals will no longer auto-grant Discord roles — ops can grant manually or re-enable the old `roleMap` block from git history.
- **API:** Users who only had `subscriptions`-row elite lose fee waiver until `DISCORD_SKU_JTT_FEE_WAIVER_IDS` matches their Discord add-on entitlement (or they are founders). Rollback: restore `findOneBy` subscription check in `user.ts`.
- **External calls:** `GET /.../elite` may call Discord entitlements when env is fully set; failures return empty entitlements (safe default: no waiver).

## Validation

- `pnpm exec vitest --run apps/api/tests/routes/user-routes.test.ts` (includes new elite cases).
- `pnpm --filter @tiltcheck/discord-monetization test`
- `pnpm --filter @tiltcheck/api build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TIL-36](https://linear.app/tiltcheck/issue/TIL-36/monetization-disable-non-game-add-on-monetization-preserve-add-ons)

<div><a href="https://cursor.com/agents/bc-a85043af-0539-4c18-9d62-43989d0cba49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a85043af-0539-4c18-9d62-43989d0cba49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

