### PR TITLE
Wallet lock: paid early unlock fee splits (trivia + microgrant + dev log)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-28
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 # ==============================================
 # TILTCHECK MONOREPO - MASTER ENVIRONMENT CONFIG (TEMPLATE)
 # ==============================================
@@ -79,6 +79,12 @@ VAULT_ENCRYPTION_KEY=REPLACE_ME_WITH_32_BYTE_HEX_KEY
 LOCKVAULT_ALLOW_PLAINTEXT=false
 LOCKVAULT_STORE_PATH=./data/lockvault
 LOCKVAULT_WITHDRAWAL_EXECUTION_TIMEOUT_MS=30000
+
+# Paid wallet-lock early unlock: fee % of vault ledger (lockedAmountSOL); remainder split trivia vs microgrant; dev % logged plus optional SOL destination.
+WALLET_EARLY_UNLOCK_FEE_PERCENT=10
+WALLET_EARLY_UNLOCK_DEV_PERCENT_OF_BALANCE=2
+WALLET_EARLY_UNLOCK_TRIVIA_SHARE_OF_REMAINDER=0.5
+EARLY_UNLOCK_DEV_SOL_ADDRESS=REPLACE_ME
 
 # --- SUPABASE ---
 SUPABASE_URL=REPLACE_ME

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ wrangler.toml.local
 data/casino-trust.json
 data/domain-trust-scores.json
 data/lockvault.json
+data/lockvault-store.json
 data/justthetip-wallets.json
 age.agekey
 data/sessions.json

--- a/apps/api/src/routes/trivia.ts
+++ b/apps/api/src/routes/trivia.ts
@@ -1,93 +1,27 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 /**
- * Trivia Jackpot Pool — persistent tracking of the Live Trivia prize pool.
- * Tracks contributions from /rain, /triviadrop, and direct Solana Pay deposits.
- * Serves the current pool balance to the degens-activity jackpot view.
+ * Trivia Jackpot Pool — HTTP surface for the Live Trivia prize pool.
+ * Persistence lives in services/community-pools.ts (shared with wallet-lock fee routing).
  */
 
 import { Router } from 'express';
-import { db } from '@tiltcheck/database';
+import {
+  getTriviaJackpotSnapshot,
+  contributeTriviaJackpot,
+  recordTriviaJackpotPayout,
+  resetTriviaJackpotPool,
+  getMicrograntPoolSnapshot,
+} from '../services/community-pools.js';
 
 const router = Router();
 
-// ── In-memory pool with DB persistence ─────────────────────────────────────────
-
-interface JackpotPool {
-  balance: number;       // SOL
-  contributions: number; // total count
-  lastWinner: string | null;
-  lastPayout: number;
-  updatedAt: number;
-}
-
-let pool: JackpotPool = {
-  balance: 0,
-  contributions: 0,
-  lastWinner: null,
-  lastPayout: 0,
-  updatedAt: Date.now(),
-};
-
-const TABLE = 'trivia_jackpot';
-
-async function loadPool(): Promise<void> {
-  try {
-    const client = db.getClient();
-    if (!client) {
-      return;
-    }
-
-    const { data } = await client.from(TABLE).select('*').order('updated_at', { ascending: false }).limit(1).single();
-    if (data) {
-      pool = {
-        balance: data.balance ?? 0,
-        contributions: data.contributions ?? 0,
-        lastWinner: data.last_winner ?? null,
-        lastPayout: data.last_payout ?? 0,
-        updatedAt: new Date(data.updated_at).getTime(),
-      };
-    }
-  } catch {
-    // Table may not exist yet — use in-memory defaults
-  }
-}
-
-async function savePool(): Promise<void> {
-  try {
-    const client = db.getClient();
-    if (!client) {
-      return;
-    }
-
-    await client.from(TABLE).upsert({
-      id: 'main',
-      balance: pool.balance,
-      contributions: pool.contributions,
-      last_winner: pool.lastWinner,
-      last_payout: pool.lastPayout,
-      updated_at: new Date().toISOString(),
-    }, { onConflict: 'id' });
-  } catch (err) {
-    console.error('[trivia] Failed to persist jackpot pool:', err);
-  }
-}
-
-// Load on startup
-loadPool().catch(() => {});
-
-// ── GET /trivia/jackpot — current pool state ───────────────────────────────────
-
 router.get('/jackpot', (_req, res) => {
-  res.json({
-    pool: pool.balance,
-    contributions: pool.contributions,
-    lastWinner: pool.lastWinner,
-    lastPayout: pool.lastPayout,
-    updatedAt: pool.updatedAt,
-  });
+  res.json(getTriviaJackpotSnapshot());
 });
 
