### PR TITLE
Fix Discord Activities blank iframe (handshake timeout, hub URL, polling)

### DIFF
--- a/apps/activity/src/sdk/DiscordBridge.ts
+++ b/apps/activity/src/sdk/DiscordBridge.ts
@@ -1,4 +1,4 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-20
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 
 import { DiscordSDK, Events } from '@discord/embedded-app-sdk';
 import { getApiEndpointCandidates } from '../config.js';
@@ -41,17 +41,28 @@ export class DiscordBridge {
   async initialize(): Promise<DiscordBridgeState> {
     const sdk = this.getOrCreateSdk();
 
-    // 8-second timeout — fall to demo mode if Discord SDK hangs
-    await Promise.race([
-      sdk.ready(),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Discord SDK ready() timeout')), 8000)
-      )
-    ]);
+    /** Full authorize + subscribe can stall indefinitely in some Discord clients; caps total wait so the shell mounts. */
+    const HANDSHAKE_MS = 18_000;
 
-    await this.authenticate(sdk);
-    await this.subscribeToEvents(sdk);
-    return this.state;
+    const handshake = async (): Promise<DiscordBridgeState> => {
+      await Promise.race([
+        sdk.ready(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Discord SDK ready() timeout')), 8000),
+        ),
+      ]);
+
+      await this.authenticate(sdk);
+      await this.subscribeToEvents(sdk);
+      return this.state;
+    };
+
+    return Promise.race([
+      handshake(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Discord activity handshake timeout')), HANDSHAKE_MS),
+      ),
+    ]);
   }
 
   private getOrCreateSdk(): DiscordSDK {

--- a/apps/activity/src/sdk/HubRelay.ts
+++ b/apps/activity/src/sdk/HubRelay.ts
@@ -78,7 +78,7 @@ export class HubRelay {
       reconnectionDelay: 1000,
       reconnectionDelayMax: this.maxReconnectDelay,
       reconnectionAttempts: Infinity,
-      transports: ['websocket'],
+      transports: ['polling', 'websocket'],
       withCredentials: true,
     });
 

--- a/apps/degens-activity/src/main.ts
+++ b/apps/degens-activity/src/main.ts
@@ -1,4 +1,4 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved.
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 // Degens Activity — main entry
 
 import { initSDK, invite, type DiscordUser } from './sdk.js';
@@ -11,9 +11,12 @@ import * as jackpotView from './views/jackpot.js';
 const VIEWS = ['lobby', 'dad', 'trivia', 'jackpot'] as const;
 type View = (typeof VIEWS)[number];
 
-const statusEl = document.getElementById('status')!;
+const statusEl = document.getElementById('status');
 
 function setStatus(msg: string, live = false): void {
+  if (!statusEl) {
+    return;
+  }
   statusEl.textContent = msg;
   statusEl.classList.toggle('live', live);
 }
