### PR TITLE
docs: Stake.us Instagram code timing note (Pacific)

### DIFF
--- a/docs/tiltcheck/8-trust-engines.md
+++ b/docs/tiltcheck/8-trust-engines.md
@@ -1,4 +1,4 @@
-© 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-12
+© 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-07
 
 # 8. Trust Engines Overview
 The TiltCheck ecosystem relies on two global trust engines that power safety, fairness, community transparency, and predictive insights:
@@ -63,6 +63,9 @@ Collected from CollectClock:
 - region inconsistencies  
 - false advertising  
 - “1SC → 0.10SC for no reason” cycles  
+
+Observed promo-drop timing note (Stake.us Instagram codes):
+- `docs/tiltcheck/8a-instagram-stake-us-code-timing.md`
 
 ### **4. FreeSpinScan Signals**
 - invalid links  

--- a/docs/tiltcheck/8-trust-engines.md
+++ b/docs/tiltcheck/8-trust-engines.md
@@ -65,7 +65,7 @@ Collected from CollectClock:
 - “1SC → 0.10SC for no reason” cycles  
 
 Observed promo-drop timing note (Stake.us Instagram codes):
-- `docs/tiltcheck/8a-instagram-stake-us-code-timing.md`
+- [8A Instagram Stake.us Code Timing (Observed)](8a-instagram-stake-us-code-timing.md)
 
 ### **4. FreeSpinScan Signals**
 - invalid links  

--- a/docs/tiltcheck/8a-instagram-stake-us-code-timing.md
+++ b/docs/tiltcheck/8a-instagram-stake-us-code-timing.md
@@ -1,0 +1,84 @@
+© 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-07
+
+# 8A. Instagram Stake.us Code Timing (Observed)
+
+This is a raw observation log of Stake.us Instagram code drops (as captured by a user) with a basic timing analysis.
+
+Scope:
+- Date range: 2026-01-02 through 2026-05-04
+- Sample size: 32 drops
+- Amounts: $5 and $10
+- Timezone: America/Los_Angeles (Pacific). DST is handled implicitly (Jan/Feb are PST, mid-March onward is PDT).
+
+## Raw log (Pacific time)
+```
+01/02/2026     20:14   $5
+01/04/2026     22:30   $10
+01/07/2026     13:23   $10
+01/09/2026     21:11   $5
+01/10/2026     16:50   $5
+01/12/2026     14:56   $5
+01/13/2026     16:41   $10
+01/16/2026     21:26   $5
+01/18/2026     19:05   $5
+01/19/2026     15:40   $10
+01/21/2026     17:25   $5
+01/23/2026     18:35   $10
+01/26/2026     14:33   $5
+01/28/2026     13:14   $10
+02/01/2026     15:36   $10
+02/09/2026     15:18   $5
+02/17/2026     14:55   $10
+02/23/2026     15:11   $10
+02/28/2026     19:01   $10
+03/03/2026     14:28   $5
+03/10/2026     15:01   $10
+03/15/2026     17:10   $5
+03/18/2026     18:05   $10
+03/23/2026     20:53   $5
+03/27/2026     20:13   $10
+03/29/2026     17:58   $5
+04/06/2026     18:58   $10
+04/11/2026     22:52   $5
+04/19/2026     17:39   $10
+04/28/2026     18:42   $10
+04/29/2026     16:20   $5
+05/04/2026     17:41   $10
+```
+
+## Summary stats
+Totals:
+- 32 drops
+- $245 total
+- $10: 17 drops
+- $5: 15 drops
+
+Weekday counts (Pacific):
+- Mon: 8
+- Tue: 5
+- Wed: 5
+- Thu: 0
+- Fri: 5
+- Sat: 3
+- Sun: 6
+
+Time-of-day bucket counts (Pacific):
+- 12:00–14:59: 6
+- 15:00–17:59: 13
+- 18:00–20:59: 9
+- 21:00–23:59: 4
+- 00:00–11:59: 0
+
+Gaps between drops (calendar days, based on Pacific-local timestamps):
+- min: ~0.82 days
+- median: ~3.04 days
+- mean: ~3.93 days
+- max: ~9.04 days
+
+## Practical takeaway
+If you’re watching for drops, the only real signal in this sample is the window:
+- Most common: 15:00–17:59 Pacific
+- Next most common: 18:00–20:59 Pacific
+
+There is not enough evidence here to treat “weekday” as a reliable schedule, and the $5/$10 amounts do not show a clear time-based rule.
+