-// ── POST /trivia/jackpot/contribute — add to the pool ──────────────────────────
+router.get('/microgrant-pool', (_req, res) => {
+  res.json(getMicrograntPoolSnapshot());
+});
 
 router.post('/jackpot/contribute', async (req, res) => {
   const { amountSol, source, signature } = req.body;
@@ -97,18 +31,11 @@ router.post('/jackpot/contribute', async (req, res) => {
     return;
   }
 
-  pool.balance += amountSol;
-  pool.contributions += 1;
-  pool.updatedAt = Date.now();
+  await contributeTriviaJackpot(amountSol, source, signature);
 
-  await savePool();
-
-  console.log(`[trivia] Jackpot contribution: +${amountSol} SOL from ${source || 'unknown'} (sig: ${signature || 'none'})`);
-
-  res.json({ pool: pool.balance, contributions: pool.contributions });
+  const snap = getTriviaJackpotSnapshot();
+  res.json({ pool: snap.pool, contributions: snap.contributions });
 });
-
-// ── POST /trivia/jackpot/payout — record a winner payout ───────────────────────
 
 router.post('/jackpot/payout', async (req, res) => {
   const { winner, amountSol } = req.body;
@@ -118,27 +45,14 @@ router.post('/jackpot/payout', async (req, res) => {
     return;
   }
 
-  pool.lastWinner = winner;
-  pool.lastPayout = amountSol;
-  pool.balance = Math.max(0, pool.balance - amountSol);
-  pool.updatedAt = Date.now();
+  await recordTriviaJackpotPayout(winner, amountSol);
 
-  await savePool();
-
-  console.log(`[trivia] Jackpot payout: ${amountSol} SOL to ${winner}`);
-
-  res.json({ pool: pool.balance, lastWinner: pool.lastWinner, lastPayout: pool.lastPayout });
+  const snap = getTriviaJackpotSnapshot();
+  res.json({ pool: snap.pool, lastWinner: snap.lastWinner, lastPayout: snap.lastPayout });
 });
 
-// ── POST /trivia/jackpot/reset — admin reset ───────────────────────────────────
-
 router.post('/jackpot/reset', async (_req, res) => {
-  pool.balance = 0;
-  pool.contributions = 0;
-  pool.updatedAt = Date.now();
-
-  await savePool();
-
+  await resetTriviaJackpotPool();
   res.json({ pool: 0, message: 'Jackpot pool reset' });
 });
 

--- a/apps/api/src/routes/vault.ts
+++ b/apps/api/src/routes/vault.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 /**
  * Vault Routes - /vault/*
  * Handles general vault balance and timed locks.
@@ -26,8 +26,14 @@ import {
   approveWithdrawal,
   executeWithdrawal
 } from '@tiltcheck/lockvault';
+import { creditEarlyUnlockFeeSplits } from '../services/community-pools.js';
 
 const router: Router = Router();
+
+function earlyUnlockFeePercent(): number {
+  const n = Number(process.env.WALLET_EARLY_UNLOCK_FEE_PERCENT);
+  return Number.isFinite(n) && n > 0 && n <= 100 ? n : 10;
+}
 
 interface VaultError extends Error {
   code?: string;
@@ -448,7 +454,7 @@ router.post('/:userId/wallet-unlock', authMiddleware, async (req, res) => {
       remainingMs: status.remainingMs,
       reason: status.reason || null,
       earlyUnlockRequest: status.earlyUnlockRequest || null,
-      unlockOptions: ['admin_approval'],
+      unlockOptions: ['admin_approval', 'paid_early_unlock'],
     });
     return;
   }
@@ -476,18 +482,25 @@ router.post('/:userId/wallet-unlock-request', authMiddleware, async (req, res) =
     return;
   }
   if (mode === 'paid_early_unlock') {
-    res.status(501).json({
-      error: 'Paid early wallet unlock is temporarily disabled until fee routing is implemented.',
-      code: 'FEATURE_NOT_IMPLEMENTED',
-    });
+    try {
+      const actorId = (auth as any)?.discordId || auth?.id || userId;
+      const record = requestPaidWalletUnlockForUser(userId, actorId, earlyUnlockFeePercent());
+      res.json({
+        success: true,
+        locked: true,
+        lockUntil: new Date(record.lockUntil).toISOString(),
+        earlyUnlockRequest: record.earlyUnlockRequest || null,
+      });
+    } catch (error) {
+      const handled = handleVaultError(error);
+      res.status(handled.status).json(handled.body);
+    }
     return;
   }
 
   try {
     const actorId = (auth as any)?.discordId || auth?.id || userId;
-    const record = mode === 'admin_approval'
-      ? requestAdminWalletUnlockForUser(userId, actorId)
-      : requestPaidWalletUnlockForUser(userId, actorId, 10);
+    const record = requestAdminWalletUnlockForUser(userId, actorId);
 
     res.json({
       success: true,
@@ -530,7 +543,7 @@ router.post('/:userId/wallet-unlock-approve', authMiddleware, async (req, res) =
 
 /**
  * POST /vault/:userId/wallet-unlock-pay
- * Pays the 10% early unlock fee from the user's latest active locked vault
+ * Credits trivia jackpot ledger + microgrant pool + structured dev skim log (non-custodial).
  */
 router.post('/:userId/wallet-unlock-pay', authMiddleware, async (req, res) => {
   const userId = param(req, 'userId');
@@ -544,11 +557,28 @@ router.post('/:userId/wallet-unlock-pay', authMiddleware, async (req, res) => {
   const paidBy = (auth as any)?.discordId || auth?.id || userId;
   try {
     const record = settlePaidWalletUnlockForUser(userId, paidBy);
+    const alloc = record.earlyUnlockRequest?.feeAllocationSOL;
+    let feeRouted = true;
+    if (alloc && (alloc.triviaSOL > 0 || alloc.micrograntSOL > 0 || alloc.devSOL > 0)) {
+      try {
+        await creditEarlyUnlockFeeSplits({
+          userId,
+          triviaSOL: alloc.triviaSOL,
+          micrograntSOL: alloc.micrograntSOL,
+          devSOL: alloc.devSOL,
+        });
+      } catch (poolErr) {
+        feeRouted = false;
+        console.error('[vault] Early unlock pool credit failed after vault debit; reconcile manually:', poolErr);
+      }
+    }
     res.json({
       success: true,
       locked: false,
       earlyUnlockRequest: record.earlyUnlockRequest || null,
       feeChargedSOL: record.earlyUnlockRequest?.feeAmountSOL ?? null,
+      feeAllocationSOL: alloc ?? null,
+      feeRouted,
     });
   } catch (error) {
     const handled = handleVaultError(error);

--- a/apps/api/src/services/community-pools.ts
+++ b/apps/api/src/services/community-pools.ts
@@ -1,0 +1,201 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+/**
+ * Ledger-backed community pools (trivia jackpot, recovery microgrant fund).
+ * LockVault early-unlock fees credit trivia + microgrant balances here; dev skim is logged for treasury reconciliation (non-custodial — no auto-transfer yet).
+ */
+
+import { db } from '@tiltcheck/database';
+
+interface TriviaJackpotPool {
+  balance: number;
+  contributions: number;
+  lastWinner: string | null;
+  lastPayout: number;
+  updatedAt: number;
+}
+
+interface MicrograntPool {
+  balance: number;
+  contributions: number;
+  updatedAt: number;
+}
+
+let triviaPool: TriviaJackpotPool = {
+  balance: 0,
+  contributions: 0,
+  lastWinner: null,
+  lastPayout: 0,
+  updatedAt: Date.now(),
+};
+
+let micrograntPool: MicrograntPool = {
+  balance: 0,
+  contributions: 0,
+  updatedAt: Date.now(),
+};
+
+const TRIVIA_TABLE = 'trivia_jackpot';
+const MICROGRANT_TABLE = 'microgrant_pool';
+
+async function loadTriviaPool(): Promise<void> {
+  try {
+    const client = db.getClient();
+    if (!client) return;
+
+    const { data } = await client.from(TRIVIA_TABLE).select('*').order('updated_at', { ascending: false }).limit(1).single();
+    if (data) {
+      triviaPool = {
+        balance: data.balance ?? 0,
+        contributions: data.contributions ?? 0,
+        lastWinner: data.last_winner ?? null,
+        lastPayout: data.last_payout ?? 0,
+        updatedAt: new Date(data.updated_at).getTime(),
+      };
+    }
+  } catch {
+    // Table may not exist yet
+  }
+}
+
+async function saveTriviaPool(): Promise<void> {
+  try {
+    const client = db.getClient();
+    if (!client) return;
+
+    await client.from(TRIVIA_TABLE).upsert(
+      {
+        id: 'main',
+        balance: triviaPool.balance,
+        contributions: triviaPool.contributions,
+        last_winner: triviaPool.lastWinner,
+        last_payout: triviaPool.lastPayout,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' },
+    );
+  } catch (err) {
+    console.error('[community-pools] Failed to persist trivia jackpot:', err);
+  }
+}
+
+async function loadMicrograntPool(): Promise<void> {
+  try {
+    const client = db.getClient();
+    if (!client) return;
+
+    const { data } = await client.from(MICROGRANT_TABLE).select('*').order('updated_at', { ascending: false }).limit(1).single();
+    if (data) {
+      micrograntPool = {
+        balance: data.balance ?? 0,
+        contributions: data.contributions ?? 0,
+        updatedAt: new Date(data.updated_at).getTime(),
+      };
+    }
+  } catch {
+    // Table may not exist yet
+  }
+}
+
+async function saveMicrograntPool(): Promise<void> {
+  try {
+    const client = db.getClient();
+    if (!client) return;
+
+    await client.from(MICROGRANT_TABLE).upsert(
+      {
+        id: 'main',
+        balance: micrograntPool.balance,
+        contributions: micrograntPool.contributions,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' },
+    );
+  } catch (err) {
+    console.error('[community-pools] Failed to persist microgrant pool:', err);
+  }
+}
+
+void Promise.all([loadTriviaPool(), loadMicrograntPool()]).catch(() => {});
+
+export function getTriviaJackpotSnapshot() {
+  return {
+    pool: triviaPool.balance,
+    contributions: triviaPool.contributions,
+    lastWinner: triviaPool.lastWinner,
+    lastPayout: triviaPool.lastPayout,
+    updatedAt: triviaPool.updatedAt,
+  };
+}
+
+export function getMicrograntPoolSnapshot() {
+  return {
+    pool: micrograntPool.balance,
+    contributions: micrograntPool.contributions,
+    updatedAt: micrograntPool.updatedAt,
+  };
+}
+
+export async function contributeTriviaJackpot(amountSol: number, source?: string, signature?: string): Promise<void> {
+  if (typeof amountSol !== 'number' || amountSol <= 0) return;
+  triviaPool.balance += amountSol;
+  triviaPool.contributions += 1;
+  triviaPool.updatedAt = Date.now();
+  await saveTriviaPool();
+  console.log(`[community-pools] Trivia jackpot: +${amountSol} SOL from ${source || 'unknown'} (sig: ${signature || 'none'})`);
+}
+
+export async function recordTriviaJackpotPayout(winner: string, amountSol: number): Promise<void> {
+  triviaPool.lastWinner = winner;
+  triviaPool.lastPayout = amountSol;
+  triviaPool.balance = Math.max(0, triviaPool.balance - amountSol);
+  triviaPool.updatedAt = Date.now();
+  await saveTriviaPool();
+  console.log(`[community-pools] Trivia jackpot payout: ${amountSol} SOL to ${winner}`);
+}
+
+export async function resetTriviaJackpotPool(): Promise<void> {
+  triviaPool.balance = 0;
+  triviaPool.contributions = 0;
+  triviaPool.updatedAt = Date.now();
+  await saveTriviaPool();
+}
+
+export async function contributeMicrograntPool(amountSol: number, source: string, meta?: Record<string, unknown>): Promise<void> {
+  if (typeof amountSol !== 'number' || amountSol <= 0) return;
+  micrograntPool.balance += amountSol;
+  micrograntPool.contributions += 1;
+  micrograntPool.updatedAt = Date.now();
+  await saveMicrograntPool();
+  console.log(`[community-pools] Microgrant pool: +${amountSol} SOL from ${source}${meta ? ` ${JSON.stringify(meta)}` : ''}`);
+}
+
+/**
+ * Applies LockVault early-unlock fee splits to trivia + microgrant ledgers.
+ * Dev allocation is structured-log only until an automated sweep exists (risk: no secret wallet handling in API).
+ */
+export async function creditEarlyUnlockFeeSplits(params: {
+  userId: string;
+  triviaSOL: number;
+  micrograntSOL: number;
+  devSOL: number;
+}): Promise<void> {
+  const { userId, triviaSOL, micrograntSOL, devSOL } = params;
+  const meta = { userId, route: 'wallet_early_unlock' };
+
+  await Promise.all([
+    triviaSOL > 0 ? contributeTriviaJackpot(triviaSOL, `wallet_early_unlock:${userId}`) : Promise.resolve(),
+    micrograntSOL > 0 ? contributeMicrograntPool(micrograntSOL, 'wallet_early_unlock', meta) : Promise.resolve(),
+  ]);
+
+  if (devSOL > 0) {
+    const dest = process.env.EARLY_UNLOCK_DEV_SOL_ADDRESS?.trim() || '';
+    console.log(
+      JSON.stringify({
+        event: 'early_unlock_dev_allocation',
+        sol: devSOL,
+        userId,
+        intendedDestinationSol: dest || 'UNCONFIGURED',
+      }),
+    );
+  }
+}

--- a/apps/api/tests/routes/vault.test.ts
+++ b/apps/api/tests/routes/vault.test.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
@@ -35,6 +35,14 @@ const lockvaultMock = vi.hoisted(() => ({
   executeWithdrawal: vi.fn(),
 }));
 
+const poolsMock = vi.hoisted(() => ({
+  creditEarlyUnlockFeeSplits: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/services/community-pools.js', () => ({
+  creditEarlyUnlockFeeSplits: poolsMock.creditEarlyUnlockFeeSplits,
+}));
+
 vi.mock('@tiltcheck/lockvault', () => lockvaultMock);
 
 import { vaultRouter } from '../../src/routes/vault.js';
@@ -53,6 +61,7 @@ app.use('/vault', vaultRouter);
 describe('Vault Routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    poolsMock.creditEarlyUnlockFeeSplits.mockClear();
     mockUserId = 'user-1';
     mockRoles = ['user'];
     lockvaultMock.getVaultBalance.mockReturnValue(0);
@@ -97,6 +106,32 @@ describe('Vault Routes', () => {
       approvalThreshold: 2,
     });
     lockvaultMock.addSecondOwner.mockResolvedValue({ id: 'v1', secondOwnerId: 'user-2' });
+    lockvaultMock.requestPaidWalletUnlockForUser.mockReturnValue({
+      userId: 'user-1',
+      lockUntil: Date.now() + 30 * 60_000,
+      createdAt: Date.now(),
+      earlyUnlockRequest: {
+        mode: 'paid_early_unlock',
+        status: 'pending',
+        feePercentage: 10,
+        feeAmountSOL: 0.15,
+      },
+    });
+    lockvaultMock.settlePaidWalletUnlockForUser.mockReturnValue({
+      userId: 'user-1',
+      lockUntil: Date.now() + 30 * 60_000,
+      createdAt: Date.now(),
+      earlyUnlockRequest: {
+        mode: 'paid_early_unlock',
+        status: 'completed',
+        feeAmountSOL: 0.15,
+        feeAllocationSOL: {
+          triviaSOL: 0.06,
+          micrograntSOL: 0.06,
+          devSOL: 0.03,
+        },
+      },
+    });
     lockvaultMock.getWithdrawalApprovalsForUser.mockReturnValue([]);
     lockvaultMock.initiateWithdrawal.mockResolvedValue({
       id: 'v1',
@@ -347,19 +382,19 @@ describe('Vault Routes', () => {
     const clearRes = await request(app).post('/vault/user-1/wallet-unlock').send({});
     expect(clearRes.status).toBe(423);
     expect(clearRes.body.code).toBe('WALLET_LOCK_STILL_ACTIVE');
-    expect(clearRes.body.unlockOptions).toEqual(['admin_approval']);
+    expect(clearRes.body.unlockOptions).toEqual(['admin_approval', 'paid_early_unlock']);
     expect(lockvaultMock.clearWalletActionLockForUser).not.toHaveBeenCalled();
   });
 
-  it('creates admin early unlock requests and rejects paid unlock requests', async () => {
+  it('creates admin early unlock requests and accepts paid unlock quotes', async () => {
     const adminReq = await request(app).post('/vault/user-1/wallet-unlock-request').send({ mode: 'admin_approval' });
     expect(adminReq.status).toBe(200);
     expect(lockvaultMock.requestAdminWalletUnlockForUser).toHaveBeenCalledWith('user-1', 'user-1');
 
     const paidReq = await request(app).post('/vault/user-1/wallet-unlock-request').send({ mode: 'paid_early_unlock' });
-    expect(paidReq.status).toBe(501);
-    expect(paidReq.body.code).toBe('FEATURE_NOT_IMPLEMENTED');
-    expect(lockvaultMock.requestPaidWalletUnlockForUser).not.toHaveBeenCalled();
+    expect(paidReq.status).toBe(200);
+    expect(lockvaultMock.requestPaidWalletUnlockForUser).toHaveBeenCalled();
+    expect(lockvaultMock.requestPaidWalletUnlockForUser.mock.calls[0][2]).toBe(10);
   });
 
   it('requires admin role to approve early unlock', async () => {
@@ -372,7 +407,25 @@ describe('Vault Routes', () => {
     expect(lockvaultMock.approveAdminWalletUnlockForUser).toHaveBeenCalledWith('user-1', 'user-1');
   });
 
-  it('rejects paid early unlock settlement while the fee sink is disabled', async () => {
+  it('settles paid early unlock and credits community pools', async () => {
+    const res = await request(app).post('/vault/user-1/wallet-unlock-pay').send({});
+    expect(res.status).toBe(200);
+    expect(res.body.feeRouted).toBe(true);
+    expect(lockvaultMock.settlePaidWalletUnlockForUser).toHaveBeenCalledWith('user-1', 'user-1');
+    expect(res.body.feeAllocationSOL).toEqual({
+      triviaSOL: 0.06,
+      micrograntSOL: 0.06,
+      devSOL: 0.03,
+    });
+    expect(poolsMock.creditEarlyUnlockFeeSplits).toHaveBeenCalledWith({
+      userId: 'user-1',
+      triviaSOL: 0.06,
+      micrograntSOL: 0.06,
+      devSOL: 0.03,
+    });
+  });
+
+  it('returns 501 when settle paid unlock throws feature-not-implemented', async () => {
     const err = createVaultError('disabled', 'FEATURE_NOT_IMPLEMENTED', 501);
     lockvaultMock.settlePaidWalletUnlockForUser.mockImplementationOnce(() => {
       throw err;

--- a/apps/user-dashboard/public/index.html
+++ b/apps/user-dashboard/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-23 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 -->
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -590,10 +590,17 @@
                     placeholder="Optional note for why this lock exists"
                   />
                 </div>
+                <p class="section-desc section-desc-inline" style="font-size: 0.75rem; opacity: 0.85">
+                  Paid early unlock charges about <strong>10%</strong> of your LockVault ledger balance from your newest active lock.
+                  Split: next trivia pot plus recovery microgrant pool, plus <strong>2%</strong> dev skim (ledger log until treasury sweep exists).
+                </p>
                 <div class="inline-action-row">
                   <button id="save-wallet-lock-btn" class="btn btn-primary">Set Wallet Lock</button>
                   <button id="request-wallet-unlock-btn" class="btn btn-ghost">
                     Request Early Unlock
+                  </button>
+                  <button id="pay-wallet-unlock-btn" class="btn btn-secondary">
+                    Pay Early Unlock Fee
                   </button>
                 </div>
                 <div id="walletLockStatusMsg" class="form-msg"></div>

--- a/apps/user-dashboard/public/js/app.js
+++ b/apps/user-dashboard/public/js/app.js
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 
 'use strict';
 
@@ -824,6 +824,7 @@ function setupSafetyPanel() {
     document.getElementById('save-exclusion-btn')?.addEventListener('click', saveExclusion);
     document.getElementById('save-wallet-lock-btn')?.addEventListener('click', saveWalletLock);
     document.getElementById('request-wallet-unlock-btn')?.addEventListener('click', requestWalletUnlock);
+    document.getElementById('pay-wallet-unlock-btn')?.addEventListener('click', paidEarlyWalletUnlock);
     document.getElementById('vault-rule-type')?.addEventListener('change', (event) => {
         renderVaultRuleFieldGroups(event.target.value);
     });
@@ -1109,6 +1110,59 @@ async function requestWalletUnlock() {
     } catch (err) {
         console.error('[Wallet Unlock Request]', err);
         setFormMessage('walletLockStatusMsg', 'Failed to request early unlock.', true);
+    }
+}
+
+async function paidEarlyWalletUnlock() {
+    if (!walletLockState.locked) return;
+
+    const confirmed = window.confirm(
+        'Pay roughly 10% of your LockVault ledger balance to drop the Wallet Lock early? ' +
+            'That fee splits across the trivia jackpot ledger, the recovery microgrant pool, and a 2% dev skim (logged - no auto chain sweep).'
+    );
+    if (!confirmed) return;
+
+    setFormMessage('walletLockStatusMsg', 'Quoting paid unlock...');
+    try {
+        const quoteRes = await apiRequest(`/api/user/${currentUser.discordId}/wallet-unlock-request`, {
+            method: 'POST',
+            body: JSON.stringify({ mode: 'paid_early_unlock' }),
+        });
+        const quoteData = await quoteRes.json().catch(() => ({}));
+        if (!quoteRes.ok) {
+            setFormMessage('walletLockStatusMsg', quoteData.error || 'Paid unlock quote failed.', true);
+            return;
+        }
+
+        const fee = quoteData.earlyUnlockRequest?.feeAmountSOL;
+        setFormMessage(
+            'walletLockStatusMsg',
+            typeof fee === 'number'
+                ? `Fee ~${fee.toFixed(4)} SOL from vault ledger. Settling...`
+                : 'Settling paid unlock...'
+        );
+
+        const payRes = await apiRequest(`/api/user/${currentUser.discordId}/wallet-unlock-pay`, {
+            method: 'POST',
+            body: JSON.stringify({}),
+        });
+        const payData = await payRes.json().catch(() => ({}));
+        if (!payRes.ok) {
+            setFormMessage('walletLockStatusMsg', payData.error || 'Paid unlock settlement failed.', true);
+            return;
+        }
+
+        setFormMessage('walletLockStatusMsg', 'Wallet Lock cleared. Vault ledger charged.');
+        if (payData.feeRouted === false) {
+            showNotification('Wallet lock cleared but trivia/microgrant ledgers did not sync; check logs.', 'warning');
+        } else {
+            showNotification('Paid early unlock completed.', 'success');
+        }
+        loadWalletLock();
+        loadVaults();
+    } catch (err) {
+        console.error('[Paid Wallet Unlock]', err);
+        setFormMessage('walletLockStatusMsg', 'Paid unlock failed.', true);
     }
 }
 

--- a/apps/user-dashboard/src/index.ts
+++ b/apps/user-dashboard/src/index.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-27 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 import express from 'express';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
@@ -1961,6 +1961,22 @@ app.post('/api/user/:discordId/wallet-unlock-request', authenticateToken, async 
   } catch (error) {
     console.error('[Wallet Unlock Request POST]', error);
     res.status(502).json({ error: getCanonicalApiErrorMessage(error, 'Failed to request early unlock') });
+  }
+});
+
+app.post('/api/user/:discordId/wallet-unlock-pay', authenticateToken, async (req: DashboardRequest, res) => {
+  try {
+    const discordId = requireAuthorizedDiscordId(req, res);
+    if (!discordId) return;
+
+    const response = await requestCanonicalApi(req, `/vault/${encodeURIComponent(discordId)}/wallet-unlock-pay`, {
+      method: 'POST',
+      body: JSON.stringify(req.body ?? {}),
+    });
+    sendCanonicalApiResponse(res, response);
+  } catch (error) {
+    console.error('[Wallet Unlock Pay POST]', error);
+    res.status(502).json({ error: getCanonicalApiErrorMessage(error, 'Failed to settle paid early unlock') });
   }
 });
 

--- a/docs/migrations/007-microgrant-pool.sql
+++ b/docs/migrations/007-microgrant-pool.sql
@@ -1,0 +1,9 @@
+-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+-- Ledger mirror for recovery microgrant fund credits (LockVault paid early-unlock routing uses apps/api/src/services/community-pools.ts).
+
+CREATE TABLE IF NOT EXISTS microgrant_pool (
+  id text PRIMARY KEY DEFAULT 'main',
+  balance double precision NOT NULL DEFAULT 0,
+  contributions bigint NOT NULL DEFAULT 0,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);

--- a/modules/lockvault/src/vault-manager.ts
+++ b/modules/lockvault/src/vault-manager.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 import { eventRouter } from '@tiltcheck/event-router';
 import { parseAmount } from '@tiltcheck/natural-language-parser';
 import { db } from '@tiltcheck/database';
@@ -153,6 +153,12 @@ export interface WalletActionLock {
     requestedBy: string;
     feePercentage?: number;
     feeAmountSOL?: number;
+    /** Populated when paid early unlock settles: trivia pot, microgrant ledger, dev skim (logged upstream). */
+    feeAllocationSOL?: {
+      triviaSOL: number;
+      micrograntSOL: number;
+      devSOL: number;
+    };
     approvedBy?: string;
     approvedAt?: number;
     completedAt?: number;
@@ -1420,21 +1426,144 @@ class VaultManager {
     return lock;
   }
 
+  /**
+   * Fee = feePct% of current vault ledger balance (lockedAmountSOL).
+   * Split: devPct% of balance to dev skim (logged by API), remainder split trivia/microgrant by triviaShare (default 0.5 each).
+   * Env: WALLET_EARLY_UNLOCK_DEV_PERCENT_OF_BALANCE (default 2), WALLET_EARLY_UNLOCK_TRIVIA_SHARE_OF_REMAINDER (default 0.5).
+   */
+  private computeEarlyUnlockFeeSplit(
+    baseSOL: number,
+    feePct: number,
+  ): { feeTotal: number; devSOL: number; triviaSOL: number; micrograntSOL: number } {
+    const devPctRaw = Number(process.env.WALLET_EARLY_UNLOCK_DEV_PERCENT_OF_BALANCE);
+    const devPct = Number.isFinite(devPctRaw) && devPctRaw >= 0 ? devPctRaw : 2;
+
+    const triviaShareRaw = Number(process.env.WALLET_EARLY_UNLOCK_TRIVIA_SHARE_OF_REMAINDER);
+    const triviaShare = Number.isFinite(triviaShareRaw) && triviaShareRaw >= 0 && triviaShareRaw <= 1
+      ? triviaShareRaw
+      : 0.5;
+
+    const feeTotal = normalizeSolAmount(baseSOL * (feePct / 100));
+    let devSOL = normalizeSolAmount(baseSOL * (devPct / 100));
+    if (devSOL > feeTotal) {
+      devSOL = feeTotal;
+    }
+    let remainder = normalizeSolAmount(feeTotal - devSOL);
+    if (remainder < 0) {
+      remainder = 0;
+    }
+
+    let triviaSOL = normalizeSolAmount(remainder * triviaShare);
+    let micrograntSOL = normalizeSolAmount(remainder - triviaSOL);
+
+    const sumParts = normalizeSolAmount(devSOL + triviaSOL + micrograntSOL);
+    if (sumParts !== feeTotal) {
+      micrograntSOL = normalizeSolAmount(feeTotal - devSOL - triviaSOL);
+      if (micrograntSOL < 0) {
+        micrograntSOL = 0;
+        triviaSOL = normalizeSolAmount(feeTotal - devSOL);
+      }
+    }
+
+    return { feeTotal, devSOL, triviaSOL, micrograntSOL };
+  }
+
   requestPaidWalletUnlock(userId: string, requestedBy: string, feePercentage = 10): WalletActionLock {
-    void userId;
-    void requestedBy;
-    void feePercentage;
-    throw createFeatureNotImplementedError(
-      'Paid early wallet unlock is temporarily disabled until fee routing is implemented.'
-    );
+    const lock = this.walletActionLocks.get(userId);
+    if (!lock) throw new Error('No active wallet lock found.');
+    const remainingMs = lock.lockUntil - now();
+    if (remainingMs <= 0) {
+      this.clearWalletActionLockInternal(userId);
+      throw new Error('Wallet lock has already expired.');
+    }
+
+    this.status(userId);
+
+    const vault = this.getLatestLockedVaultForUser(userId);
+    const baseSOL = normalizeSolAmount(vault.lockedAmountSOL);
+    if (!isPositiveSolAmount(baseSOL)) {
+      throw new Error('Vault balance is too small for a paid early unlock fee.');
+    }
+
+    const feePct =
+      Number.isFinite(feePercentage) && feePercentage > 0 && feePercentage <= 100 ? feePercentage : 10;
+
+    const feeTotal = normalizeSolAmount(baseSOL * (feePct / 100));
+    if (!isPositiveSolAmount(feeTotal)) {
+      throw new Error('Computed early unlock fee rounds to zero; vault balance is too small.');
+    }
+
+    lock.earlyUnlockRequest = {
+      mode: 'paid_early_unlock',
+      status: 'pending',
+      requestedAt: now(),
+      requestedBy,
+      feePercentage: feePct,
+      feeAmountSOL: feeTotal,
+    };
+    this.schedulePersist();
+    return lock;
   }
 
   settlePaidWalletUnlock(userId: string, paidBy: string): WalletActionLock {
-    void userId;
-    void paidBy;
-    throw createFeatureNotImplementedError(
-      'Paid early wallet unlock is temporarily disabled until fee routing is implemented.'
-    );
+    const lock = this.walletActionLocks.get(userId);
+    if (!lock) throw new Error('No active wallet lock found.');
+
+    const req = lock.earlyUnlockRequest;
+    if (!req || req.mode !== 'paid_early_unlock') {
+      throw new Error('No paid early unlock request is pending for this wallet lock.');
+    }
+    if (req.status !== 'pending') {
+      throw new Error('Paid early unlock request is not pending.');
+    }
+
+    const remainingMs = lock.lockUntil - now();
+    if (remainingMs <= 0) {
+      this.clearWalletActionLockInternal(userId);
+      throw new Error('Wallet lock has already expired.');
+    }
+
+    this.status(userId);
+
+    const vault = this.getLatestLockedVaultForUser(userId);
+    const baseSOL = normalizeSolAmount(vault.lockedAmountSOL);
+    const feePct = req.feePercentage ?? 10;
+
+    const { feeTotal, devSOL, triviaSOL, micrograntSOL } = this.computeEarlyUnlockFeeSplit(baseSOL, feePct);
+
+    if (!isPositiveSolAmount(feeTotal)) {
+      throw new Error('Early unlock fee rounds to zero.');
+    }
+    if (feeTotal > baseSOL) {
+      throw new Error('Early unlock fee exceeds vault balance.');
+    }
+
+    vault.lockedAmountSOL = normalizeSolAmount(baseSOL - feeTotal);
+    vault.releasedAmountSOL = normalizeSolAmount(Math.min(vault.releasedAmountSOL, vault.lockedAmountSOL));
+
+    vault.history.push({
+      ts: now(),
+      action: 'wallet-lock-paid-early-unlock',
+      note: JSON.stringify({
+        feeTotalSOL: feeTotal,
+        triviaSOL,
+        micrograntSOL,
+        devSOL,
+        paidBy,
+        feePercentage: feePct,
+      }),
+    });
+
+    req.status = 'completed';
+    req.completedAt = now();
+    req.approvedBy = paidBy;
+    req.approvedAt = now();
+    req.feeAmountSOL = feeTotal;
+    req.feeAllocationSOL = { triviaSOL, micrograntSOL, devSOL };
+
+    this.clearWalletActionLockInternal(userId);
+    this.schedulePersist();
+    return lock;
   }
 
   setAutoVault(userId: string, settings: AutoVaultSettings): void {

--- a/modules/lockvault/tests/lockvault.test.ts
+++ b/modules/lockvault/tests/lockvault.test.ts
@@ -1,4 +1,4 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const databaseMock = vi.hoisted(() => ({
@@ -278,10 +278,38 @@ describe('LockVault Module', () => {
     ]);
   });
 
-  it('gates paid early unlock until fee routing exists', async () => {
-    vaultManager.setWalletActionLock('u1', 30 * 60 * 1000, 'manual');
-    expect(() => vaultManager.requestPaidWalletUnlock('u1', 'u1')).toThrow(/temporarily disabled/i);
-    expect(() => vaultManager.settlePaidWalletUnlock('u1', 'u1')).toThrow(/temporarily disabled/i);
+  it('paid early unlock quotes fee then settles with split deductions', async () => {
+    vi.stubEnv('WALLET_EARLY_UNLOCK_DEV_PERCENT_OF_BALANCE', '2');
+    vi.stubEnv('WALLET_EARLY_UNLOCK_TRIVIA_SHARE_OF_REMAINDER', '0.5');
+    try {
+      const rec = await vaultManager.lock({
+        userId: 'u1',
+        amountRaw: '10',
+        durationRaw: '10m',
+        disclaimerAccepted: true,
+      });
+      vaultManager.setWalletActionLock('u1', 30 * 60 * 1000, 'manual');
+
+      vaultManager.requestPaidWalletUnlock('u1', 'u1', 10);
+      expect(vaultManager.getWalletActionLock('u1')?.earlyUnlockRequest?.feeAmountSOL).toBeCloseTo(1, 5);
+
+      vaultManager.settlePaidWalletUnlock('u1', 'u1');
+
+      const v = vaultManager.get(rec.id);
+      expect(v?.lockedAmountSOL).toBeCloseTo(9, 5);
+
+      const h = v?.history.find((x) => x.action === 'wallet-lock-paid-early-unlock');
+      expect(h).toBeDefined();
+      const payload = JSON.parse(h!.note || '{}');
+      expect(payload.feeTotalSOL).toBeCloseTo(1, 5);
+      expect(payload.devSOL).toBeCloseTo(0.2, 5);
+      expect(payload.triviaSOL).toBeCloseTo(0.4, 5);
+      expect(payload.micrograntSOL).toBeCloseTo(0.4, 5);
+
+      expect(vaultManager.getWalletActionLock('u1')).toBeNull();
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it('rejects direct deposits while a wallet action lock is active', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- **LockVault (`modules/lockvault`):** `requestPaidWalletUnlock` / `settlePaidWalletUnlock` are implemented. Fee defaults to **10% of `lockedAmountSOL`** on the user newest active locked vault. Settlement splits the fee into **dev skim** (**2% of vault balance**, default env `WALLET_EARLY_UNLOCK_DEV_PERCENT_OF_BALANCE`) plus **half / half** of the remainder between trivia and microgrant (`WALLET_EARLY_UNLOCK_TRIVIA_SHARE_OF_REMAINDER`, default `0.5`). Vault ledger is debited by the total fee; history stores JSON splits.

- **API (`apps/api`):** Extracted **`services/community-pools.ts`** — trivia jackpot + new microgrant pool persistence (same Supabase upsert pattern as before). `POST /vault/:id/wallet-unlock-pay` calls `creditEarlyUnlockFeeSplits` after settle; dev allocation is **structured JSON log** plus optional `EARLY_UNLOCK_DEV_SOL_ADDRESS` for ops (no on-chain transfer in this PR). Response adds **`feeRouted`**; if pool persistence throws after the vault debit, unlock still succeeds and ops reconcile from logs.

- **Routes:** `trivia.ts` thin wrapper + **`GET /trivia/microgrant-pool`**. Paid **`wallet-unlock-request`** path enabled; **`423 wallet-unlock`** lists `paid_early_unlock`.

- **Dashboard:** Proxy **`POST /api/user/:discordId/wallet-unlock-pay`**, UI button + confirm flow (quote then pay).

- **Ops:** `docs/migrations/007-microgrant-pool.sql`, `.env.example` knobs, `.gitignore` for `data/lockvault-store.json`.

## Risk / rollback

- **Ordering:** Vault debit is durable before pool credit; pool failures set `feeRouted: false` — grep logs `Early unlock pool credit failed after vault debit`.

- **Non-custodial:** Ledger credits only; treasury sweep to dev / fund wallets is manual until wired.

- **Rollback:** Re-disable paid branch in `vault.ts` (501) and restore stub throws in `vault-manager` if policy reverses.

## Validation

- `vitest` — `modules/lockvault/tests/lockvault.test.ts`, `apps/api/tests/routes/vault.test.ts`
- `pnpm --filter @tiltcheck/api build`

Apply **`007-microgrant-pool.sql`** in Neon/Supabase before relying on durable microgrant totals (trivia table unchanged).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TIL-36](https://linear.app/tiltcheck/issue/TIL-36/monetization-disable-non-game-add-on-monetization-preserve-add-ons)

<div><a href="https://cursor.com/agents/bc-a85043af-0539-4c18-9d62-43989d0cba49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a85043af-0539-4c18-9d62-43989d0cba49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