@@ -32,6 +35,12 @@ function switchView(view: string): void {
 async function boot(): Promise<void> {
   setStatus('CONNECTING');
 
+  const lobbySkeleton = document.getElementById('view-lobby');
+  if (lobbySkeleton) {
+    lobbySkeleton.innerHTML =
+      '<div class="card card--accent" data-boot-skeleton><p class="card__body">Discord wiring — if this hangs, wait a few seconds; we fall back to demo mode automatically.</p></div>';
+  }
+
   let user: DiscordUser;
   try {
     user = await initSDK();
@@ -49,10 +58,14 @@ async function boot(): Promise<void> {
   relay.joinLobby();
 
   // Mount views
-  const lobbyEl = document.getElementById('view-lobby')!;
-  const dadEl = document.getElementById('view-dad')!;
-  const triviaEl = document.getElementById('view-trivia')!;
-  const jackpotEl = document.getElementById('view-jackpot')!;
+  const lobbyEl = document.getElementById('view-lobby');
+  const dadEl = document.getElementById('view-dad');
+  const triviaEl = document.getElementById('view-trivia');
+  const jackpotEl = document.getElementById('view-jackpot');
+
+  if (!lobbyEl || !dadEl || !triviaEl || !jackpotEl) {
+    throw new Error('Degens Activity shell DOM is missing expected #view-* roots');
+  }
 
   lobbyView.mount(lobbyEl, switchView, user.username);
   dadView.mount(dadEl, user.id);

--- a/apps/degens-activity/src/relay.ts
+++ b/apps/degens-activity/src/relay.ts
@@ -6,7 +6,17 @@ import { getAccessToken } from './sdk.js';
 
 type Handler = (data: unknown) => void;
 
-const ARENA_URL = import.meta.env.VITE_ARENA_URL || 'http://localhost:3010';
+/** Production ships without localhost — game-arena public ingress is arena.tiltcheck.me. Dev uses the Vite dev origin so `/socket.io` hits the proxy. */
+function resolveArenaUrl(): string {
+  const env = typeof import.meta.env.VITE_ARENA_URL === 'string' ? import.meta.env.VITE_ARENA_URL.trim() : '';
+  if (env) {
+    return env;
+  }
+  if (import.meta.env.DEV && typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin;
+  }
+  return 'https://arena.tiltcheck.me';
+}
 
 let socket: Socket | null = null;
 const handlers = new Map<string, Handler[]>();
@@ -23,12 +33,15 @@ export function on(event: string, handler: Handler): void {
 export function connect(userId: string): void {
   if (socket) return;
 
-  socket = io(ARENA_URL, {
+  const arenaUrl = resolveArenaUrl();
+
+  socket = io(arenaUrl, {
     auth: { token: getAccessToken() || 'activity-bypass', userId },
     reconnection: true,
     reconnectionDelay: 1000,
     reconnectionDelayMax: 15000,
-    transports: ['websocket'],
+    // Prefer polling-compatible path — some Discord/mobile webviews are picky about websocket-only.
+    transports: ['polling', 'websocket'],
   });
 
   socket.on('connect', () => emit('connected', true));

--- a/apps/degens-activity/src/relay.ts
+++ b/apps/degens-activity/src/relay.ts
@@ -6,7 +6,7 @@ import { getAccessToken } from './sdk.js';
 
 type Handler = (data: unknown) => void;
 
-/** Production ships without localhost — game-arena public ingress is arena.tiltcheck.me. Dev uses the Vite dev origin so `/socket.io` hits the proxy. */
+/** Production ships without localhost — Socket.IO public ingress is game-arena.tiltcheck.me. Dev uses the Vite dev origin so `/socket.io` hits the proxy. */
 function resolveArenaUrl(): string {
   const env = typeof import.meta.env.VITE_ARENA_URL === 'string' ? import.meta.env.VITE_ARENA_URL.trim() : '';
   if (env) {
@@ -15,7 +15,7 @@ function resolveArenaUrl(): string {
   if (import.meta.env.DEV && typeof window !== 'undefined' && window.location?.origin) {
     return window.location.origin;
   }
-  return 'https://arena.tiltcheck.me';
+  return 'https://game-arena.tiltcheck.me';
 }
 
 let socket: Socket | null = null;

--- a/apps/degens-activity/src/sdk.ts
+++ b/apps/degens-activity/src/sdk.ts
@@ -1,7 +1,10 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved.
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 // Discord Embedded App SDK bridge — lean wrapper
 
 import { DiscordSDK, Events } from '@discord/embedded-app-sdk';
+
+/** Covers ready + authorize + token exchange + authenticate + subscribe — avoids an infinite hang with a blank iframe body. */
+const DISCORD_HANDSHAKE_DEADLINE_MS = 18_000;
 
 export interface DiscordUser {
   id: string;
@@ -31,16 +34,11 @@ export function getAccessToken(): string | null {
   return accessToken;
 }
 
-export async function initSDK(): Promise<DiscordUser> {
-  // Outside Discord — demo mode
-  if (window.self === window.top) {
-    return { id: 'demo-0000', username: 'DEMO DEGEN', channelId: null };
-  }
-
+async function handshakeDiscordActivity(): Promise<DiscordUser> {
   sdk = new DiscordSDK(CLIENT_ID);
   await Promise.race([
     sdk.ready(),
-    new Promise<never>((_, reject) => setTimeout(() => reject(new Error('SDK timeout')), 8000)),
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error('SDK ready timeout')), 8000)),
   ]);
 
   const { code } = await sdk.commands.authorize({
@@ -61,7 +59,6 @@ export async function initSDK(): Promise<DiscordUser> {
   accessToken = access_token;
   const auth = await sdk.commands.authenticate({ access_token });
 
-  // Subscribe to participant changes
   await sdk.subscribe(Events.ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE, (data) => {
     emit('participants', data.participants);
   });
@@ -71,6 +68,23 @@ export async function initSDK(): Promise<DiscordUser> {
     username: auth.user.username,
     channelId: sdk.channelId,
   };
+}
+
+export async function initSDK(): Promise<DiscordUser> {
+  // Outside Discord — demo mode
+  if (window.self === window.top) {
+    return { id: 'demo-0000', username: 'DEMO DEGEN', channelId: null };
+  }
+
+  return Promise.race([
+    handshakeDiscordActivity(),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error('Discord activity handshake timeout')),
+        DISCORD_HANDSHAKE_DEADLINE_MS,
+      ),
+    ),
+  ]);
 }
 
 export async function openExternal(url: string): Promise<void> {

--- a/apps/game-arena/src/server.ts
+++ b/apps/game-arena/src/server.ts
@@ -62,6 +62,7 @@ app.use((req, res, next) => {
     'https://api.tiltcheck.me',
     'https://activity.tiltcheck.me',
     'https://dev-activity.tiltcheck.me',
+    'https://game-arena.tiltcheck.me',
     'https://game.tiltcheck.me',
     'https://tiltcheck-game-arena-164294266634.us-central1.run.app',
   ];
@@ -95,6 +96,7 @@ const socketIoCorsOrigins = [
   'https://api.tiltcheck.me',
   'https://activity.tiltcheck.me',
   'https://dev-activity.tiltcheck.me',
+  'https://game-arena.tiltcheck.me',
   'https://game.tiltcheck.me',
   'https://tiltcheck-game-arena-164294266634.us-central1.run.app',
 ];

--- a/apps/tiltcheck-activity/src/main.ts
+++ b/apps/tiltcheck-activity/src/main.ts
@@ -1,4 +1,4 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved.
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 // TiltCheck Activity — main entry
 
 import { initSDK, invite, type DiscordUser } from './sdk.js';
@@ -10,9 +10,12 @@ import * as trustView from './views/trust.js';
 const VIEWS = ['session', 'tilt', 'trust'] as const;
 type View = (typeof VIEWS)[number];
 
-const statusEl = document.getElementById('status')!;
+const statusEl = document.getElementById('status');
 
 function setStatus(msg: string, live = false): void {
+  if (!statusEl) {
+    return;
+  }
   statusEl.textContent = msg;
   statusEl.classList.toggle('live', live);
 }
@@ -31,6 +34,12 @@ function switchView(view: string): void {
 async function boot(): Promise<void> {
   setStatus('CONNECTING');
 
+  const sessionShell = document.getElementById('view-session');
+  if (sessionShell) {
+    sessionShell.innerHTML =
+      '<div class="card card--accent" data-boot-skeleton><p class="card__body">Discord wiring — we time out and fall back automatically if the iframe stalls.</p></div>';
+  }
+
   let user: DiscordUser;
   try {
     user = await initSDK();
@@ -47,9 +56,16 @@ async function boot(): Promise<void> {
   });
 
   // Mount views
-  sessionView.mount(document.getElementById('view-session')!, user.id, user.channelId ?? 'demo-channel');
-  tiltView.mount(document.getElementById('view-tilt')!, relay);
-  trustView.mount(document.getElementById('view-trust')!);
+  const sessionEl = document.getElementById('view-session');
+  const tiltEl = document.getElementById('view-tilt');
+  const trustEl = document.getElementById('view-trust');
+  if (!sessionEl || !tiltEl || !trustEl) {
+    throw new Error('TiltCheck Activity shell DOM is missing expected #view-* roots');
+  }
+
+  sessionView.mount(sessionEl, user.id, user.channelId ?? 'demo-channel');
+  tiltView.mount(tiltEl, relay);
+  trustView.mount(trustEl);
 
   // Tab navigation
   document.querySelectorAll<HTMLElement>('.tab').forEach((tab) => {

--- a/apps/tiltcheck-activity/src/relay.ts
+++ b/apps/tiltcheck-activity/src/relay.ts
@@ -1,5 +1,5 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved.
-// Socket.io relay to TiltCheck hub
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+// Socket.io relay to TiltCheck hub (same Socket.IO surface as apps/activity Railway host)
 
 import { io, Socket } from 'socket.io-client';
 import { getAccessToken } from './sdk.js';
@@ -12,7 +12,16 @@ export interface SessionRound {
 
 type Handler = (data: unknown) => void;
 
-const HUB_URL = import.meta.env.VITE_HUB_URL || 'https://api.tiltcheck.me';
+function resolveHubUrl(): string {
+  const env = typeof import.meta.env.VITE_HUB_URL === 'string' ? import.meta.env.VITE_HUB_URL.trim() : '';
+  if (env) {
+    return env;
+  }
+  if (import.meta.env.DEV && typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin;
+  }
+  return 'https://activity.tiltcheck.me';
+}
 
 let socket: Socket | null = null;
 const handlers = new Map<string, Handler[]>();
@@ -29,12 +38,14 @@ export function on(event: string, handler: Handler): void {
 export function connect(userId: string, channelId: string): void {
   if (socket) return;
 
-  socket = io(HUB_URL, {
+  const hubUrl = resolveHubUrl();
+
+  socket = io(hubUrl, {
     auth: { accessToken: getAccessToken(), userId },
     reconnection: true,
     reconnectionDelay: 1000,
     reconnectionDelayMax: 15000,
-    transports: ['websocket'],
+    transports: ['polling', 'websocket'],
     withCredentials: true,
   });
 

--- a/apps/tiltcheck-activity/src/sdk.ts
+++ b/apps/tiltcheck-activity/src/sdk.ts
@@ -1,7 +1,9 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved.
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 // Discord Embedded App SDK bridge — lean wrapper
 
 import { DiscordSDK, Events } from '@discord/embedded-app-sdk';
+
+const DISCORD_HANDSHAKE_DEADLINE_MS = 18_000;
 
 export interface DiscordUser {
   id: string;
@@ -31,15 +33,11 @@ export function getAccessToken(): string | null {
   return accessToken;
 }
 
-export async function initSDK(): Promise<DiscordUser> {
-  if (window.self === window.top) {
-    return { id: 'demo-0000', username: 'DEMO DEGEN', channelId: null };
-  }
-
+async function handshakeDiscordActivity(): Promise<DiscordUser> {
   sdk = new DiscordSDK(CLIENT_ID);
   await Promise.race([
     sdk.ready(),
-    new Promise<never>((_, reject) => setTimeout(() => reject(new Error('SDK timeout')), 8000)),
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error('SDK ready timeout')), 8000)),
   ]);
 
   const { code } = await sdk.commands.authorize({
@@ -69,6 +67,22 @@ export async function initSDK(): Promise<DiscordUser> {
     username: auth.user.username,
     channelId: sdk.channelId,
   };
+}
+
+export async function initSDK(): Promise<DiscordUser> {
+  if (window.self === window.top) {
+    return { id: 'demo-0000', username: 'DEMO DEGEN', channelId: null };
+  }
+
+  return Promise.race([
+    handshakeDiscordActivity(),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error('Discord activity handshake timeout')),
+        DISCORD_HANDSHAKE_DEADLINE_MS,
+      ),
+    ),
+  ]);
 }
 
 export async function openExternal(url: string): Promise<void> {

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -117,6 +117,9 @@ Use the **same Discord application** as `VITE_DISCORD_CLIENT_ID` at build time (
 - Local tunnel support is wired for Discord dev sessions:
   - `pnpm --filter @tiltcheck/degens-activity dev:tunnel` -> `dev-degens.tiltcheck.me`
   - `pnpm --filter @tiltcheck/tiltcheck-activity dev:tunnel` -> `dev-tiltcheck-activity.tiltcheck.me`
+- Runtime defaults (override with `VITE_*` when your Activity host is not the TiltCheck public ingress):
+  - Degens `VITE_ARENA_URL`: production build falls back to `https://arena.tiltcheck.me`; dev uses `window.location.origin` so the Vite `/socket.io` proxy is used.
+  - TiltCheck session `VITE_HUB_URL`: production build falls back to `https://activity.tiltcheck.me` (REST still uses `VITE_API_URL` separately); dev uses `window.location.origin` for the proxy.
 - Replace the placeholder tunnel UUID and generic credentials path placeholder in each app's `cloudflare-tunnel.yml` before use.
 
 ### `chrome-extension`

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -118,7 +118,7 @@ Use the **same Discord application** as `VITE_DISCORD_CLIENT_ID` at build time (
   - `pnpm --filter @tiltcheck/degens-activity dev:tunnel` -> `dev-degens.tiltcheck.me`
   - `pnpm --filter @tiltcheck/tiltcheck-activity dev:tunnel` -> `dev-tiltcheck-activity.tiltcheck.me`
 - Runtime defaults (override with `VITE_*` when your Activity host is not the TiltCheck public ingress):
-  - Degens `VITE_ARENA_URL`: production build falls back to `https://arena.tiltcheck.me`; dev uses `window.location.origin` so the Vite `/socket.io` proxy is used.
+  - Degens `VITE_ARENA_URL`: production build falls back to `https://game-arena.tiltcheck.me`; dev uses `window.location.origin` so the Vite `/socket.io` proxy is used.
   - TiltCheck session `VITE_HUB_URL`: production build falls back to `https://activity.tiltcheck.me` (REST still uses `VITE_API_URL` separately); dev uses `window.location.origin` for the proxy.
 - Replace the placeholder tunnel UUID and generic credentials path placeholder in each app's `cloudflare-tunnel.yml` before use.
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -33,14 +33,14 @@ This file is the canonical deploy map for the current repo. If a workflow, image
 | `dad-bot` | `apps/dad-bot` | GHCR -> Railway | `.github/workflows/deploy-railway.yml` | `ghcr.io/tiltcheck-me/tiltcheck-dad-bot` | `dad-bot` | `DISCORD_CLIENT_ID` plus one dad bot token var (`DAD_DISCORD_BOT_TOKEN`, `DISCORD_TOKEN`, or `DISCORD_BOT_TOKEN`) | Railway private `/health` on service port |
 | `trust-rollup` | `apps/trust-rollup` | GHCR -> Railway | `.github/workflows/deploy-railway.yml` | `ghcr.io/tiltcheck-me/tiltcheck-trust-rollup` | `trust-rollup` | `TRUST_ROLLUP_*` config and any upstream data-source keys required by enabled fetchers | Railway private `/health` on service port |
 | `control-room` | `apps/control-room` | GHCR -> Railway | `.github/workflows/deploy-railway.yml` | `ghcr.io/tiltcheck-me/tiltcheck-control-room` | `control-room` | `ADMIN_PASSWORD`, `SESSION_SECRET` | `https://admin.tiltcheck.me/health` when that hostname maps to this service |
-| `game-arena` | `apps/game-arena` | GHCR -> Railway | `.github/workflows/deploy-railway.yml` | `ghcr.io/tiltcheck-me/tiltcheck-game-arena` | `game-arena` | `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SESSION_SECRET` and/or `JWT_SECRET` | `https://arena.tiltcheck.me/health` when that hostname maps to this service |
+| `game-arena` | `apps/game-arena` | GHCR -> Railway | `.github/workflows/deploy-railway.yml` | `ghcr.io/tiltcheck-me/tiltcheck-game-arena` | `game-arena` | `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SESSION_SECRET` and/or `JWT_SECRET` | `https://game-arena.tiltcheck.me/health` or `https://arena.tiltcheck.me/health` depending on which public hostname maps to this service |
 | `user-dashboard` | `apps/user-dashboard` | GHCR -> Railway | `.github/workflows/deploy-railway.yml` | `ghcr.io/tiltcheck-me/tiltcheck-user-dashboard` | `user-dashboard` | `JWT_SECRET`, `MAGIC_SECRET_KEY` when Magic routes stay enabled | `https://dashboard.tiltcheck.me/health` when that hostname maps to this service |
 | `activity` | `apps/activity` | GHCR -> Railway | `.github/workflows/deploy-railway.yml` | `ghcr.io/tiltcheck-me/tiltcheck-activity` | `activity` | `VITE_DISCORD_CLIENT_ID`, `VITE_API_URL`, `VITE_DASHBOARD_URL` | `https://activity.tiltcheck.me/` when that hostname maps to this service |
 | `cloudflared` | `apps/cloudflared` | Optional GHCR -> Railway tunnel daemon | `.github/workflows/deploy-railway.yml` | `ghcr.io/tiltcheck-me/tiltcheck-cloudflared` | `cloudflared` | `TUNNEL_TOKEN` | Only when tunnel ingress is active: verify Railway service health and optional `.github/workflows/configure-tunnel.yml` reconciliation |
 | `hub` | `apps/hub` | Cloudflare Workers via Wrangler | `.github/workflows/deploy-hub.yml` | n/a | n/a | Wrangler bindings such as `DB`, `SESSIONS`, `API_BASE_URL`, and `INTERNAL_API_SECRET` | `GET /health` on the deployed Worker URL; public `hub.tiltcheck.me` may map here or to `user-dashboard` depending on live ingress |
 | `chrome-extension` | `apps/chrome-extension` | Browser asset; manual ZIP or Chrome Web Store publish | none | n/a | n/a | Build/runtime config in `apps/chrome-extension/src/config.ts` | Manual smoke: `pnpm -C apps/chrome-extension build`, load built extension, and verify API calls against `https://api.tiltcheck.me` |
-| `degens-activity` | `apps/degens-activity` | Static Discord activity asset; manual publish to CDN or Discord-managed asset host | none | n/a | n/a | `VITE_DISCORD_CLIENT_ID`, `VITE_TOKEN_ENDPOINT`, `VITE_ARENA_URL` | Manual smoke: `pnpm --filter @tiltcheck/degens-activity build` and verify the built SPA in a Discord Activity session; no production host is wired in-repo |
-| `tiltcheck-activity` | `apps/tiltcheck-activity` | Static Discord activity asset; manual publish to CDN or Discord-managed asset host | none | n/a | n/a | `VITE_DISCORD_CLIENT_ID`, `VITE_TOKEN_ENDPOINT`, `VITE_HUB_URL` | Manual smoke: `pnpm --filter @tiltcheck/tiltcheck-activity build` and verify the built SPA in a Discord Activity session; no production host is wired in-repo |
+| `degens-activity` | `apps/degens-activity` | **Recommended:** GHCR → Railway second service (static nginx SPA, mirror `apps/activity` Dockerfile pattern). **Alternative:** manual static CDN. Workflow/image names are placeholders until wired in `.github/workflows/deploy-railway.yml`. | `.github/workflows/deploy-railway.yml` (extend when Dockerfile exists) | `ghcr.io/tiltcheck-me/tiltcheck-degens-activity` *(suggested)* | `degens-activity` *(suggested)* | **`VITE_DISCORD_CLIENT_ID`**, **`VITE_TOKEN_ENDPOINT`**, **`VITE_ARENA_URL=https://game-arena.tiltcheck.me`** (realtime ingress; do not omit in prod builds) | **`https://degens.activity.tiltcheck.me/`** *(example hostname — set Railway Custom Domain + Discord Embedded URL to the same canonical URL)* |
+| `tiltcheck-activity` | `apps/tiltcheck-activity` | Static Discord activity asset; manual publish OR optional future Railway row | none | n/a | n/a | `VITE_DISCORD_CLIENT_ID`, `VITE_TOKEN_ENDPOINT`, `VITE_HUB_URL` | Manual smoke: `pnpm --filter @tiltcheck/tiltcheck-activity build` and verify in Discord |
 
 ## Public Routing
 
@@ -50,7 +50,8 @@ Public hostnames do not automatically come from the deploy workflow itself. This
 - `tiltcheck.me` and `www.tiltcheck.me` -> `web.railway.internal:3000`
 - `dashboard.tiltcheck.me` and `hub.tiltcheck.me` -> `user-dashboard.railway.internal:6001`
 - activity.tiltcheck.me -> activity.railway.internal:8080 (matches the container listen port in the Dockerfile)
-- `arena.tiltcheck.me` -> `game-arena.railway.internal:3000`
+- `arena.tiltcheck.me` -> `game-arena.railway.internal:3000` (historic / alternate DNS; Socket.IO and web may also use **`game-arena.tiltcheck.me`** per your edge mapping)
+- Degens second Activity (example): **`degens.activity.tiltcheck.me`** -> `degens-activity.railway.internal:<port>` once the Railway service and custom domain exist
 - `admin.tiltcheck.me` -> `control-room.railway.internal:3000`
 
 ## Discord Activity (`apps/activity`) — production checklist
@@ -91,11 +92,54 @@ Use the **same Discord application** as `VITE_DISCORD_CLIENT_ID` at build time (
 
 ### How to verify health end-to-end
 
-1. **Pipeline:** After merge to `main`, confirm the workflow built `tiltcheck-activity` and the Railway deploy step succeeded for the `activity` matrix row.
+1. **Pipeline:** After merge to `main`, confirm the workflow built the **`activity`** image (`ghcr.io/tiltcheck-me/tiltcheck-activity`) and Railway deployed the `activity` service.
 2. **Edge:** Open `https://activity.tiltcheck.me/` in a browser; you should get the SPA (not a persistent 5xx). Fetch `https://activity.tiltcheck.me/version.json` after a deploy if you need a coarse build stamp (generated at Vite build).
 3. **Discord:** Join a voice channel, launch the Embedded Activity, and confirm the shell reaches CONNECTED (not permanently DEMO MODE). DEMO MODE usually means SDK or token exchange failed—check API logs for `/auth/discord/activity/token` and Discord OAuth config.
 
 - **Activity-only rollback:** In Railway, roll back the `activity` service to a previous image or redeploy a known-good tag from GHCR.
+
+## Degens Activity (`apps/degens-activity`) — second Railway service
+
+This is the **separate** Discord Embedded App for the Degens lobby (DA&D, trivia, jackpot). It does **not** ship from the `activity` service on `activity.tiltcheck.me`. Run a **second** Railway service so you have two public URLs: **TiltCheck shell** vs **Degens games**.
+
+### Hosting target (pattern)
+
+| Item | Value |
+| :--- | :--- |
+| Public URL | Your choice (example: `https://degens.activity.tiltcheck.me/`). Must match the **Embedded App / Activity URL** in the **Degens** Discord application. |
+| Image | Suggested: `ghcr.io/tiltcheck-me/tiltcheck-degens-activity` once CI builds it |
+| Railway service | Suggested name: `degens-activity` |
+| CI/CD | Add a matrix row and Dockerfile mirroring `apps/activity` (Vite build + nginx static + optional `/api/` and `/socket.io/` upstreams). Until then, build locally and deploy the image manually. |
+
+### Build-time environment (Railway or CI)
+
+Set at **`pnpm build`** time (Vite embeds `VITE_*`):
+
+| Variable | Required | Notes |
+| :--- | :--- | :--- |
+| `VITE_DISCORD_CLIENT_ID` | Yes | Use the Discord **application** that owns the Degens Activity. |
+| `VITE_TOKEN_ENDPOINT` | Recommended | Defaults to `https://api.tiltcheck.me/auth/discord/activity/token` in code if unset; override if API is not public at that URL. |
+| `VITE_ARENA_URL` | **Yes in production** | Set to **`https://game-arena.tiltcheck.me`** (or your live game-arena Socket.IO origin). Do not rely on localhost in Discord users’ browsers. |
+
+### Realtime / CORS
+
+- The browser connects Socket.IO **to game-arena**, not necessarily to the Degens Activity hostname.
+- After the Degens SPA has a stable **HTTPS origin**, add it to **`apps/game-arena/src/server.ts`** `allowedOrigins` and `socketIoCorsOrigins` if connections are cross-origin from the SPA (same pattern as `activity.tiltcheck.me`).
+
+### Discord Developer Portal
+
+- Use **this** Embedded App URL + OAuth config for Degens only; **do not** reuse `activity.tiltcheck.me` for the Degens Discord app unless you intentionally serve both products from one host (you are not).
+- Include `https://<APPLICATION_ID>.discordsays.com` on OAuth2 redirects the same way as the main Activity.
+
+### Internal networking (optional nginx in Docker)
+
+If you copy the `apps/activity` Dockerfile pattern, proxy **`/socket.io/`** to `game-arena.railway.internal:3000` so the iframe can use **same-origin** Socket.IO (then `VITE_ARENA_URL` can be omitted or set to the Degens public origin). If you **do not** proxy, clients must use **`VITE_ARENA_URL`** pointing at **`https://game-arena.tiltcheck.me`**.
+
+### Smoke
+
+1. `pnpm --filter @tiltcheck/degens-activity build`
+2. Open the public URL in a normal browser; confirm JS loads and status is not stuck forever on CONNECTING after Discord handshake timeout (see app `initSDK` timeout behavior).
+3. Launch the Activity in Discord; confirm trivia/lobby mounts and realtime events reach the client.
 
 ## Rollback Notes
 
@@ -106,21 +150,19 @@ Use the **same Discord application** as `VITE_DISCORD_CLIENT_ID` at build time (
 
 ## Manual Publish Notes
 
-### `degens-activity` and `tiltcheck-activity`
+### `tiltcheck-activity` (manual)
 
-- Chosen target: static asset publish, not Railway.
-- Reason: both apps are Vite SPAs for Discord Activities, the repo has no Railway service IDs or production tunnel routes for them, and adding placeholder matrix rows would create broken deploy automation.
-- Build commands:
-  - `pnpm --filter @tiltcheck/degens-activity build`
-  - `pnpm --filter @tiltcheck/tiltcheck-activity build`
-- Publish the resulting `dist/` artifacts to the CDN or Discord-managed asset host that backs the Activity configuration outside this repo.
-- Local tunnel support is wired for Discord dev sessions:
-  - `pnpm --filter @tiltcheck/degens-activity dev:tunnel` -> `dev-degens.tiltcheck.me`
-  - `pnpm --filter @tiltcheck/tiltcheck-activity dev:tunnel` -> `dev-tiltcheck-activity.tiltcheck.me`
-- Runtime defaults (override with `VITE_*` when your Activity host is not the TiltCheck public ingress):
-  - Degens `VITE_ARENA_URL`: production build falls back to `https://game-arena.tiltcheck.me`; dev uses `window.location.origin` so the Vite `/socket.io` proxy is used.
-  - TiltCheck session `VITE_HUB_URL`: production build falls back to `https://activity.tiltcheck.me` (REST still uses `VITE_API_URL` separately); dev uses `window.location.origin` for the proxy.
-- Replace the placeholder tunnel UUID and generic credentials path placeholder in each app's `cloudflare-tunnel.yml` before use.
+- **Chosen target:** static asset publish **or** a future Railway row (same pattern as Degens once needed).
+- **Build:** `pnpm --filter @tiltcheck/tiltcheck-activity build`
+- **Publish:** Deploy `dist/` to the host configured in Discord for that slim session app.
+- **Runtime defaults:** `VITE_HUB_URL` prod fallback `https://activity.tiltcheck.me`; dev uses `window.location.origin` for the proxy.
+- Replace the placeholder UUID in `apps/tiltcheck-activity/cloudflare-tunnel.yml` before dev tunnel use.
+
+### `degens-activity` pointers
+
+- **Recommended production path:** second Railway service and public hostname — see **Degens Activity (`apps/degens-activity`) — second Railway service** above.
+- **Alternative:** publish `pnpm --filter @tiltcheck/degens-activity build` output to any HTTPS static host without Railway.
+- **Local tunnel:** `pnpm --filter @tiltcheck/degens-activity dev:tunnel` → `dev-degens.tiltcheck.me`
 
 ### `chrome-extension`
 
@@ -137,4 +179,4 @@ When this file changes, confirm all three checks before merging:
 
 1. `git ls-files ".github/workflows/*"` still shows no tracked `deploy-gcp` workflow file in the repo.
 2. If GitHub UI or `gh workflow list` still shows retired workflow metadata, confirm `gh workflow view <id> --yaml` fails before treating it as an active source of truth.
-3. Every deployable row above still matches the active workflow or an explicit manual-only path.
+3. Every deployable row above still matches the active workflow, an explicit manual path, or an explicitly **TBD** Railway extension (e.g. **degens-activity** CI wiring).

--- a/docs/TRAINING-MANUAL.md
+++ b/docs/TRAINING-MANUAL.md
@@ -932,7 +932,7 @@ ANY ENTRY POINT (Discord / Web / Extension)
 |---|---|---|
 | `VITE_DISCORD_CLIENT_ID` | Both activities | No (fallback exists) |
 | `VITE_TOKEN_ENDPOINT` | Both activities | No (fallback: api.tiltcheck.me) |
-| `VITE_ARENA_URL` | Degens activity | No (fallback: localhost:3010) |
+| `VITE_ARENA_URL` | Degens activity | No (prod fallback: `https://game-arena.tiltcheck.me`; dev: Vite origin / proxy) |
 | `VITE_HUB_URL` | TiltCheck activity | No (fallback: api.tiltcheck.me) |
 
 ### Infrastructure


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What you were seeing

Discord Activity iframes start with **empty** `#view-*` sections until `boot()` finishes **`initSDK()`** / **`DiscordBridge.initialize()`**. Two failure modes caused an apparently blank UI:

1. **`authorize()` / token exchange never settled** — only `sdk.ready()` had an 8s timeout; the rest could hang forever, so mounts never ran.
2. **Wrong Socket.IO URL in production builds** — Degens defaulted `VITE_ARENA_URL` to `http://localhost:3010` (user device localhost). TiltCheck session activity defaulted `VITE_HUB_URL` to `https://api.tiltcheck.me` (REST host, not the Activity Socket.IO surface). **`transports: ['websocket']`-only** also breaks some Discord / mobile webviews.

## Fixes

- **18s handshake ceiling** around full Discord auth in `apps/degens-activity/src/sdk.ts`, `apps/tiltcheck-activity/src/sdk.ts`, and `apps/activity/src/sdk/DiscordBridge.ts` — on timeout, existing `catch` paths fall through to demo mode so the shell mounts.
- **Degens** `relay.ts`: `resolveArenaUrl()` — prod fallback **`https://game-arena.tiltcheck.me`**; dev `window.location.origin` (Vite `/socket.io` proxy); **`polling` before `websocket`**.
- **TiltCheck session** `relay.ts`: `resolveHubUrl()` — prod fallback `https://activity.tiltcheck.me`; same transport order; dev uses origin for proxy.
- **HubRelay** (`apps/activity`): polling + websocket.
- **`main.ts`**: skeleton + guarded `#status` and view roots on both mini activities.
- **`docs/DEPLOY.md`**: **Degens second Railway service** checklist (split from `activity.tiltcheck.me`), `VITE_*` table, CORS note, optional nginx proxy vs direct `VITE_ARENA_URL`; public routing + inventory row updates; **`docs/TRAINING-MANUAL.md`** env row.
- **Game-arena** CORS allowlists include **`https://game-arena.tiltcheck.me`**.

## Verification

- `pnpm exec tsc --noEmit` in `apps/degens-activity`, `apps/tiltcheck-activity`, `apps/activity`
- `pnpm test:e2e:degens-trivia`

## Rollback

Revert transport / URL resolver changes if a specific CDN host must pin a different ingress; revert handshake timeouts only if Discord auth latency can exceed ~18s in production (unlikely).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TIL-17](https://linear.app/tiltcheck/issue/TIL-17/live-trivia-test-real-time-multiplayer)

<div><a href="https://cursor.com/agents/bc-32ae1035-62cd-46b7-b886-06d7e7b40e8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32ae1035-62cd-46b7-b886-06d7e7b40e8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