--- a/docs/tiltcheck/index.md
+++ b/docs/tiltcheck/index.md
@@ -3,6 +3,8 @@ title: TiltCheck Documentation Hub
 layout: default
 ---
 
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-07 -->
+
 # TiltCheck Ecosystem Docs
 
 Built by a degen, for degens. Fast reference to every internal spec, prompt, and module.
@@ -21,6 +23,7 @@ Built by a degen, for degens. Fast reference to every internal spec, prompt, and
 
 ## Trust & Architecture
 - [8 Trust Engines](8-trust-engines.md)
+- [8A Instagram Stake.us Code Timing (Observed)](8a-instagram-stake-us-code-timing.md)
 - [9 Architecture](9-architecture.md)
 - [10 Data Models](10-data-models.md)
 

--- a/scripts/email-crawler.ts
+++ b/scripts/email-crawler.ts
@@ -1,4 +1,4 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-07
 /**
  * Casino Email Crawler
  *
@@ -200,33 +200,38 @@ function saveSeen(seen: Set<string>): void {
 
 // ─── API call ────────────────────────────────────────────────────────────────
 
-async function ingestEmail(rawEmail: string): Promise<{ success: boolean; brand?: string; bonusCount?: number; riskLevel?: string }> {
+async function ingestEmail(rawEmail: string): Promise<{ success: boolean; brand?: string; bonusCount?: number; riskLevel?: string; error?: string }> {
   if (FLAGS.dryRun) return { success: true };
 
-  const res = await fetch(`${API_URL}/rgaas/email-ingest`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Requested-With': 'TiltCheck-Email-Crawler',
-      ...(process.env.EMAIL_INGEST_SECRET?.trim()
-        ? { 'X-Email-Ingest-Key': process.env.EMAIL_INGEST_SECRET.trim() }
-        : {}),
-    },
-    body: JSON.stringify({ raw_email: rawEmail }),
-  });
+  try {
+    const res = await fetch(`${API_URL}/rgaas/email-ingest`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'TiltCheck-Email-Crawler',
+        ...(process.env.EMAIL_INGEST_SECRET?.trim()
+          ? { 'X-Email-Ingest-Key': process.env.EMAIL_INGEST_SECRET.trim() }
+          : {}),
+      },
+      body: JSON.stringify({ raw_email: rawEmail }),
+    });
 
-  if (!res.ok) {
-    console.warn(`  API ${res.status}: ${await res.text().catch(() => '')}`);
-    return { success: false };
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      const snippet = body.trim().slice(0, 240);
+      return { success: false, error: `api ${res.status}${snippet ? `: ${snippet}` : ''}` };
+    }
+
+    const data = await res.json() as { intel?: { casinoBrand?: string; bonusSignals?: unknown[] }; domainScan?: { riskLevel?: string } };
+    return {
+      success: true,
+      brand: data.intel?.casinoBrand ?? undefined,
+      bonusCount: data.intel?.bonusSignals?.length ?? 0,
+      riskLevel: data.domainScan?.riskLevel ?? 'unknown',
+    };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
   }
-
-  const data = await res.json() as { intel?: { casinoBrand?: string; bonusSignals?: unknown[] }; domainScan?: { riskLevel?: string } };
-  return {
-    success: true,
-    brand: data.intel?.casinoBrand ?? undefined,
-    bonusCount: data.intel?.bonusSignals?.length ?? 0,
-    riskLevel: data.domainScan?.riskLevel ?? 'unknown',
-  };
 }
 
 // ─── IMAP helpers ────────────────────────────────────────────────────────────
@@ -299,6 +304,20 @@ async function run(): Promise<void> {
   const seen = loadSeen();
   const imap = buildImapClient();
 
+  if (!FLAGS.dryRun) {
+    const url = String(API_URL || '').trim();
+    if (!url || url.includes('[REDACTED]') || !/^https?:\/\//i.test(url)) {
+      console.error([
+        '',
+        'CRAWLER_API_URL is required and must be a valid http(s) URL.',
+        'Example: CRAWLER_API_URL=https://api.tiltcheck.me',
+        '',
+        'If you see this error, your .env is missing CRAWLER_API_URL (or NEXT_PUBLIC_API_URL is set to a placeholder).',
+      ].join('\n'));
+      process.exit(1);
+    }
+  }
+
   console.log(`\nTiltCheck Casino Email Crawler`);
   console.log(`Mode: ${FLAGS.dryRun ? 'DRY RUN' : 'LIVE'} | Limit: ${FLAGS.limit} | Reset: ${FLAGS.all} | Delete processed: ${FLAGS.deleteProcessed}`);
   console.log(`API: ${API_URL}`);
@@ -366,7 +385,7 @@ async function run(): Promise<void> {
               }
               console.log(`OK | ${result.brand ?? 'unknown brand'} | ${result.bonusCount ?? 0} bonuses | domain: ${result.riskLevel}`);
             } else {
-              console.log('FAILED');
+              console.log(`FAILED${result.error ? ` | ${result.error}` : ''}`);
               errors++;
             }
 

--- a/tools/channel-watcher/README.md
+++ b/tools/channel-watcher/README.md
@@ -1,4 +1,4 @@
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-03 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-07 -->
 # TiltCheck Channel Watcher
 
 Passively watches a Discord channel from your logged-in browser session, then runs scheduled GPT-4o analysis to surface pain points, friction, and community insights — no keyword lists needed.
@@ -7,7 +7,7 @@ Passively watches a Discord channel from your logged-in browser session, then ru
 
 1. Opens Discord web in a real browser using your saved login
 2. Watches the channel silently — every message is logged to `messages.jsonl`
-3. Every 2 hours (configurable), sends the buffered messages to GPT-4o-mini
+3. Every 6 hours (configurable), sends the buffered messages to GPT-4o-mini
 4. GPT produces a structured **analyst report** identifying:
    - 🔴 Pain points & frustrations
    - ⚡ Friction moments
@@ -78,7 +78,7 @@ Optional flags:
 ./run-cloud-watcher.ps1 -VmName "my-vm" -Zone "us-central1-a" -ProjectId "my-project"
 ```
 
-## Schedule it on Windows (every 2 hours)
+## Schedule it on Windows (every 6 hours)
 
 Create a recurring Task Scheduler job that runs the cloud watcher automatically:
 
@@ -89,7 +89,7 @@ npm run cloud:schedule
 Default schedule created by the script:
 
 - Days: Monday through Sunday
-- Times: every 2 hours (`00:00, 02:00, 04:00, ..., 22:00`)
+- Times: every 6 hours (`00:00, 06:00, 12:00, 18:00`)
 - Run length per execution: 2 minutes
 
 Custom schedule example:
@@ -98,7 +98,7 @@ Custom schedule example:
 ./register-cloud-watcher-task.ps1 `
   -TaskName "TiltCheck-Cloud-Watcher" `
   -Days Monday,Tuesday,Wednesday,Thursday,Friday,Saturday,Sunday `
-  -Times 00:00,02:00,04:00,06:00,08:00,10:00,12:00,14:00,16:00,18:00,20:00,22:00 `
+  -Times 00:00,06:00,12:00,18:00 `
   -DurationMinutes 2
 ```
 

--- a/tools/channel-watcher/register-cloud-watcher-task.ps1
+++ b/tools/channel-watcher/register-cloud-watcher-task.ps1
@@ -1,8 +1,8 @@
-<# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-18 #>
+<# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-07 #>
 param(
     [string]$TaskName = "TiltCheck-ChannelWatcher-Cloud",
     [string[]]$Days = @("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"),
-    [string[]]$Times = @("00:00", "02:00", "04:00", "06:00", "08:00", "10:00", "12:00", "14:00", "16:00", "18:00", "20:00", "22:00"),
+    [string[]]$Times = @("00:00", "06:00", "12:00", "18:00"),
     [int]$DurationMinutes = 2,
     [switch]$DisableAfterCreate
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an internal research note with a raw observed log and basic timing stats for Stake.us Instagram code drops, then links it from the Trust Engines doc and docs hub.

Also:
- Improves email crawler failure output so each listed email shows the actual API/status failure reason inline.
- Adds a hard fail early when `CRAWLER_API_URL` is missing/placeholder to avoid confusing per-email FAIL spam.
- Reduces default channel-watcher scheduled cadence (Windows task helper + README) from every 2 hours to every 6 hours (still configurable).

Risk notes
- Docs + scripts only.
- Email crawler now surfaces response body snippets (truncated) on non-2xx; verify the ingest endpoint does not echo secrets.

Validation
- Ran a JS syntax check for `tools/channel-watcher/index.js`.
- Verified doc links resolve:
  - `docs/tiltcheck/index.md` links to `docs/tiltcheck/8a-instagram-stake-us-code-timing.md`
  - `docs/tiltcheck/8-trust-engines.md` references the note

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f12a321e-0bc9-4abf-a523-9bc3287e43ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f12a321e-0bc9-4abf-a523-9bc3287e43ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

