### PR TITLE
feat(chrome-extension): Core/Pro split, guards UI, and hardened risk scoring

### DIFF
--- a/apps/chrome-extension/build.js
+++ b/apps/chrome-extension/build.js
@@ -73,7 +73,7 @@ async function build() {
     minify: true,
   });
 
-  // Build content script
+  // Build content script (Core + dynamic import of Pro monolith; keeps content.js small)
   await esbuild.build({
     entryPoints: [path.join(__dirname, 'src/content.ts')],
     bundle: true,
@@ -84,6 +84,28 @@ async function build() {
     sourcemap: true,
     minify: false,
     plugins: [],
+    alias: {
+      crypto: 'crypto-browserify',
+      stream: 'stream-browserify',
+      vm: 'vm-browserify',
+      buffer: 'buffer',
+    },
+    define: {
+      global: 'window',
+      process: '{"env":{}}',
+    },
+  });
+
+  // Pro monolith — full sidebar, extractor, fairness, telemetry (loaded when storage flag is on)
+  await esbuild.build({
+    entryPoints: [path.join(__dirname, 'src/pro-monolith-bootstrap.ts')],
+    bundle: true,
+    outfile: path.join(__dirname, 'dist/pro-monolith-bootstrap.js'),
+    format: 'esm',
+    platform: 'browser',
+    target: 'chrome100',
+    sourcemap: true,
+    minify: false,
     alias: {
       crypto: 'crypto-browserify',
       stream: 'stream-browserify',

--- a/apps/chrome-extension/docs/development.md
+++ b/apps/chrome-extension/docs/development.md
@@ -84,19 +84,53 @@ pnpm -C apps/chrome-extension build
 
 ### content.ts
 
-Main content script. Runs on every page (minus excluded domains). Responsibilities:
+Slim **core** content script. Runs on supported casino origins (see manifest). Responsibilities:
 
 - Early exit for excluded domains (discord.com, API auth routes, localhost dev ports).
-- Initializes `CasinoDataExtractor`, `TiltDetector`, `CasinoLicenseVerifier`, `FairnessService`, and `GameBlocker`.
-- Manages the sidebar lifecycle.
-- Handles `WalletBridge` and `SolanaProvider` injection.
-- Listens for messages from `background.js`.
+- **Always-on core circuit breaker** — single capture-phase `click` listener on `document` for velocity; 2s poll; `triggerTouchGrassTimeout` from `core-options.ts` keys only.
+- Reads `chrome.storage.local['tiltcheck_pro_monolith_enabled']`.
+  - When **`true`**: lazy-imports `pro-monolith-bootstrap.js` and runs `startProMonolith()` in addition to core (does not replace core).
+  - When flag flips **`false`**: calls `deactivateProMonolith()` — disconnects Pro observers/WebSocket paths, removes Pro UI roots; **does not** remove `#tiltcheck-lockdown-root` (core-owned).
+- Core options refresh only on `CORE_CIRCUIT_BREAKER_STORAGE_KEYS` changes (Pro/popup must not write those keys mid-session except via popup).
+- Sets `window.__tiltcheckCoreShieldActive` so Pro skips duplicate Touch Grass at risk ≥ 80.
 
-`GameBlocker` is initialized after the user session resolves. If no Discord session is present, the blocker is skipped silently.
+### pro-monolith-bootstrap.ts
+
+Former monolith logic from `content.ts`. Built to `dist/pro-monolith-bootstrap.js` (ESM). Exports `startProMonolith()` / `deactivateProMonolith()`. `LocalGameBlocker` and fairness bet-button observers ignore mutations inside safety roots (`pro/containment.ts`: lockdown overlay, local block overlay, sidebar, etc.).
+
+### touch-grass-timeout.ts
+
+Fullscreen **Touch Grass Timeout** overlay (~120s), no dismiss controls, paired with `blockBettingUI`. Used by core and Pro (`triggerEmergencyStop` replaced by this flow). Timer uses `aria-live="polite"`; forensic ticker is static (`aria-live="off"`) inside a region labeled for 20s updates.
+
+### core-options.ts
+
+`chrome.storage.local` keys for the core circuit breaker (popup/options should write after explicit opt-in):
+
+- `tiltcheck_risk_profile` — `conservative` (μ=1.2), `moderate` (1.0), `degen` (0.8); falls back to legacy `riskLevel` if unset.
+
+### tilt-detector.ts (Core scoring)
+
+`getTiltRiskScore()` combines indicator composite (capped), continuous micro-pacing (`last_click_delta_ms` trend under ~500ms), and exponential loss-streak compound when both co-occur (`consecutiveLosses > 3` + hot pacing). Core `content.ts` polls every 2s against `tiltcheck_risk_threshold`.
+
+| Key | Default | Notes |
+| :--- | :--- | :--- |
+| `tiltcheck_risk_threshold` | `85` | Clamped 50–100 |
+| `tiltcheck_touch_grass_duration_ms` | `120000` | Clamped 30s–10m |
+| `tiltcheck_touch_grass_cooldown_ms` | duration + 5s | Must exceed lockout to avoid re-fire |
+| `tiltcheck_touch_grass_opt_in` | unset = on | Set `false` to disable core enforcement; popup should require policy ack before `true` |
 
 ### game-blocker.ts
 
-Enforces the user's Surgical Self-Exclusion list at the DOM level. See [docs/surgical-self-exclusion.md](surgical-self-exclusion.md) for the full reference.
+Enforces the user's Surgical Self-Exclusion list at the DOM level (API-backed `ForbiddenGamesProfile`). See [docs/surgical-self-exclusion.md](surgical-self-exclusion.md) for the full reference.
+
+### pro/local-game-blocker.ts (Pro only)
+
+**Strategic filter** — persistent local blocklist via `tiltcheck_blocked_games` (`string[]` slugs, e.g. `plinko`, `mines`). Loaded only from `pro-monolith-bootstrap.js`:
+
+- **URL hard-stop** — full-page overlay before the game client loads.
+- **DOM redaction** — MutationObserver replaces matching lobby cards with `[ GAME EXCLUDED ]`.
+
+Schema helpers: `pro/blocked-games-options.ts`. No network; does not touch core click-velocity logic.
 
 Key internals:
 

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -74,6 +74,9 @@ import { triggerTouchGrassTimeout } from './touch-grass-timeout.js';
 
 export const TILTCHECK_PRO_MONOLITH_KEY = 'tiltcheck_pro_monolith_enabled';
 
+/** Pro dispatches bet rounds so Core tilt scoring includes loss-streak signals. */
+export const TILTCHECK_CORE_RECORD_BET_EVENT = 'tiltcheck-core-record-bet';
+
 
 
 type ProMonolithModule = {
@@ -282,7 +285,13 @@ async function startCoreCircuitBreaker(): Promise<void> {
 
   document.addEventListener('click', coreClickListener, true);
 
-
+  window.addEventListener(TILTCHECK_CORE_RECORD_BET_EVENT, (event) => {
+    const detail = (event as CustomEvent<{ bet?: number; payout?: number }>).detail;
+    const bet = Number(detail?.bet);
+    const payout = Number(detail?.payout);
+    if (!tiltDetector || !Number.isFinite(bet)) return;
+    tiltDetector.recordBet(bet, Number.isFinite(payout) ? payout : 0);
+  });
 
   corePoll = window.setInterval(() => {
 
@@ -408,9 +417,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
       });
 
-      break;
-
-
+      return true;
 
     case 'get_sidebar_state':
 
@@ -426,19 +433,13 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
       });
 
-      break;
-
-
+      return true;
 
     default:
 
-      sendResponse({ error: 'Unknown message type' });
+      return false;
 
   }
-
-
-
-  return true;
 
 });
 

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -1,1944 +1,453 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-08 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+
+
 
 /**
- * Enhanced Content Script - TiltCheck + License Verification
- * 
- * Monitors:
- * - Casino license legitimacy
- * - Tilt indicators (rage betting, chasing losses, etc.)
- * - RTP/fairness analysis
- * 
- * Provides:
- * - Real-time interventions
- * - Vault recommendations
- * - Real-world spending reminders
+
+ * Core content script — always-on TiltDetector + Touch Grass circuit breaker.
+
+ * Pro monolith (sidebar, extractor, strategic filters) lazy-loads when
+
+ * `tiltcheck_pro_monolith_enabled === true` and tears down on flag off.
+
  */
 
-/**
- * Check if hostname matches a domain (handles subdomains correctly)
- */
+
+
 function isDomain(hostname: string, domain: string): boolean {
-  // Exact match or subdomain match (e.g., "www.discord.com" matches "discord.com")
+
   return hostname === domain || hostname.endsWith('.' + domain);
+
 }
 
-// Early exit if on Discord or localhost API - BEFORE any imports or code runs
+
+
 const hostname = window.location.hostname.toLowerCase();
+
 const pathname = window.location.pathname.toLowerCase();
+
 const isDiscordAuthRoute = pathname.startsWith('/auth/discord');
 
+
+
 const isExcludedDomain =
+
   isDomain(hostname, 'discord.com') ||
+
   (hostname === 'localhost' && window.location.port === '3333') ||
+
   (hostname === 'localhost' && window.location.port === '3001' && isDiscordAuthRoute) ||
+
   (isDomain(hostname, 'api.tiltcheck.me') && isDiscordAuthRoute);
 
+
+
 if (isExcludedDomain) {
-  if (process.env.NODE_ENV !== 'production') console.log('[TiltCheck] Skipping - excluded domain:', hostname);
+
+  if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
+
+    console.log('[TiltCheck] Skipping - excluded domain:', hostname);
+
+  }
+
 }
 
-// Only import and run on allowed casino sites
-import { CasinoDataExtractor, AnalyzerClient, SpinEvent } from './extractor.js';
+
+
 import { TiltDetector } from './tilt-detector.js';
-import { CasinoLicenseVerifier, getAnalysisBlockMessage } from './license-verifier.js';
-import { updateMobileLicenseHud } from './mobile-license-hud.js';
-import { initSidebar } from './sidebar/index.js';
-import { SidebarUI } from './sidebar/types.js';
-import { INJECTION_DISABLED_KEY } from './sidebar/constants.js';
-import { Analyzer } from './analyzer.js';
-import { FairnessService } from './FairnessService.js';
-import { postRoundTelemetry, postWinSecureTelemetry } from './telemetry-client.js';
-import { GameBlocker } from './game-blocker.js';
-import type { CasinoVerification } from './license-verifier.js';
+
 import {
-  attachMarketingSiteStorageListener,
-  syncMarketingSiteTokenFromExtensionStorage,
-} from './web-app-session-sync.js';
 
-interface StoredUserData {
-  id?: string;
-  discordId?: string;
-}
+  CORE_CIRCUIT_BREAKER_STORAGE_KEYS,
 
-interface UserStorageSnapshot {
-  userData?: StoredUserData;
-  tiltguard_user_id?: string;
-}
+  loadCoreCircuitBreakerOptions,
 
-interface CooldownInterventionData {
-  duration: number;
-}
+  type CoreCircuitBreakerOptions,
 
-interface VaultPromptData {
-  suggestedAmount: number;
-}
+} from './core-options.js';
 
-interface SpendingReminderData {
-  message: string;
-  cost: number;
-}
+import { triggerTouchGrassTimeout } from './touch-grass-timeout.js';
 
-interface StopLossData {
-  reason: string;
-}
 
-interface RedeemNudgeData {
-  message: string;
-  amount: number;
-}
 
-type RuntimeIntervention =
-  | { type: 'cooldown'; data: CooldownInterventionData }
-  | { type: 'vault_balance'; data: VaultPromptData }
-  | { type: 'spending_reminder'; data: { realWorldComparison: SpendingReminderData } }
-  | { type: 'stop_loss_triggered'; data: StopLossData }
-  | { type: 'phone_friend'; data?: Record<string, unknown> }
-  | { type: 'session_break'; data?: Record<string, unknown> }
-  | { type: 'redeem_nudge'; data: RedeemNudgeData };
+/** When `true`, loads the legacy full extension (`pro-monolith-bootstrap.js`). */
 
-type FairnessSpinData = SpinEvent & {
-  rows?: number | null;
-  hash?: string | null;
+export const TILTCHECK_PRO_MONOLITH_KEY = 'tiltcheck_pro_monolith_enabled';
+
+
+
+type ProMonolithModule = {
+
+  startProMonolith: () => Promise<void>;
+
+  deactivateProMonolith: () => void;
+
 };
 
-interface FairnessCommitment {
-  blockHash?: string;
-  discordId: string;
-  clientSeed: string;
-  timestamp: number;
-}
 
-type SidebarStatsUpdate = {
-  startTime: number;
-  totalBets: number;
-  totalWagered: number;
-  totalWon: number;
-};
 
-type TiltCheckWindow = Window & {
-  TiltCheckSidebar?: {
-    updateStats?: (stats: SidebarStatsUpdate) => void;
-  };
-};
+type TiltCheckWindow = Window & { __tiltcheckCoreShieldActive?: boolean };
 
-// Configuration
-const ANALYZER_WS_URL = 'wss://api.tiltcheck.me/analyzer';
 
-// State
-let extractor: CasinoDataExtractor | null = null;
+
 let tiltDetector: TiltDetector | null = null;
-let licenseVerifier: CasinoLicenseVerifier | null = null;
-let client: AnalyzerClient | null = null;
-let sessionId: string | null = null;
-let stopObserving: (() => void) | null = null;
-let isMonitoring = false;
-let casinoVerification: CasinoVerification | null = null;
-let analyzer: Analyzer | null = null;
-let fairness: FairnessService | null = null;
-let tiltMonitoringInterval: ReturnType<typeof setInterval> | null = null;
-let sidebar: SidebarUI | null = null;
-let gameBlocker: GameBlocker | null = null;
-let analysisRuntimeReady = false;
-let initializationComplete = false;
-let runtimeBootPromise: Promise<void> | null = null;
-let runtimeListenersAttached = false;
-let spaResumeWatchInstalled = false;
-let injectionDisabled = false;
-let lastAnalysisBlockMessage: string | null = null;
-const FULL_SIDEBAR_WIDTH = 340;
-const MINIMIZED_SIDEBAR_WIDTH = 40;
-const SIDEBAR_VISIBILITY_KEY = 'tiltcheck_sidebar_visible';
-const SITE_REDEEM_THRESHOLDS_KEY = 'tiltcheck_site_thresholds';
-const SUPPORT_INTERVENTION_COOLDOWN_MS = 10 * 60 * 1000;
 
-// Intervention state
-let cooldownEndTime: number | null = null;
-let lastRedeemNudgeBalance: number | null = null;
-let lastRedeemNudgeThreshold = 0;
-const lastSupportInterventionByType: Record<string, number> = {};
+let corePoll: ReturnType<typeof setInterval> | null = null;
 
-function normalizeInterventionData(data: unknown): Record<string, unknown> {
-  if (!data || typeof data !== 'object' || Array.isArray(data)) {
-    return {};
-  }
+let coreClickListener: (() => void) | null = null;
 
-  return data as Record<string, unknown>;
-}
+let touchGrassCooldownUntil = 0;
 
-function isFairnessCommitment(value: unknown): value is FairnessCommitment {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return false;
-  }
+let coreOptions: CoreCircuitBreakerOptions | null = null;
 
-  const record = value as Record<string, unknown>;
-  return typeof record.discordId === 'string'
-    && typeof record.clientSeed === 'string'
-    && typeof record.timestamp === 'number';
-}
+let proModulePromise: Promise<ProMonolithModule> | null = null;
 
-function normalizeSiteHost(value: string): string {
-  return value.replace(/^www\./, '').toLowerCase();
-}
+let proActive = false;
 
-function getStoredSiteRedeemThresholds(value: unknown): Record<string, number> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return {};
-  }
 
-  const thresholds: Record<string, number> = {};
-  for (const [host, rawValue] of Object.entries(value as Record<string, unknown>)) {
-    const threshold = Number(rawValue);
-    if (Number.isFinite(threshold) && threshold > 0) {
-      thresholds[normalizeSiteHost(host)] = threshold;
-    }
-  }
 
-  return thresholds;
-}
+async function waitForDocumentEnd(): Promise<void> {
 
-function shouldShowRedeemNudge(data: { amount: number; threshold: number }): boolean {
-  if (document.getElementById('tiltcheck-redeem-nudge')) return false;
-
-  const threshold = Number(data.threshold) || 0;
-  if (threshold <= 0) return false;
-
-  const amount = Number(data.amount) || 0;
-  const thresholdChanged = threshold !== lastRedeemNudgeThreshold;
-  // Re-fire if this is the first nudge (null), threshold changed, or a meaningful gain occurred.
-  const meaningfulGain = lastRedeemNudgeBalance !== null &&
-    amount >= lastRedeemNudgeBalance + Math.max(5, threshold * 0.1);
-
-  if (thresholdChanged || lastRedeemNudgeBalance === null || meaningfulGain) {
-    lastRedeemNudgeThreshold = threshold;
-    lastRedeemNudgeBalance = amount;
-    return true;
-  }
-
-  return false;
-}
-
-function refreshLicenseVerification() {
-  if (!licenseVerifier) {
-    licenseVerifier = new CasinoLicenseVerifier();
-  }
-  casinoVerification = licenseVerifier.verifyCasino();
-  sidebar?.updateLicense(casinoVerification);
-  updateMobileLicenseHud(casinoVerification);
-  if (initializationComplete) {
-    applyAnalysisGate(casinoVerification);
-  }
-  return casinoVerification;
-}
-
-function ensureAnalysisRuntime() {
-  if (analysisRuntimeReady) {
-    return;
-  }
-
-  analyzer = new Analyzer();
-  fairness = new FairnessService();
-  setupFairnessListeners();
-  analysisRuntimeReady = true;
-}
-
-function applyAnalysisGate(verification: CasinoVerification) {
-  const blockMessage = getAnalysisBlockMessage(verification);
-  if (!blockMessage) {
-    lastAnalysisBlockMessage = null;
-
-    if (!analysisRuntimeReady) {
-      ensureAnalysisRuntime();
-    }
-
-    if (!isMonitoring) {
-      void startMonitoring().catch((err) => {
-        console.warn('[TiltCheck] Auto-start monitoring failed:', err);
-      });
-    }
-
-    return;
-  }
-
-  if (isMonitoring) {
-    _stopMonitoring();
-  } else {
-    sidebar?.updateRealityCheck(false);
-  }
-
-  const statusType = verification.verdict === 'suspicious' ? 'danger' : 'warning';
-  sidebar?.updateStatus(blockMessage, statusType);
-  if (lastAnalysisBlockMessage !== blockMessage) {
-    sidebar?.addFeedMessage(blockMessage);
-    lastAnalysisBlockMessage = blockMessage;
-  }
-}
-
-function notifySupportIntervention(type: string, data: Record<string, unknown>): boolean {
-  const lastSentAt = lastSupportInterventionByType[type] || 0;
-  if (Date.now() - lastSentAt < SUPPORT_INTERVENTION_COOLDOWN_MS) {
-    return false;
-  }
-
-  lastSupportInterventionByType[type] = Date.now();
-  sidebar?.notifyBuddy('intervention', { type, data });
-  return true;
-}
-
-function setSidebarVisibility(visible: boolean): boolean {
-  const sidebar = document.getElementById('tiltcheck-sidebar');
-  if (!sidebar) return false;
-  sidebar.style.display = visible ? 'block' : 'none';
-  return visible;
-}
-
-function persistSidebarVisibility(visible: boolean) {
-  try {
-    chrome.storage.local.set({ [SIDEBAR_VISIBILITY_KEY]: visible });
-  } catch {
-    // Ignore persistence failures; UI still works in-memory.
-  }
-}
-
-async function restoreSidebarVisibility(defaultVisible: boolean) {
-  try {
-    const stored = await chrome.storage.local.get([SIDEBAR_VISIBILITY_KEY]);
-    if (typeof stored[SIDEBAR_VISIBILITY_KEY] === 'boolean') {
-      setSidebarVisibility(stored[SIDEBAR_VISIBILITY_KEY]);
-      return;
-    }
-  } catch {
-    // Fall back to default visibility.
-  }
-  setSidebarVisibility(defaultVisible);
-}
-
-function toggleSidebarVisibility(): boolean {
-  const sidebarEl = document.getElementById('tiltcheck-sidebar');
-  if (!sidebarEl) {
-    sidebar = initSidebar(disableInjectionFromHud);
-    if (sidebar) persistSidebarVisibility(true);
-    return !!sidebar;
-  }
-  const currentlyVisible = sidebarEl.style.display !== 'none';
-  const visible = setSidebarVisibility(!currentlyVisible);
-  persistSidebarVisibility(visible);
-  return visible;
-}
-
-function getSidebarState() {
-  const sidebar = document.getElementById('tiltcheck-sidebar');
-  return {
-    exists: !!sidebar,
-    visible: !!sidebar && sidebar.style.display !== 'none',
-    injectionDisabled,
-  };
-}
-
-async function getStoredInjectionDisabled(): Promise<boolean> {
-  try {
-    const stored = await chrome.storage.local.get([INJECTION_DISABLED_KEY]);
-    return stored[INJECTION_DISABLED_KEY] === true;
-  } catch {
-    return false;
-  }
-}
-
-async function setInjectionDisabled(disabled: boolean): Promise<void> {
-  injectionDisabled = disabled;
-  try {
-    await chrome.storage.local.set({ [INJECTION_DISABLED_KEY]: disabled });
-  } catch {
-    // In-memory state still protects this page when extension storage is unavailable.
-  }
-}
-
-function waitForDocumentEnd(): Promise<void> {
   if (document.readyState !== 'loading' && document.body) {
-    return Promise.resolve();
+
+    return;
+
   }
 
-  return new Promise((resolve) => {
+
+
+  await new Promise<void>((resolve) => {
+
     const resolveWhenReady = () => {
+
       if (document.body) {
+
         document.removeEventListener('DOMContentLoaded', resolveWhenReady);
+
         resolve();
+
       }
+
     };
+
     document.addEventListener('DOMContentLoaded', resolveWhenReady, { once: true });
+
     setTimeout(resolveWhenReady, 0);
-  });
-}
 
-function teardownInjectedRuntime(): void {
-  if (isMonitoring) {
-    _stopMonitoring();
-  }
-
-  gameBlocker?.destroy();
-  gameBlocker = null;
-  extractor = null;
-  tiltDetector = null;
-  casinoVerification = null;
-  sessionId = null;
-  initializationComplete = false;
-  lastAnalysisBlockMessage = null;
-
-  document.getElementById('tiltcheck-sidebar')?.remove();
-  document.getElementById('tiltcheck-game-block-overlay')?.remove();
-  document.getElementById('tiltcheck-redeem-nudge')?.remove();
-  sidebar = null;
-}
-
-async function disableInjectionFromHud(): Promise<void> {
-  await setInjectionDisabled(true);
-  teardownInjectedRuntime();
-}
-
-async function resumeRuntimeAfterNavigation(source: string): Promise<void> {
-  if (isExcludedDomain || injectionDisabled) {
-    return;
-  }
-
-  if (!initializationComplete) {
-    await startRuntimeAtDocumentEnd();
-    return;
-  }
-
-  if (!document.getElementById('tiltcheck-sidebar')) {
-    sidebar = initSidebar(disableInjectionFromHud);
-    const defaultVisible = !isDomain(hostname, 'tiltcheck.me');
-    void restoreSidebarVisibility(defaultVisible);
-  }
-
-  syncMarketingSiteTokenFromExtensionStorage();
-  attachMarketingSiteStorageListener();
-  const verification = refreshLicenseVerification();
-  applyAnalysisGate(verification);
-  gameBlocker?.resume(source);
-}
-
-function installSpaResumeWatch(): void {
-  if (spaResumeWatchInstalled) {
-    return;
-  }
-
-  spaResumeWatchInstalled = true;
-  let lastUrl = window.location.href;
-  let pending = false;
-
-  const queueResume = (source: string) => {
-    if (pending) {
-      return;
-    }
-
-    pending = true;
-    queueMicrotask(() => {
-      pending = false;
-      const currentUrl = window.location.href;
-      if (currentUrl === lastUrl && source !== 'pageshow') {
-        return;
-      }
-      lastUrl = currentUrl;
-      void resumeRuntimeAfterNavigation(source);
-    });
-  };
-
-  const patchHistoryMethod = (method: 'pushState' | 'replaceState') => {
-    const original = window.history[method] as (...args: unknown[]) => unknown;
-    if ((original as { __tiltcheckPatched?: boolean }).__tiltcheckPatched) {
-      return;
-    }
-
-    const patched = function patchedHistoryMethod(this: History, ...args: unknown[]) {
-      const result = original.apply(this, args);
-      queueResume(method);
-      return result;
-    };
-    Object.defineProperty(patched, '__tiltcheckPatched', { value: true });
-    window.history[method] = patched as typeof window.history[typeof method];
-  };
-
-  patchHistoryMethod('pushState');
-  patchHistoryMethod('replaceState');
-  window.addEventListener('popstate', () => queueResume('popstate'));
-  window.addEventListener('hashchange', () => queueResume('hashchange'));
-  window.addEventListener('pageshow', () => queueResume('pageshow'));
-}
-
-async function startRuntimeAtDocumentEnd(options: { forceEnable?: boolean } = {}): Promise<void> {
-  if (isExcludedDomain) {
-    return;
-  }
-
-  if (runtimeBootPromise) {
-    await runtimeBootPromise;
-    return;
-  }
-
-  runtimeBootPromise = (async () => {
-    await waitForDocumentEnd();
-    installSpaResumeWatch();
-
-    if (options.forceEnable) {
-      await setInjectionDisabled(false);
-    } else {
-      injectionDisabled = await getStoredInjectionDisabled();
-    }
-
-    if (injectionDisabled) {
-      teardownInjectedRuntime();
-      return;
-    }
-
-    initialize();
-  })().finally(() => {
-    runtimeBootPromise = null;
   });
 
-  await runtimeBootPromise;
 }
 
-async function openRuntimeFromToolbar(): Promise<{ success: true; visible: boolean; injectionDisabled: boolean }> {
-  if (injectionDisabled || await getStoredInjectionDisabled()) {
-    await startRuntimeAtDocumentEnd({ forceEnable: true });
-    const sidebarEl = document.getElementById('tiltcheck-sidebar');
-    if (!sidebarEl) {
-      sidebar = initSidebar(disableInjectionFromHud);
-    }
-    const visible = setSidebarVisibility(true);
-    persistSidebarVisibility(true);
-    return { success: true, visible, injectionDisabled: false };
-  }
 
-  const visible = toggleSidebarVisibility();
-  return { success: true, visible, injectionDisabled: false };
-}
 
-/**
- * Visual Picker for selecting elements
- */
-class VisualPicker {
-  private overlay: HTMLElement | null = null;
-  private active = false;
-  private callback: ((selector: string) => void) | null = null;
-
-  start(callback: (selector: string) => void) {
-    if (this.active) return;
-    this.active = true;
-    this.callback = callback;
-
-    // Create overlay for highlighting
-    this.overlay = document.createElement('div');
-    this.overlay.style.cssText = `
-      position: fixed;
-      pointer-events: none;
-      background: rgba(0, 255, 136, 0.2);
-      border: 2px solid #00ff88;
-      z-index: 2147483647;
-      transition: all 0.1s;
-      display: none;
-      border-radius: 4px;
-    `;
-    document.body.appendChild(this.overlay);
-
-    document.addEventListener('mousemove', this.onHover, true);
-    document.addEventListener('click', this.onClick, true);
-    document.body.style.cursor = 'crosshair';
-  }
-
-  stop() {
-    this.active = false;
-    this.callback = null;
-    if (this.overlay) this.overlay.remove();
-    document.removeEventListener('mousemove', this.onHover, true);
-    document.removeEventListener('click', this.onClick, true);
-    document.body.style.cursor = '';
-  }
-
-  private onHover = (e: MouseEvent) => {
-    if (!this.overlay) return;
-    const target = e.target as HTMLElement;
-    if (target === this.overlay || target.closest('#tiltcheck-sidebar')) return;
-
-    const rect = target.getBoundingClientRect();
-    this.overlay.style.display = 'block';
-    this.overlay.style.top = rect.top + 'px';
-    this.overlay.style.left = rect.left + 'px';
-    this.overlay.style.width = rect.width + 'px';
-    this.overlay.style.height = rect.height + 'px';
-  }
-
-  private onClick = (e: MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    const target = e.target as HTMLElement;
-    if (target.closest('#tiltcheck-sidebar')) return;
-
-    const selector = this.generateSelector(target);
-    if (this.callback) this.callback(selector);
-    this.stop();
-  }
-
-  private generateSelector(el: HTMLElement): string {
-    // 1. ID (if valid and unique)
-    if (el.id && /^[a-z][a-z0-9_-]*$/i.test(el.id) && document.querySelectorAll(`#${el.id}`).length === 1) {
-      return `#${el.id}`;
-    }
-
-    // 2. Data Attributes (High priority for testing/scraping)
-    const dataAttrs = ['data-test', 'data-testid', 'data-qa', 'data-automation-id'];
-    for (const attr of dataAttrs) {
-      if (el.hasAttribute(attr)) {
-        return `[${attr}="${el.getAttribute(attr)}"]`;
-      }
-    }
-
-    // 3. Unique Class Combination
-    if (el.className && typeof el.className === 'string') {
-      const classes = el.className.trim().split(/\s+/).filter(c => c && !c.includes(':'));
-      if (classes.length > 0) {
-        // Try single classes
-        for (const cls of classes) {
-          if (document.querySelectorAll(`.${cls}`).length === 1) return `.${cls}`;
-        }
-      }
-    }
-
-    // 4. Fallback: Path with nth-of-type
-    const path: string[] = [];
-    let current: HTMLElement | null = el;
-
-    while (current && current !== document.body && current !== document.documentElement) {
-      let selector = current.tagName.toLowerCase();
-
-      if (current.id && /^[a-z][a-z0-9_-]*$/i.test(current.id)) {
-        selector = `#${current.id}`;
-        path.unshift(selector);
-        break; // Stop at ID
-      } else {
-        // Calculate nth-of-type
-        let sibling = current;
-        let nth = 1;
-        while (sibling.previousElementSibling) {
-          sibling = sibling.previousElementSibling as HTMLElement;
-          if (sibling.tagName === current.tagName) nth++;
-        }
-
-        if (nth > 1) selector += `:nth-of-type(${nth})`;
-      }
-
-      path.unshift(selector);
-      current = current.parentElement;
-    }
-
-    return path.join(' > ');
-  }
-}
-
-/**
- * Highlighter for testing selectors
- */
-class Highlighter {
-  private overlay: HTMLElement | null = null;
-
-  highlight(selector: string) {
-    this.clear();
-    try {
-      const el = document.querySelector(selector) as HTMLElement;
-      if (!el) {
-        console.warn('[TiltCheck] Element not found for highlighting');
-        return;
-      }
-
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-
-      const rect = el.getBoundingClientRect();
-      this.overlay = document.createElement('div');
-      this.overlay.style.cssText = `
-        position: fixed;
-        top: ${rect.top}px;
-        left: ${rect.left}px;
-        width: ${rect.width}px;
-        height: ${rect.height}px;
-        background: rgba(0, 255, 136, 0.2);
-        border: 2px solid #00ff88;
-        z-index: 2147483647;
-        pointer-events: none;
-        transition: all 0.3s;
-        border-radius: 4px;
-        box-shadow: 0 0 15px rgba(0, 255, 136, 0.4);
-      `;
-      document.body.appendChild(this.overlay);
-
-      // Remove after 2 seconds
-      setTimeout(() => this.clear(), 2000);
-
-    } catch (e) {
-      console.error('Invalid selector', e);
-    }
-  }
-
-  clear() {
-    if (this.overlay) {
-      this.overlay.remove();
-      this.overlay = null;
-    }
-  }
-}
-
-/**
- * Initialize on page load
- */
-function initialize() {
-  if (initializationComplete) {
-    return;
-  }
-
-  if (process.env.NODE_ENV !== 'production') console.log('[TiltCheck] Initializing on:', window.location.hostname);
-
-  syncMarketingSiteTokenFromExtensionStorage();
-  attachMarketingSiteStorageListener();
-
-  // Create sidebar UI
-  sidebar = initSidebar(disableInjectionFromHud);
-  // Default hidden on TiltCheck-owned pages, visible on supported casino pages.
-  const defaultVisible = !isDomain(hostname, 'tiltcheck.me');
-  void restoreSidebarVisibility(defaultVisible);
-  if (process.env.NODE_ENV !== 'production') console.log('[TiltCheck] Sidebar created:', !!sidebar);
-
-  updateMobileLicenseHud(null);
-
-  // Check casino license from footer/legal sections and refresh after delayed page content loads.
-  const initialLicenseStatus = refreshLicenseVerification();
-  if (process.env.NODE_ENV !== 'production') console.log('[TiltCheck] License verification:', initialLicenseStatus);
-  setTimeout(() => refreshLicenseVerification(), 3000);
-  setTimeout(() => refreshLicenseVerification(), 8000);
-
-  if (!runtimeListenersAttached) {
-    runtimeListenersAttached = true;
-
-    // Setup Visual Picker Listener
-    const picker = new VisualPicker();
-    window.addEventListener('tg-start-picker', ((e: CustomEvent) => {
-      picker.start((selector) => {
-        // Send result back to sidebar via event
-        window.dispatchEvent(new CustomEvent('tg-picker-result', { detail: { field: e.detail.field, selector } }));
-      });
-    }) as EventListener);
-
-    // Setup Highlighter Listener
-    const highlighter = new Highlighter();
-    window.addEventListener('tg-test-selector', ((e: CustomEvent) => {
-      highlighter.highlight(e.detail.selector);
-    }) as EventListener);
-
-    window.addEventListener('tg-redeem-threshold-updated', ((e: CustomEvent<{ hostname?: string; threshold?: number }>) => {
-      if (!tiltDetector) return;
-
-      const updatedHost = normalizeSiteHost(e.detail?.hostname || '');
-      if (updatedHost && updatedHost !== normalizeSiteHost(window.location.hostname)) {
-        return;
-      }
-
-      const threshold = Number(e.detail?.threshold) || 0;
-      tiltDetector.setRedeemThreshold(threshold > 0 ? threshold : null);
-      lastRedeemNudgeBalance = 0;
-      lastRedeemNudgeThreshold = 0;
-    }) as EventListener);
-
-    // Setup Fairness Calculator Listener
-    window.addEventListener('tg-calc-fairness', (async (e: CustomEvent) => {
-      if (!fairness) return;
-      const { serverSeed, clientSeed, nonce } = e.detail;
-      try {
-        const hash = await fairness.verifyCasinoResult(serverSeed, clientSeed, parseInt(nonce));
-        const float = fairness.hashToFloat(hash);
-
-        window.dispatchEvent(new CustomEvent('tg-fairness-result', {
-          detail: {
-            hash,
-            float,
-            dice: fairness.getDiceResult(float),
-            limbo: fairness.getLimboResult(float)
-          }
-        }));
-      } catch (err) {
-        console.error('Fairness calc error', err);
-      }
-    }) as EventListener);
-  }
-
-  initializationComplete = true;
-  applyAnalysisGate(initialLicenseStatus);
-
-  // Surgical Self-Exclusion: init game blocker after a tick so auth storage is ready.
-  setTimeout(() => {
-    Promise.all([
-      getLinkedDiscordId(),
-      chrome.storage.local.get(['authToken']),
-    ]).then(([discordId, authState]) => {
-      const authToken = typeof authState.authToken === 'string' ? authState.authToken : '';
-      if (!discordId || !authToken) {
-        return;
-      }
-
-      gameBlocker = new GameBlocker(discordId, authToken);
-      gameBlocker.init().catch((err) => {
-        console.warn('[TiltCheck] Game blocker init failed:', err);
-      });
-    }).catch(() => {
-      // No linked Discord session — skip blocker silently
-    });
-  }, 500);
-
-}
-
-/**
- * Start monitoring
- */
-async function startMonitoring() {
-  if (isMonitoring) return;
-
-  console.log('[TiltCheck] Starting monitoring...');
-
-  const verification = casinoVerification ?? refreshLicenseVerification();
-  const blockMessage = getAnalysisBlockMessage(verification);
-  if (blockMessage) {
-    sidebar?.updateRealityCheck(false);
-    sidebar?.updateStatus(blockMessage, verification?.verdict === 'suspicious' ? 'danger' : 'warning');
-    return;
-  }
-
-  // Update UI
-  sidebar?.updateRealityCheck(true);
-  isMonitoring = true;
-
-  // Get initial balance
-  extractor = new CasinoDataExtractor();
-  await extractor.initialize();
-  const initialBalance = extractor.extractBalance();
-
-  peakBalance = typeof initialBalance === 'number' ? initialBalance : 0;
-  zeroTriggered = false;
-  fumbleStrikes = 0;
-
-  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Initial balance:', initialBalance);
-
-  // Get risk level, redeem threshold, and auth token from storage
-  const storageResult = await chrome.storage.local.get(['riskLevel', 'redeemThreshold', 'authToken', SITE_REDEEM_THRESHOLDS_KEY]);
-  const riskLevel = (storageResult.riskLevel as 'conservative' | 'moderate' | 'degen') || 'moderate';
-  const siteThresholds = getStoredSiteRedeemThresholds(storageResult[SITE_REDEEM_THRESHOLDS_KEY]);
-  const siteHost = normalizeSiteHost(window.location.hostname);
-  const redeemThreshold = siteThresholds[siteHost] ?? (Number(storageResult.redeemThreshold) || 0);
-  const authToken = storageResult.authToken as string | undefined;
-
-  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Using profile:', { riskLevel, redeemThreshold, hasToken: !!authToken });
-
-  // Initialize tilt detector
-  tiltDetector = new TiltDetector(initialBalance, riskLevel, redeemThreshold);
-
-  if (authToken) {
-    const wsUrlWithAuth = `${ANALYZER_WS_URL}?token=${authToken}`;
-    client = new AnalyzerClient(wsUrlWithAuth, (error) => {
-      // Surface post-open disconnect/reconnect failures to UI and logs.
-      console.warn('[TiltGuard] Analyzer connection issue:', error);
-      sidebar?.updateRealityCheck(false);
-      window.dispatchEvent(
-        new CustomEvent('tg-status-update', {
-          detail: { message: 'Analyzer connection dropped. Reconnecting...', type: 'warning' }
-        })
-      );
-    });
-
-    try {
-      await client.connect();
-      if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Connected to analyzer server');
-      sidebar?.updateRealityCheck(true);
-    } catch {
-      if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Analyzer backend offline - tilt monitoring only');
-    }
-  } else {
-    if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Analyzer disabled until Discord auth is connected');
-    sidebar?.updateRealityCheck(false);
-  }
-
-  // Generate session ID using cryptographically secure random
-  const randomBytes = new Uint32Array(1);
-  crypto.getRandomValues(randomBytes);
-  sessionId = `session_${Date.now()}_${randomBytes[0].toString(36)}`;
-  const userId = await getUserId();
-  const casinoId = detectCasinoId();
-  const gameId = detectGameId();
-
-  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Session started:', { sessionId, userId, casinoId, gameId });
-
-  // Start tilt monitoring
-  startTiltMonitoring();
-
-  // Start observing
-  stopObserving = extractor.startObserving((spinData) => {
-    if (!spinData) return;
-
-    if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Spin detected:', spinData);
-
-    // Check if sessionId is valid before using
-    if (!sessionId) {
-      console.warn('[TiltGuard] Session not started, cannot record spin');
-      return;
-    }
-
-    handleSpinEvent(spinData, { sessionId, userId, casinoId, gameId });
-  });
-
-  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Monitoring started successfully');
-}
-
-/**
- * Stop monitoring
- */
-function _stopMonitoring() {
-  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Stopping monitoring...');
-
-  if (stopObserving) {
-    stopObserving();
-    stopObserving = null;
-  }
-
-  if (client) {
-    client.disconnect();
-    client = null;
-  }
-  if (tiltMonitoringInterval) {
-    clearInterval(tiltMonitoringInterval);
-    tiltMonitoringInterval = null;
-  }
-
-  isMonitoring = false;
-  sidebar?.updateRealityCheck(false);
-
-  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Monitoring stopped');
-}
-
-/**
- * Handle spin event
- */
-function handleSpinEvent(spinData: SpinEvent, session: { sessionId: string, userId: string, casinoId: string, gameId: string }) {
-  // Null means verification has not completed yet; allow analysis until verdict arrives.
-  // Only block when verification has explicitly flagged shouldAnalyze = false.
-  if (casinoVerification != null && !casinoVerification.shouldAnalyze) {
-    return;
-  }
-
-  const bet = spinData.bet || 0;
-  const payout = spinData.win || 0;
-
-  // Record in tilt detector
-  if (tiltDetector) {
-    tiltDetector.recordBet(bet, payout);
-    if (typeof spinData.balance === 'number') {
-      tiltDetector.updateBalance(spinData.balance);
-    }
-
-    // Get session summary for accurate stats
-    const sessionSummary = tiltDetector.getSessionSummary();
-
-    // Update sidebar stats
-    // Note: sessionSummary.duration is the session duration in ms
-    // netProfit represents total winnings (payouts - bets)
-    const stats = {
-      startTime: sessionSummary.startTime || Date.now(),
-      totalBets: sessionSummary.totalBets || 0,
-      totalWagered: sessionSummary.totalWagered || 0,
-      totalWon: sessionSummary.totalWon || 0
-    };
-    (window as TiltCheckWindow).TiltCheckSidebar?.updateStats?.(stats);
-
-    const redeemOpportunity = tiltDetector.detectRedeemOpportunity();
-    if (redeemOpportunity) {
-      if (shouldShowRedeemNudge(redeemOpportunity)) {
-        showRedeemNudge(redeemOpportunity);
-      }
-    } else {
-      // Balance is below the redeem threshold. Reset so the nudge can re-fire if
-      // the player recovers and crosses the threshold again.
-      lastRedeemNudgeBalance = null;
-      lastRedeemNudgeThreshold = 0;
-    }
-
-    // Check for tilt immediately after bet
-    const tiltSigns = tiltDetector.detectAllTiltSigns();
-    const tiltRisk = tiltDetector.getTiltRiskScore();
-    const indicators = tiltSigns.map(sign => sign.description);
-
-    // Update sidebar tilt score
-    sidebar?.updateTilt(tiltRisk, indicators);
-  }
-
-  // Send to analyzer (if connected)
-  if (client && sessionId) {
-    client.sendSpin({
-      sessionId: session.sessionId,
-      casinoId: session.casinoId,
-      gameId: session.gameId,
-      userId: session.userId,
-      bet,
-      payout,
-      gameResult: spinData.gameResult,
-      symbols: spinData.symbols,
-      bonusRound: spinData.bonusActive,
-      freeSpins: (spinData.freeSpins || 0) > 0
-    });
-  }
-
-  // NEW: Push to Hub Relay for Discord Activity
-  postRoundTelemetry({
-    userId: session.userId,
-    bet,
-    win: payout,
-    sessionId: session.sessionId,
-    casinoId: session.casinoId,
-    gameId: session.gameId,
-    timestamp: spinData.timestamp,
-  }).catch(err => console.warn('[TiltCheck] Hub relay failed:', err));
-
-  // Check for Bag Fumble or Zero Balance Intervention
-  if (tiltDetector) {
-    checkBagFumble(spinData.balance, tiltDetector.getSessionSummary().initialBalance);
-  }
-
-  // Auto-increment Nonce for Fairness Verifier
-  const currentNonce = parseInt(localStorage.getItem('tiltcheck_nonce') || '0');
-  const nextNonce = currentNonce + 1;
-  localStorage.setItem('tiltcheck_nonce', nextNonce.toString());
-
-  // Notify Sidebar (Visual Indicator)
-  window.dispatchEvent(new CustomEvent('tg-nonce-update', { detail: { nonce: nextNonce, source: 'spin' } }));
-
-  // Update Status Bar
-  window.dispatchEvent(new CustomEvent('tg-status-update', { detail: { message: 'Analyzing spin...', type: 'thinking' } }));
-
-  // Verify Provably Fair (Check Yourself)
-  verifySpinFairness(spinData, session.gameId);
-}
-
-/**
- * Monitor Bag Fumbling (Buddy System)
- * Triggers if user was up significantly and is now blowing their bag, or if they zero out completely.
- */
-let peakBalance = 0;
-let zeroTriggered = false;
-let fumbleStrikes = 0;
-
-function checkBagFumble(balance: number | null, initialBalance: number | null) {
-  if (balance === null || initialBalance <= 0) return;
-
-  if (balance > peakBalance) {
-    peakBalance = balance;
-  }
-
-  const hadBigBag = peakBalance >= initialBalance * 1.5;
-  const isBlowingIt = hadBigBag && balance <= (initialBalance * 1.1) && balance < (peakBalance * 0.5);
-  const isZero = balance < 0.05;
-
-  if ((isBlowingIt || isZero) && !zeroTriggered) {
-    zeroTriggered = true;
-    fumbleStrikes++;
-
-    if (fumbleStrikes === 1) {
-      // Strike 1
-      showInteractiveNotification(
-        isZero ? 
-        "0 BALANCE DETECTED. Hey, stop it. You're gonna be mad if you deposit again. Close the tab and go touch grass." :
-        "BAG FUMBLE DETECTED. You were up and now you're giving it all back. Stop spinning before you ruin your week. Go touch grass.",
-        [
-          { text: "Close Tab", action: () => { window.close(); } },
-          { text: "I Won't Deposit (Lie)", action: () => { } }
-        ]
-      );
-    } else {
-      // Strike 2+ (Continued zeroing out / fumbling)
-      showInteractiveNotification(
-        "REPEATED FUMBLES. You obviously aren't going to stop yourself, so I just pinged the Discord. Get in the 'degen-accountability' VC for a lifeline before you do something stupid.",
-        [
-          { text: "Get Yelled At (Join VC)", action: () => { window.open('https://discord.gg/gdBsEJfCar', '_blank'); } },
-          { text: "Ignore Me", action: () => { } }
-        ]
-      );
-      
-      notifySupportIntervention('phone_friend_discord', {
-        message: 'Repeated fumble detected. Get them into the accountability voice room.',
-        supportActions: ['tell them to stop depositing', 'tell them to cash out', 'pull them into voice'],
-        balance,
-        initialBalance,
-        peakBalance,
-        strikeCount: fumbleStrikes,
-      });
-    }
-  } else if (balance >= initialBalance * 1.2 && !isBlowingIt) {
-    // Reset trigger if they actually recover (Strikes persist)
-    zeroTriggered = false;
-  }
-}
-
-/**
- * Periodic tilt monitoring
- */
-function startTiltMonitoring() {
-  if (tiltMonitoringInterval) {
-    clearInterval(tiltMonitoringInterval);
-  }
-  tiltMonitoringInterval = setInterval(() => {
-    if (!tiltDetector || !isMonitoring) return;
-
-    const tiltSigns = tiltDetector.detectAllTiltSigns();
-    const tiltRisk = tiltDetector.getTiltRiskScore();
-    const indicators = tiltSigns.map(sign => sign.description);
-
-    // Update sidebar
-    sidebar?.updateTilt(tiltRisk, indicators);
-
-    // Check for critical tilt
-    if (tiltRisk >= 80) {
-      triggerEmergencyStop('Critical tilt detected!');
-      notifySupportIntervention('critical_tilt', {
-        message: 'Critical tilt detected from live extension telemetry.',
-        risk: tiltRisk,
-        indicators,
-      });
-    }
-  }, 5000); // Check every 5 seconds
-}
-
-/**
- * Handle interventions
- */
-function handleInterventions(interventions: RuntimeIntervention[]) {
-  for (const intervention of interventions) {
-    if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Intervention:', intervention);
-
-    switch (intervention.type) {
-      case 'cooldown':
-        startCooldown(intervention.data.duration);
-        break;
-
-      case 'vault_balance':
-        showVaultPrompt(intervention.data);
-        break;
-
-      case 'spending_reminder':
-        showSpendingReminder(intervention.data.realWorldComparison);
-        break;
-
-      case 'stop_loss_triggered':
-        triggerStopLoss(intervention.data);
-        break;
-
-      case 'phone_friend':
-        showPhoneFriendPrompt();
-        break;
-
-      case 'session_break':
-        showBreakPrompt();
-        break;
-
-      case 'redeem_nudge':
-        showRedeemNudge(intervention.data);
-        break;
-    }
-
-    notifySupportIntervention(intervention.type, normalizeInterventionData(intervention.data));
-  }
-}
-
-/**
- * Start cooldown period
- */
-function startCooldown(duration: number) {
-  cooldownEndTime = Date.now() + duration;
-
-  // Block betting UI
-  blockBettingUI(true);
-
-  // Show overlay
-  showCooldownOverlay(duration);
-
-  // Countdown
-  const countdown = setInterval(() => {
-    if (!cooldownEndTime) {
-      clearInterval(countdown);
-      return;
-    }
-
-    const remaining = cooldownEndTime - Date.now();
-    if (remaining <= 0) {
-      clearInterval(countdown);
-      endCooldown();
-    } else {
-      updateCooldownOverlay(remaining);
-    }
-  }, 1000);
-}
-
-/**
- * End cooldown
- */
-function endCooldown() {
-  cooldownEndTime = null;
-  blockBettingUI(false);
-  removeCooldownOverlay();
-  showNotification('Cooldown complete. Play responsibly.', 'success');
-}
-
-/**
- * Block betting UI during cooldown
- */
-function blockBettingUI(block: boolean) {
-  // Find common bet buttons
-  const betButtons = document.querySelectorAll<HTMLElement>(
-    'button[class*="bet"], button[class*="spin"], [data-action="bet"], [data-action="spin"]'
-  );
-
-  betButtons.forEach((btn) => {
-    if (block) {
-      if (btn instanceof HTMLButtonElement) {
-        btn.disabled = true;
-      }
-      btn.style.opacity = '0.5';
-      btn.style.cursor = 'not-allowed';
-      btn.dataset.tiltguardBlocked = 'true';
-    } else if (btn.dataset.tiltguardBlocked) {
-      if (btn instanceof HTMLButtonElement) {
-        btn.disabled = false;
-      }
-      btn.style.opacity = '';
-      btn.style.cursor = '';
-      delete btn.dataset.tiltguardBlocked;
-    }
-  });
-}
-
-/**
- * Show cooldown overlay
- */
-function showCooldownOverlay(duration: number) {
-  const overlay = document.createElement('div');
-  overlay.id = 'tiltcheck-cooldown-overlay';
-  overlay.style.cssText = `
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.9);
-    z-index: 999999;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    color: white;
-    font-family: Arial, sans-serif;
-  `;
-
-  overlay.innerHTML = `
-    <div style="text-align: center;">
-      <h1 style="font-size: 48px; margin-bottom: 20px;">STOP</h1>
-      <h2 style="font-size: 32px; margin-bottom: 10px;">Cooldown Period</h2>
-      <p style="font-size: 18px; color: #ffaa00; margin-bottom: 30px;">
-        Tilt detected. Take a break.
-      </p>
-      <div id="cooldown-timer" style="font-size: 72px; font-weight: bold; color: #00ff88;">
-        ${Math.ceil(duration / 1000)}
-      </div>
-      <p style="font-size: 14px; margin-top: 20px; color: rgba(255, 255, 255, 0.7);">
-        Betting will resume when the timer reaches zero.
-      </p>
-    </div>
-  `;
-
-  document.body.appendChild(overlay);
-}
-
-/**
- * Update cooldown overlay
- */
-function updateCooldownOverlay(remaining: number) {
-  const timer = document.getElementById('cooldown-timer');
-  if (timer) {
-    timer.textContent = Math.ceil(remaining / 1000).toString();
-  }
-}
-
-/**
- * Remove cooldown overlay
- */
-function removeCooldownOverlay() {
-  const overlay = document.getElementById('tiltcheck-cooldown-overlay');
-  if (overlay) overlay.remove();
-}
-
-/**
- * Show vault prompt
- */
-function showVaultPrompt(vaultData: VaultPromptData) {
-  const message = `Your balance is ${vaultData.suggestedAmount.toFixed(2)}. Consider vaulting to protect your winnings.`;
-  showInteractiveNotification(message, [
-    { text: 'Vault Now', action: () => openVaultInterface(vaultData.suggestedAmount) },
-    { text: 'Later', action: () => { } }
-  ]);
-}
-
-/**
- * Show spending reminder
- */
-function showSpendingReminder(comparison: SpendingReminderData) {
-  showInteractiveNotification(comparison.message, [
-    { text: 'Vault & Buy', action: () => openVaultInterface(comparison.cost) },
-    { text: 'Remind Me Later', action: () => { } }
-  ]);
-}
-
-/**
- * Trigger stop loss
- */
-function triggerStopLoss(data: StopLossData) {
-  triggerEmergencyStop(data.reason);
-  showVaultPrompt({ suggestedAmount: tiltDetector?.getSessionSummary().currentBalance || 0 });
-}
-
-/**
- * Show phone a friend prompt
- */
-function showPhoneFriendPrompt() {
-  showInteractiveNotification(
-    'Multiple tilt signs detected. Consider calling someone before continuing.',
-    [
-      { text: 'Take Break', action: () => startCooldown(5 * 60 * 1000) },
-      { text: 'Continue', action: () => { } }
-    ]
-  );
-}
-
-/**
- * Show break prompt
- */
-function showBreakPrompt() {
-  showInteractiveNotification(
-    'You have been playing for a while. How about a quick break?',
-    [
-      { text: '5 Min Break', action: () => startCooldown(5 * 60 * 1000) },
-      { text: 'Keep Playing', action: () => { } }
-    ]
-  );
-}
-
-/**
- * Emergency stop
- */
-function triggerEmergencyStop(reason: string) {
-  // Stop all betting
-  blockBettingUI(true);
-
-  // Show critical warning
-  const warning = document.createElement('div');
-  warning.style.cssText = `
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background: linear-gradient(135deg, #ff3838 0%, #cc0000 100%);
-    color: white;
-    padding: 30px;
-    border-radius: 12px;
-    box-shadow: 0 8px 32px rgba(255, 56, 56, 0.5);
-    z-index: 999999;
-    max-width: 400px;
-    text-align: center;
-    font-family: Arial, sans-serif;
-  `;
-
-  warning.innerHTML = `
-    <h2 style="font-size: 24px; margin-bottom: 15px; letter-spacing: -0.05em; font-weight: 900;">EMERGENCY STOP</h2>
-    <p style="font-size: 16px; margin-bottom: 10px; font-weight: bold;">${reason}</p>
-    
-    <div style="
-      background: rgba(0,0,0,0.3); 
-      padding: 15px; 
-      margin-bottom: 20px; 
-      border: 1px solid rgba(255,255,255,0.2);
-      text-align: left;
-      font-size: 11px;
-      line-height: 1.4;
-      color: rgba(255,255,255,0.9);
-      max-height: 120px;
-      overflow-y: auto;
-    ">
-      <b style="color: #ffda00; text-transform: uppercase; font-size: 10px; display: block; margin-bottom: 5px;">Digital Asset Risk Disclosure:</b>
-      TiltCheck is a non-custodial tool. We do not hold your funds. You are solely responsible for your private keys. Crypto assets are highly volatile and involves risk of total loss. No information provided constitutes financial advice.
-    </div>
-
-    <div style="display: flex; gap: 10px; justify-content: center;">
-      <button id="emergency-vault" style="
-        background: white;
-        color: #cc0000;
-        border: none;
-        padding: 14px 20px;
-        font-size: 13px;
-        font-weight: 900;
-        border-radius: 4px;
-        cursor: pointer;
-        text-transform: uppercase;
-      ">Vault Balance</button>
-      <button id="emergency-continue" style="
-        background: rgba(0,0,0,0.4);
-        color: white;
-        border: 2px solid white;
-        padding: 14px 20px;
-        font-size: 13px;
-        font-weight: 900;
-        border-radius: 4px;
-        cursor: pointer;
-        text-transform: uppercase;
-      ">I Acknowledge Risk</button>
-    </div>
-  `;
-
-  document.body.appendChild(warning);
-
-  // Event listeners
-  document.getElementById('emergency-vault')?.addEventListener('click', () => {
-    openVaultInterface(tiltDetector?.getSessionSummary().currentBalance || 0);
-    warning.remove();
-  });
-
-  document.getElementById('emergency-continue')?.addEventListener('click', () => {
-    blockBettingUI(false);
-    warning.remove();
-  });
-}
-
-/**
- * Open vault interface (integrate with LockVault)
- */
-function openVaultInterface(amount: number) {
-  // Send vault request to background script for processing
-  chrome.runtime.sendMessage({
-    type: 'open_vault',
-    data: { suggestedAmount: amount }
-  }, (response) => {
-    if (response?.success) {
-      showNotification('✓ Vault interface opened', 'success');
-    } else if (response?.error) {
-      showNotification(`✗ Vault error: ${response.error}`, 'error');
-    }
-  });
-}
-
-/**
- * Show persistent warning (reserved for future use)
- */
-function _showPersistentWarning(message: string) {
-  const warning = document.createElement('div');
-  warning.style.cssText = `
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    background: linear-gradient(135deg, #ff3838 0%, #cc0000 100%);
-    color: white;
-    padding: 15px;
-    text-align: center;
-    font-family: Arial, sans-serif;
-    font-size: 14px;
-    font-weight: bold;
-    z-index: 999998;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  `;
-  warning.textContent = message;
-  document.body.appendChild(warning);
-}
-
-/**
- * Show interactive notification
- */
-function showInteractiveNotification(message: string, actions: Array<{ text: string; action: () => void }>) {
-  const notification = document.createElement('div');
-  notification.className = 'tiltguard-notification';
-  notification.style.cssText = `
-    position: fixed;
-    top: 80px;
-    right: 20px;
-    background: rgba(0, 0, 0, 0.95);
-    color: white;
-    padding: 20px;
-    border-radius: 12px;
-    box-shadow: 0 8px 32px rgba(0, 255, 136, 0.3);
-    z-index: 999999;
-    max-width: 350px;
-    font-family: Arial, sans-serif;
-    border: 2px solid #00ff88;
-  `;
-
-  const messageEl = document.createElement('p');
-  messageEl.style.cssText = 'margin-bottom: 15px; font-size: 14px; line-height: 1.4;';
-  messageEl.textContent = message;
-  notification.appendChild(messageEl);
-
-  const actionsContainer = document.createElement('div');
-  actionsContainer.style.cssText = 'display: flex; gap: 10px;';
-
-  for (const actionDef of actions) {
-    const button = document.createElement('button');
-    button.textContent = actionDef.text;
-    button.style.cssText = `
-      flex: 1;
-      padding: 10px;
-      border: none;
-      border-radius: 6px;
-      font-size: 12px;
-      font-weight: bold;
-      cursor: pointer;
-      background: linear-gradient(135deg, #00ff88 0%, #00ccff 100%);
-      color: black;
-    `;
-
-    button.addEventListener('click', () => {
-      actionDef.action();
-      notification.remove();
-    });
-
-    actionsContainer.appendChild(button);
-  }
-
-  notification.appendChild(actionsContainer);
-  document.body.appendChild(notification);
-
-  // Auto-remove after 30 seconds
-  setTimeout(() => notification.remove(), 30000);
-}
-
-/**
- * Show notification message
- */
-function showNotification(message: string, type: 'success' | 'warning' | 'error' = 'success') {
-  const notification = document.createElement('div');
-  const bgColors = {
-    success: 'linear-gradient(135deg, #10b981 0%, #059669 100%)',
-    warning: 'linear-gradient(135deg, #f59e0b 0%, #d97706 100%)',
-    error: 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)'
-  };
-
-  notification.style.cssText = `
-    position: fixed;
-    top: 20px;
-    right: 20px;
-    background: ${bgColors[type]};
-    color: white;
-    padding: 15px 20px;
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    z-index: 999999;
-    max-width: 350px;
-    font-family: Arial, sans-serif;
-    font-size: 14px;
-    animation: slideIn 0.3s ease;
-  `;
-  notification.textContent = message;
-  document.body.appendChild(notification);
-
-  // Auto-remove after 5 seconds
-  setTimeout(() => {
-    notification.style.animation = 'slideOut 0.3s ease';
-    setTimeout(() => notification.remove(), 300);
-  }, 5000);
-}
-
-/**
- * Detect casino ID from hostname
- */
-function detectCasinoId(): string {
-  const hostname = window.location.hostname.toLowerCase();
-
-  // Use isDomain for secure domain matching
-  if (isDomain(hostname, 'stake.com') || isDomain(hostname, 'stake.us')) return 'stake';
-  if (isDomain(hostname, 'roobet.com')) return 'roobet';
-  if (isDomain(hostname, 'bc.game')) return 'bc-game';
-  if (isDomain(hostname, 'duelbits.com')) return 'duelbits';
-  if (isDomain(hostname, 'rollbit.com')) return 'rollbit';
-  if (isDomain(hostname, 'shuffle.com')) return 'shuffle';
-  if (isDomain(hostname, 'gamdom.com')) return 'gamdom';
-  if (isDomain(hostname, 'csgoempire.com')) return 'csgoempire';
-
-  // Extract domain name as fallback
-  const parts = hostname.replace('www.', '').split('.');
-  return parts[0] || 'unknown';
-}
-
-/**
- * Detect game ID from URL or page content
- */
-function detectGameId(): string {
-  const pathname = window.location.pathname.toLowerCase();
-  const href = window.location.href.toLowerCase();
-
-  // Try to extract from URL patterns
-  // e.g., /casino/slots/game-name, /games/sweet-bonanza
-  const patterns = [
-    /\/casino\/slots\/([a-z0-9-]+)/,
-    /\/games?\/([a-z0-9-]+)/,
-    /\/slots?\/([a-z0-9-]+)/,
-    /\/play\/([a-z0-9-]+)/
-  ];
-
-  for (const pattern of patterns) {
-    const match = pathname.match(pattern) || href.match(pattern);
-    if (match && match[1]) {
-      return match[1];
-    }
-  }
-
-  // Try to get from page title
-  const pageTitle = document.title.toLowerCase();
-  if (pageTitle.includes('sweet bonanza')) return 'sweet-bonanza';
-  if (pageTitle.includes('gates of olympus')) return 'gates-of-olympus';
-  if (pageTitle.includes('sugar rush')) return 'sugar-rush';
-  if (pageTitle.includes('starlight princess')) return 'starlight-princess';
-  if (pageTitle.includes('wild west gold')) return 'wild-west-gold';
-  if (pageTitle.includes('dog house')) return 'dog-house';
-  if (pageTitle.includes('book of dead')) return 'book-of-dead';
-  if (pageTitle.includes('fire joker')) return 'fire-joker';
-
-  return 'unknown-game';
-}
-
-/**
- * Get user ID from storage or generate one
- */
-async function getUserId(): Promise<string> {
-  const createUserId = () => {
-    const rand = crypto.getRandomValues(new Uint32Array(1))[0].toString(36);
-    return `user_${Date.now()}_${rand}`;
-  };
-  return new Promise((resolve) => {
-    try {
-      // 1. Prefer authenticated Discord ID if available
-      chrome.storage.local.get(['userData', 'tiltguard_user_id'], (result: UserStorageSnapshot) => {
-        if (result.userData?.id) {
-          resolve(result.userData.id as string);
-        } else if (result.tiltguard_user_id) {
-          resolve(result.tiltguard_user_id as string);
-        } else {
-          // Generate new user ID
-          const newId = createUserId();
-          chrome.storage.local.set({ tiltguard_user_id: newId });
-          resolve(newId as string);
-        }
-      });
-    } catch {
-      // Fallback to localStorage
-      const storedUserData = localStorage.getItem('userData');
-      if (storedUserData) {
-        try {
-          const user = JSON.parse(storedUserData);
-          if (user.id) return resolve(user.id);
-        } catch { /* ignore */ }
-      }
-      
-      let userId = localStorage.getItem('tiltguard_user_id');
-      if (!userId) {
-        userId = createUserId();
-        localStorage.setItem('tiltguard_user_id', userId);
-      }
-      resolve(userId);
-    }
-  });
-}
-
-async function getLinkedDiscordId(): Promise<string | null> {
-  return new Promise((resolve) => {
-    try {
-      chrome.storage.local.get(['userData'], (result: UserStorageSnapshot) => {
-        resolve(typeof result.userData?.discordId === 'string' ? result.userData.discordId : null);
-      });
-    } catch {
-      resolve(null);
-    }
-  });
-}
-
-/**
- * Setup listeners for "Play" button to capture commitment
- */
-function setupFairnessListeners() {
-  const observer = new MutationObserver((_mutations) => {
-    if (typeof document === 'undefined' || !document.body) {
-      return;
-    }
-
-    // Generic selector for bet buttons - refine per casino
-    const playBtns = document.querySelectorAll('[data-testid="bet-button"], .bet-button, button[class*="bet"]');
-
-    playBtns.forEach((btn) => {
-      if (btn instanceof HTMLElement && !btn.dataset.tiltCheckAttached) {
-        btn.dataset.tiltCheckAttached = "true";
-        btn.addEventListener('click', async () => {
-          try {
-            const discordId = await getUserId();
-            const clientSeed = localStorage.getItem('tiltcheck_client_seed') || 'default-seed';
-
-            sessionStorage.setItem('tiltcheck_pending_commitment', JSON.stringify({
-              discordId,
-              clientSeed,
-              timestamp: Date.now()
-            }));
-          } catch (err) {
-            console.error("[TiltCheck] Commitment Error:", err);
-          }
-        });
-      }
-    });
-  });
-
-  observer.observe(document.body, { childList: true, subtree: true });
-}
-
-/**
- * Verify the fairness of a finished spin
- */
-async function verifySpinFairness(spinData: FairnessSpinData, gameId: string) {
-  // Null means verification has not completed yet; allow analysis until verdict arrives.
-  if (casinoVerification != null && !casinoVerification.shouldAnalyze) {
-    return;
-  }
-
-  if (!fairness || !analyzer) return;
-
-  const storedCommitment = sessionStorage.getItem('tiltcheck_pending_commitment');
-  if (!storedCommitment) return; // No commitment made for this spin
+async function shouldLoadProMonolith(): Promise<boolean> {
 
   try {
-    const parsedCommitment: unknown = JSON.parse(storedCommitment);
-    if (!isFairnessCommitment(parsedCommitment)) {
-      return;
-    }
-    const commitment = parsedCommitment;
 
-    // Clear immediately to prevent reusing for next spin
-    sessionStorage.removeItem('tiltcheck_pending_commitment');
+    const stored = await chrome.storage.local.get(TILTCHECK_PRO_MONOLITH_KEY);
 
-    if (typeof commitment.blockHash !== 'string' || commitment.blockHash.trim() === '') {
-      console.warn('[TiltCheck] Missing block hash for fairness verification');
-      return;
-    }
+    return stored[TILTCHECK_PRO_MONOLITH_KEY] === true;
 
-    // 1. Calculate the "Source of Truth" from the commitment
-    const expectedHash = await fairness.generateHash(
-      commitment.blockHash,
-      commitment.discordId,
-      commitment.clientSeed
-    );
-    const expectedFloat = fairness.hashToFloat(expectedHash);
+  } catch {
 
-    // 2. Normalize based on Game ID
-    let expectedResult: number | string = expectedFloat;
-    let gameType = 'standard';
+    return false;
 
-    if (gameId.includes('dice')) {
-      gameType = 'dice';
-      expectedResult = fairness.getDiceResult(expectedFloat);
-    } else if (gameId.includes('limbo') || gameId.includes('crash')) {
-      gameType = 'limbo';
-      expectedResult = fairness.getLimboResult(expectedFloat);
-    } else if (gameId.includes('plinko')) {
-      gameType = 'plinko';
-      // Default to 16 rows if unknown, or extract from spinData if available
-      const rows = spinData.rows || 16;
-      expectedResult = fairness.getPlinkoPath(expectedHash, rows).join(',');
-    }
-
-    if (process.env.NODE_ENV !== 'production') {
-      console.log(`[TiltCheck] Fair Result Calculated (${gameType}):`, expectedResult);
-      console.log(`[TiltCheck] Server Hash:`, expectedHash);
-    }
-
-    // 3. Verify against Casino Data
-    // If the casino provided the hash in the metadata, we can verify strictly
-    if (spinData.hash) {
-      const isHashValid = spinData.hash === expectedHash;
-      if (isHashValid) {
-        window.dispatchEvent(new CustomEvent('tg-status-update', { detail: { message: 'Fairness Verified (Hash Match)', type: 'success' } }));
-        showNotification("Fair Game Verified (Hash Match)", "success");
-      } else {
-        showNotification("Fairness Hash Mismatch!", "error");
-        console.warn(`[TiltCheck] Hash Mismatch! Expected: ${expectedHash}, Got: ${spinData.hash}`);
-      }
-    } else if (spinData.gameResult !== null && spinData.gameResult !== undefined) {
-      // Automated check against scraped result
-      const resultVal = Number(spinData.gameResult);
-
-      // Only compare if expectedResult is a number (skip Plinko paths for now)
-      if (typeof expectedResult === 'number') {
-        // Use a reasonable tolerance (e.g. 0.05 for dice/crash rounding)
-        if (Math.abs(resultVal - expectedResult) < 0.05) {
-          window.dispatchEvent(new CustomEvent('tg-status-update', { detail: { message: `Fairness Verified (Result: ${resultVal})`, type: 'success' } }));
-          showNotification(`Fair Game Verified (Result: ${resultVal})`, "success");
-          if (process.env.NODE_ENV !== 'production') {
-            console.log(`[TiltCheck] Scraped result ${resultVal} matches expected ${expectedResult}`);
-          }
-        } else {
-          console.warn(`[TiltCheck] Result Mismatch! Expected: ${expectedResult}, Scraped: ${resultVal}`);
-        }
-      }
-    } else {
-      // If no hash provided, we rely on the user checking the console or UI overlay
-      // In a full implementation, we would use Analyzer.waitForResult() here to scrape the visual result
-      if (process.env.NODE_ENV !== 'production') {
-        console.log(`[TiltCheck] Visual Verify: Does the screen show ${expectedResult}?`);
-      }
-      window.dispatchEvent(new CustomEvent('tg-status-update', { detail: { message: `Visual Check: Expecting ${expectedResult}`, type: 'info' } }));
-    }
-
-  } catch (err) {
-    console.error("[TiltCheck] Verification Error:", err);
   }
+
 }
 
-// Listen for extension messages
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Message received:', message.type);
 
-  // Keep excluded domains isolated even if content script is injected.
-  if (isExcludedDomain && message.type !== 'get_sidebar_state') {
-    sendResponse({ error: 'Feature disabled on this domain' });
-    return true;
+
+async function loadProModule(): Promise<ProMonolithModule> {
+
+  if (!proModulePromise) {
+
+    proModulePromise = import(
+
+      chrome.runtime.getURL('pro-monolith-bootstrap.js')
+
+    ) as Promise<ProMonolithModule>;
+
   }
+
+  return proModulePromise;
+
+}
+
+
+
+async function setProMonolithEnabled(enabled: boolean): Promise<void> {
+
+  if (enabled) {
+
+    if (proActive) return;
+
+    const mod = await loadProModule();
+
+    await mod.startProMonolith();
+
+    proActive = true;
+
+    return;
+
+  }
+
+
+
+  if (!proActive) return;
+
+  const mod = await loadProModule();
+
+  mod.deactivateProMonolith();
+
+  proActive = false;
+
+}
+
+
+
+async function refreshCoreOptions(): Promise<CoreCircuitBreakerOptions> {
+
+  coreOptions = await loadCoreCircuitBreakerOptions();
+
+  tiltDetector?.setRiskProfile(coreOptions.riskProfile);
+
+  return coreOptions;
+
+}
+
+
+
+function installCoreOptionsListener(): void {
+
+  try {
+
+    chrome.storage.onChanged.addListener((changes, area) => {
+
+      if (area !== 'local') return;
+
+
+
+      if (TILTCHECK_PRO_MONOLITH_KEY in changes) {
+
+        const enabled = changes[TILTCHECK_PRO_MONOLITH_KEY]?.newValue === true;
+
+        void setProMonolithEnabled(enabled);
+
+      }
+
+
+
+      const coreKeyTouched = CORE_CIRCUIT_BREAKER_STORAGE_KEYS.some((k) => k in changes);
+
+      if (coreKeyTouched) {
+
+        void refreshCoreOptions();
+
+      }
+
+    });
+
+  } catch {
+
+    // Storage listener unavailable in some test harnesses.
+
+  }
+
+}
+
+
+
+async function startCoreCircuitBreaker(): Promise<void> {
+
+  await waitForDocumentEnd();
+
+  await refreshCoreOptions();
+
+  installCoreOptionsListener();
+
+
+
+  (window as TiltCheckWindow).__tiltcheckCoreShieldActive = true;
+
+  tiltDetector = new TiltDetector(null, coreOptions.riskProfile);
+
+
+
+  coreClickListener = () => {
+
+    tiltDetector?.recordClick();
+
+  };
+
+  document.addEventListener('click', coreClickListener, true);
+
+
+
+  corePoll = window.setInterval(() => {
+
+    const opts = coreOptions;
+
+    if (!tiltDetector || !opts || Date.now() < touchGrassCooldownUntil) {
+
+      return;
+
+    }
+
+
+
+    if (!opts.enforcementEnabled) {
+
+      return;
+
+    }
+
+
+
+    const fast = tiltDetector.detectFastClicks();
+
+    if (fast && (fast.severity === 'high' || fast.severity === 'critical')) {
+
+      touchGrassCooldownUntil = Date.now() + opts.touchGrassCooldownMs;
+
+      triggerTouchGrassTimeout(fast.description, opts.touchGrassDurationMs);
+
+      return;
+
+    }
+
+
+
+    const risk = tiltDetector.getTiltRiskScore();
+
+    if (risk >= opts.riskThreshold) {
+
+      touchGrassCooldownUntil = Date.now() + opts.touchGrassCooldownMs;
+
+      triggerTouchGrassTimeout('Pacing looks off — take a break.', opts.touchGrassDurationMs);
+
+    }
+
+  }, 2000);
+
+}
+
+
+
+async function boot(): Promise<void> {
+
+  if (isExcludedDomain) {
+
+    return;
+
+  }
+
+
+
+  await startCoreCircuitBreaker();
+
+
+
+  if (await shouldLoadProMonolith()) {
+
+    await setProMonolithEnabled(true);
+
+  }
+
+}
+
+
+
+void boot();
+
+
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+
+  if (isExcludedDomain && message.type !== 'get_sidebar_state') {
+
+    sendResponse({ error: 'Feature disabled on this domain' });
+
+    return true;
+
+  }
+
+
+
+  if (
+
+    proActive &&
+
+    (message.type === 'toggle_sidebar' ||
+
+      message.type === 'open_sidebar' ||
+
+      message.type === 'get_sidebar_state')
+
+  ) {
+
+    return false;
+
+  }
+
+
 
   switch (message.type) {
-    case 'toggle_sidebar': {
-      void openRuntimeFromToolbar()
-        .then(sendResponse)
-        .catch((err) => {
-          sendResponse({ success: false, error: err instanceof Error ? err.message : 'Runtime toggle failed' });
-        });
-      break;
-    }
 
-    case 'open_sidebar': {
-      void startRuntimeAtDocumentEnd({ forceEnable: true })
-        .then(() => {
-          const sidebarEl = document.getElementById('tiltcheck-sidebar');
-          if (!sidebarEl) {
-            sidebar = initSidebar(disableInjectionFromHud);
-          }
-          const visible = setSidebarVisibility(true);
-          persistSidebarVisibility(true);
-          sendResponse({ success: true, visible, injectionDisabled: false });
-        })
-        .catch((err) => {
-          sendResponse({ success: false, error: err instanceof Error ? err.message : 'Runtime open failed' });
-        });
+    case 'toggle_sidebar':
+
+    case 'open_sidebar':
+
+      sendResponse({
+
+        success: false,
+
+        coreOnly: true,
+
+        hint: 'Set tiltcheck_pro_monolith_enabled to true in chrome.storage.local to load the full TiltCheck panel.',
+
+      });
+
       break;
-    }
+
+
 
     case 'get_sidebar_state':
-      sendResponse(getSidebarState());
+
+      sendResponse({
+
+        exists: false,
+
+        visible: false,
+
+        injectionDisabled: false,
+
+        coreOnly: true,
+
+      });
+
       break;
 
+
+
     default:
+
       sendResponse({ error: 'Unknown message type' });
+
   }
+
+
+
   return true;
+
 });
 
-/**
- * Show high-intensity Redeem Nudge
- */
-function showRedeemNudge(data: RedeemNudgeData) {
-  const existing = document.getElementById('tiltcheck-redeem-nudge');
-  if (existing) {
-    existing.remove();
-  }
 
-  const overlay = document.createElement('div');
-  overlay.id = 'tiltcheck-redeem-nudge';
-  overlay.style.cssText = `
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.95);
-    z-index: 1000000;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    color: white;
-    font-family: 'Inter', sans-serif;
-    text-align: center;
-  `;
 
-  overlay.innerHTML = `
-    <div style="max-width: 500px; padding: 40px; border: 2px solid #00ff88; border-radius: 20px; background: rgba(0, 255, 136, 0.05); box-shadow: 0 0 50px rgba(0, 255, 136, 0.2);">
-      <h1 style="font-size: 64px; margin-bottom: 10px;">WIN</h1>
-      <h2 style="font-size: 28px; color: #00ff88; text-transform: uppercase; letter-spacing: 2px;">WIN SECURED</h2>
-      <p style="font-size: 20px; margin: 20px 0; line-height: 1.5;">${data.message}</p>
-      <div style="font-size: 48px; font-weight: 800; margin-bottom: 30px;">$${Number(data.amount).toFixed(2)}</div>
-      
-      <div style="display: flex; gap: 15px; justify-content: center;">
-        <button id="redeem-btn" style="background: #00ff88; color: black; border: none; padding: 15px 30px; border-radius: 10px; font-weight: 900; cursor: pointer; font-size: 18px; text-transform: uppercase;">
-          Redeem Now & Quit
-        </button>
-        <button id="later-btn" style="background: transparent; color: white; border: 1px solid rgba(255,255,255,0.2); padding: 15px 30px; border-radius: 10px; font-weight: 600; cursor: pointer; font-size: 14px;">
-          Maybe Later (Risk It)
-        </button>
-      </div>
-      
-      <div style="margin-top: 30px; font-size: 11px; opacity: 0.5; text-transform: uppercase; letter-spacing: 1px;">
-        Made for Degens. By Degens.
-      </div>
-    </div>
-  `;
+if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
 
-  document.body.appendChild(overlay);
+  console.log('[TiltCheck] Core content script loaded');
 
-  document.getElementById('redeem-btn')?.addEventListener('click', (evt) => {
-    const btn = evt.currentTarget as HTMLButtonElement;
-    btn.disabled = true;
-    btn.textContent = 'Securing win...';
-
-    relayWinSecure(data.amount)
-      .then(() => {
-        overlay.remove();
-        window.close(); // Hard exit
-      })
-      .catch(() => {
-        btn.disabled = false;
-        btn.textContent = 'Redeem Now & Quit';
-        const errEl = document.createElement('p');
-        errEl.style.cssText = 'margin-top: 12px; color: #ff4444; font-size: 13px; font-weight: 600;';
-        errEl.textContent = 'Win relay failed. Screenshot this and contact support.';
-        btn.parentElement?.insertAdjacentElement('afterend', errEl);
-      });
-  });
-
-  document.getElementById('later-btn')?.addEventListener('click', () => {
-    overlay.remove();
-  });
 }
 
-async function relayWinSecure(amount: number) {
-  const userId = await getUserId();
-  const response = await postWinSecureTelemetry({ amount, userId });
 
-  if (!response.ok) {
-    console.error('[TiltCheck] Win secure relay returned non-OK status:', response.status);
-    throw new Error(`Win secure relay failed with status ${response.status}`);
-  }
-}
-
-// Initialize at document-end. The manifest also requests document_end, and this guard
-// keeps tests or future programmatic injection from touching the DOM too early.
-void startRuntimeAtDocumentEnd();
-
-if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Content script loaded');

--- a/apps/chrome-extension/src/core-options.ts
+++ b/apps/chrome-extension/src/core-options.ts
@@ -1,0 +1,134 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+
+/**
+ * Core circuit-breaker settings (chrome.storage.local).
+ * Popup/options UI should write these keys after explicit user opt-in.
+ */
+
+import { TOUCH_GRASS_DURATION_MS } from './touch-grass-timeout.js';
+
+export const TILTCHECK_RISK_THRESHOLD_KEY = 'tiltcheck_risk_threshold';
+export const TILTCHECK_TOUCH_GRASS_DURATION_MS_KEY = 'tiltcheck_touch_grass_duration_ms';
+export const TILTCHECK_TOUCH_GRASS_COOLDOWN_MS_KEY = 'tiltcheck_touch_grass_cooldown_ms';
+/** User must enable enforcement + accept policy before popup writes `true`. */
+export const TILTCHECK_TOUCH_GRASS_OPT_IN_KEY = 'tiltcheck_touch_grass_opt_in';
+/** Core tilt sensitivity profile (Conservative / Moderate / Degen). */
+export const TILTCHECK_RISK_PROFILE_KEY = 'tiltcheck_risk_profile';
+
+export type RiskProfile = 'conservative' | 'moderate' | 'degen';
+
+export const DEFAULT_RISK_PROFILE: RiskProfile = 'moderate';
+
+const RISK_PROFILE_MULTIPLIERS: Record<RiskProfile, number> = {
+  conservative: 1.2,
+  moderate: 1.0,
+  degen: 0.8,
+};
+
+/** Keys the Core circuit breaker reads; Pro/popup must not write these mid-session. */
+export const CORE_CIRCUIT_BREAKER_STORAGE_KEYS = [
+  TILTCHECK_RISK_THRESHOLD_KEY,
+  TILTCHECK_TOUCH_GRASS_DURATION_MS_KEY,
+  TILTCHECK_TOUCH_GRASS_COOLDOWN_MS_KEY,
+  TILTCHECK_TOUCH_GRASS_OPT_IN_KEY,
+  TILTCHECK_RISK_PROFILE_KEY,
+] as const;
+
+export function normalizeRiskProfile(value: unknown, legacyRiskLevel?: unknown): RiskProfile {
+  if (value === 'conservative' || value === 'moderate' || value === 'degen') {
+    return value;
+  }
+  if (legacyRiskLevel === 'conservative' || legacyRiskLevel === 'moderate' || legacyRiskLevel === 'degen') {
+    return legacyRiskLevel;
+  }
+  return DEFAULT_RISK_PROFILE;
+}
+
+export function riskProfileMultiplier(profile: RiskProfile): number {
+  return RISK_PROFILE_MULTIPLIERS[profile];
+}
+
+export const DEFAULT_RISK_THRESHOLD = 85;
+export const DEFAULT_TOUCH_GRASS_DURATION_MS = TOUCH_GRASS_DURATION_MS;
+/** Cooldown slightly longer than lockout to prevent re-fire on first click after unlock. */
+export const DEFAULT_TOUCH_GRASS_COOLDOWN_MS = DEFAULT_TOUCH_GRASS_DURATION_MS + 5_000;
+
+const MIN_RISK_THRESHOLD = 50;
+const MAX_RISK_THRESHOLD = 100;
+const MIN_DURATION_MS = 30_000;
+const MAX_DURATION_MS = 600_000;
+const MIN_COOLDOWN_MS = 30_000;
+const MAX_COOLDOWN_MS = 900_000;
+
+export interface CoreCircuitBreakerOptions {
+  riskThreshold: number;
+  touchGrassDurationMs: number;
+  touchGrassCooldownMs: number;
+  riskProfile: RiskProfile;
+  /** When false, core path does not fire Touch Grass (default true until options UI ships). */
+  enforcementEnabled: boolean;
+}
+
+function clampInt(value: unknown, min: number, max: number, fallback: number): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, Math.round(n)));
+}
+
+/**
+ * Load core thresholds from extension storage with safe fallbacks.
+ */
+export async function loadCoreCircuitBreakerOptions(): Promise<CoreCircuitBreakerOptions> {
+  try {
+    const stored = await chrome.storage.local.get([
+      TILTCHECK_RISK_THRESHOLD_KEY,
+      TILTCHECK_TOUCH_GRASS_DURATION_MS_KEY,
+      TILTCHECK_TOUCH_GRASS_COOLDOWN_MS_KEY,
+      TILTCHECK_TOUCH_GRASS_OPT_IN_KEY,
+      TILTCHECK_RISK_PROFILE_KEY,
+      'riskLevel',
+    ]);
+
+    const durationMs = clampInt(
+      stored[TILTCHECK_TOUCH_GRASS_DURATION_MS_KEY],
+      MIN_DURATION_MS,
+      MAX_DURATION_MS,
+      DEFAULT_TOUCH_GRASS_DURATION_MS
+    );
+
+    const cooldownDefault = durationMs + 5_000;
+    const cooldownMs = clampInt(
+      stored[TILTCHECK_TOUCH_GRASS_COOLDOWN_MS_KEY],
+      MIN_COOLDOWN_MS,
+      MAX_COOLDOWN_MS,
+      cooldownDefault
+    );
+
+    const optIn = stored[TILTCHECK_TOUCH_GRASS_OPT_IN_KEY];
+    const enforcementEnabled = optIn === undefined ? true : optIn === true;
+
+    return {
+      riskThreshold: clampInt(
+        stored[TILTCHECK_RISK_THRESHOLD_KEY],
+        MIN_RISK_THRESHOLD,
+        MAX_RISK_THRESHOLD,
+        DEFAULT_RISK_THRESHOLD
+      ),
+      touchGrassDurationMs: durationMs,
+      touchGrassCooldownMs: Math.max(cooldownMs, durationMs + 1_000),
+      riskProfile: normalizeRiskProfile(
+        stored[TILTCHECK_RISK_PROFILE_KEY],
+        stored['riskLevel']
+      ),
+      enforcementEnabled,
+    };
+  } catch {
+    return {
+      riskThreshold: DEFAULT_RISK_THRESHOLD,
+      touchGrassDurationMs: DEFAULT_TOUCH_GRASS_DURATION_MS,
+      touchGrassCooldownMs: DEFAULT_TOUCH_GRASS_COOLDOWN_MS,
+      riskProfile: DEFAULT_RISK_PROFILE,
+      enforcementEnabled: true,
+    };
+  }
+}

--- a/apps/chrome-extension/src/manifest.json
+++ b/apps/chrome-extension/src/manifest.json
@@ -85,6 +85,7 @@
         "auth-bridge.html",
         "auth-bridge.js",
         "warning.html",
+        "pro-monolith-bootstrap.js",
         "icons/*"
       ],
       "matches": ["<all_urls>"]

--- a/apps/chrome-extension/src/popup-settings.ts
+++ b/apps/chrome-extension/src/popup-settings.ts
@@ -1,0 +1,129 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+
+/**
+ * Popup bindings for core Touch Grass + Pro strategic filter storage keys.
+ */
+
+import {
+  DEFAULT_RISK_THRESHOLD,
+  DEFAULT_TOUCH_GRASS_DURATION_MS,
+  loadCoreCircuitBreakerOptions,
+  TILTCHECK_RISK_THRESHOLD_KEY,
+  TILTCHECK_TOUCH_GRASS_DURATION_MS_KEY,
+  TILTCHECK_TOUCH_GRASS_OPT_IN_KEY,
+  type CoreCircuitBreakerOptions,
+} from './core-options.js';
+import {
+  loadBlockedGameSlugs,
+  loadGameBlockOptIn,
+  normalizeBlockedGameSlug,
+  normalizeBlockedGamesList,
+  TILTCHECK_BLOCKED_GAMES_KEY,
+  TILTCHECK_GAME_BLOCK_OPT_IN_KEY,
+} from './pro/blocked-games-options.js';
+
+export const RISK_MIN = 50;
+export const RISK_MAX = 100;
+export const DURATION_MIN_MS = 30_000;
+export const DURATION_MAX_MS = 300_000;
+
+export const QUICK_BLOCK_SLUGS = ['plinko', 'mines', 'dice', 'crash'] as const;
+
+export interface TouchGrassUiState {
+  optIn: boolean;
+  riskThreshold: number;
+  durationMs: number;
+}
+
+export interface GameBlockUiState {
+  optIn: boolean;
+  slugs: string[];
+}
+
+export async function loadTouchGrassUiState(): Promise<TouchGrassUiState> {
+  const opts = await loadCoreCircuitBreakerOptions();
+  return {
+    optIn: opts.enforcementEnabled,
+    riskThreshold: opts.riskThreshold,
+    durationMs: opts.touchGrassDurationMs,
+  };
+}
+
+export async function loadGameBlockUiState(): Promise<GameBlockUiState> {
+  return {
+    optIn: await loadGameBlockOptIn(),
+    slugs: await loadBlockedGameSlugs(),
+  };
+}
+
+export function clampRisk(value: number): number {
+  return Math.min(RISK_MAX, Math.max(RISK_MIN, Math.round(value)));
+}
+
+export function clampDurationMs(value: number): number {
+  return Math.min(DURATION_MAX_MS, Math.max(DURATION_MIN_MS, Math.round(value)));
+}
+
+export async function saveTouchGrassOptIn(enabled: boolean): Promise<void> {
+  await chrome.storage.local.set({ [TILTCHECK_TOUCH_GRASS_OPT_IN_KEY]: enabled });
+}
+
+export async function saveRiskThreshold(value: number): Promise<void> {
+  await chrome.storage.local.set({ [TILTCHECK_RISK_THRESHOLD_KEY]: clampRisk(value) });
+}
+
+export async function saveTouchGrassDurationMs(value: number): Promise<void> {
+  const durationMs = clampDurationMs(value);
+  await chrome.storage.local.set({
+    [TILTCHECK_TOUCH_GRASS_DURATION_MS_KEY]: durationMs,
+    tiltcheck_touch_grass_cooldown_ms: durationMs + 5_000,
+  });
+}
+
+export async function saveGameBlockOptIn(enabled: boolean): Promise<void> {
+  await chrome.storage.local.set({ [TILTCHECK_GAME_BLOCK_OPT_IN_KEY]: enabled });
+}
+
+export async function saveBlockedGames(slugs: string[]): Promise<void> {
+  await chrome.storage.local.set({
+    [TILTCHECK_BLOCKED_GAMES_KEY]: normalizeBlockedGamesList(slugs),
+  });
+}
+
+export function toggleSlugInList(slugs: readonly string[], slug: string): string[] {
+  const normalized = normalizeBlockedGameSlug(slug);
+  if (!normalized) return [...slugs];
+  const set = new Set(slugs);
+  if (set.has(normalized)) {
+    set.delete(normalized);
+  } else {
+    set.add(normalized);
+  }
+  return normalizeBlockedGamesList([...set]);
+}
+
+export function addCustomSlug(slugs: readonly string[], raw: string): string[] {
+  const normalized = normalizeBlockedGameSlug(raw);
+  if (!normalized) return [...slugs];
+  return normalizeBlockedGamesList([...slugs, normalized]);
+}
+
+export function formatDurationLabel(ms: number): string {
+  const sec = Math.round(ms / 1000);
+  if (sec >= 60) {
+    const m = Math.floor(sec / 60);
+    const r = sec % 60;
+    return r > 0 ? `${m}m ${r}s` : `${m}m`;
+  }
+  return `${sec}s`;
+}
+
+export function riskLabel(threshold: number): string {
+  if (threshold <= 60) return 'Strict';
+  if (threshold <= 75) return 'Balanced';
+  if (threshold <= 90) return 'Moderate';
+  return 'Lenient';
+}
+
+export { DEFAULT_RISK_THRESHOLD, DEFAULT_TOUCH_GRASS_DURATION_MS };
+export type { CoreCircuitBreakerOptions };

--- a/apps/chrome-extension/src/popup.html
+++ b/apps/chrome-extension/src/popup.html
@@ -547,6 +547,141 @@
       height: 12px;
     }
     @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+
+    /* --- GUARDS (Touch Grass + Strategic Filters) --- */
+    .guard-panel {
+      background: #0f1115;
+      border: 1px solid rgba(255, 74, 74, 0.22);
+      border-radius: var(--radius);
+      padding: 12px;
+      margin-bottom: 12px;
+      font-family: var(--mono);
+    }
+    .guard-panel h3 {
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: #ff4a4a;
+      margin-bottom: 8px;
+    }
+    .guard-policy {
+      font-size: 11px;
+      line-height: 1.55;
+      color: rgba(245, 245, 245, 0.78);
+      margin-bottom: 10px;
+      padding: 8px 10px;
+      border: 1px dashed rgba(255, 255, 255, 0.12);
+      border-radius: 6px;
+      background: rgba(0, 0, 0, 0.25);
+    }
+    .guard-opt-row {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      margin-bottom: 10px;
+      cursor: pointer;
+    }
+    .guard-opt-row input { width: auto; margin-top: 2px; accent-color: #ff4a4a; }
+    .guard-opt-row span { font-size: 11px; line-height: 1.45; color: rgba(245, 245, 245, 0.9); }
+    fieldset.guard-controls {
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 6px;
+      padding: 10px;
+      margin: 0;
+    }
+    fieldset.guard-controls:disabled {
+      opacity: 0.45;
+      pointer-events: none;
+    }
+    fieldset.guard-controls legend {
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--muted);
+      padding: 0 4px;
+    }
+    .slider-row { margin-bottom: 12px; }
+    .slider-row:last-child { margin-bottom: 0; }
+    .slider-meta {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: 6px;
+      font-size: 10px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .slider-value { color: #fff; font-weight: 700; }
+    input[type="range"].guard-range {
+      width: 100%;
+      accent-color: #ff4a4a;
+      padding: 0;
+      border: none;
+      background: transparent;
+    }
+    .slug-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-bottom: 10px;
+    }
+    .slug-chip {
+      padding: 6px 10px;
+      border-radius: 6px;
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      background: rgba(255, 255, 255, 0.04);
+      color: var(--muted);
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+    .slug-chip.active {
+      border-color: rgba(255, 74, 74, 0.55);
+      background: rgba(255, 74, 74, 0.14);
+      color: #ff9a9a;
+    }
+    .slug-add-row { display: flex; gap: 6px; margin-bottom: 8px; }
+    .slug-add-row input { flex: 1; font-family: var(--mono); font-size: 11px; }
+    .slug-add-row .btn { flex-shrink: 0; padding: 8px 12px; }
+    .slug-registry {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      min-height: 24px;
+    }
+    .slug-registry .registry-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 8px;
+      border-radius: 4px;
+      background: rgba(23, 195, 178, 0.12);
+      border: 1px solid rgba(23, 195, 178, 0.35);
+      color: var(--teal);
+      font-size: 10px;
+      font-weight: 700;
+    }
+    .registry-chip button {
+      background: none;
+      border: none;
+      color: inherit;
+      cursor: pointer;
+      font-size: 12px;
+      line-height: 1;
+      padding: 0;
+    }
+    .guard-note {
+      font-size: 10px;
+      color: var(--muted);
+      line-height: 1.45;
+      margin-top: 8px;
+    }
   </style>
 </head>
 <body>
@@ -572,7 +707,7 @@
 
 <div class="tabs">
   <button class="tab active" data-tab="status">Status</button>
-  <button class="tab" data-tab="block">Filters</button>
+  <button class="tab" data-tab="block">Guards</button>
   <button class="tab" data-tab="vault">Vault</button>
   <button class="tab" data-tab="activity">Activity</button>
 </div>
@@ -648,16 +783,74 @@
 
 </div>
 
-<!-- ===== BLOCK PANEL ===== -->
+<!-- ===== GUARDS PANEL ===== -->
 <div id="panel-block" class="panel">
 
+  <section class="guard-panel" id="touch-grass-panel">
+    <h3>Touch Grass Timeout</h3>
+    <p class="guard-policy">
+      When click velocity or tilt risk crosses your line, this tab locks for the full countdown.
+      You cannot dismiss it early. Not a suggestion — the timer must hit zero.
+    </p>
+    <label class="guard-opt-row" for="opt-in-checkbox">
+      <input type="checkbox" id="opt-in-checkbox" />
+      <span>I accept enforced session lockouts on this device. I understand the tab cannot be unlocked until the timer ends.</span>
+    </label>
+    <fieldset id="slider-controls" class="guard-controls" disabled>
+      <legend>Thresholds (enabled after opt-in)</legend>
+      <div class="slider-row">
+        <div class="slider-meta">
+          <span>Sensitivity</span>
+          <span class="slider-value" id="risk-threshold-label">85 — Balanced</span>
+        </div>
+        <input type="range" id="risk-threshold-slider" class="guard-range" min="50" max="100" step="1" value="85" />
+      </div>
+      <div class="slider-row">
+        <div class="slider-meta">
+          <span>Lockout duration</span>
+          <span class="slider-value" id="duration-label">2m 0s</span>
+        </div>
+        <input type="range" id="duration-slider" class="guard-range" min="30" max="300" step="15" value="120" />
+      </div>
+    </fieldset>
+    <p class="guard-note">Core circuit breaker runs locally. No server required to fire.</p>
+  </section>
+
+  <section class="guard-panel" id="strategic-filter-panel">
+    <h3>Strategic Filters</h3>
+    <p class="guard-policy">
+      Permanently remove game types from your lobby grid and block direct URLs.
+      Requires Pro mode on the casino tab (<code style="color:#ff9a9a">tiltcheck_pro_monolith_enabled</code>).
+    </p>
+    <label class="guard-opt-row" for="game-block-master-toggle">
+      <input type="checkbox" id="game-block-master-toggle" />
+      <span>I enable local game-type exclusion on this device. I choose which games never render.</span>
+    </label>
+    <div id="game-block-controls-container" style="opacity:0.45; pointer-events:none;">
+      <p class="guard-note" style="margin-top:0; margin-bottom:8px;">Quick targets</p>
+      <div class="slug-grid" id="slug-quick-grid">
+        <button type="button" class="slug-chip" data-slug="plinko">Plinko</button>
+        <button type="button" class="slug-chip" data-slug="mines">Mines</button>
+        <button type="button" class="slug-chip" data-slug="dice">Dice</button>
+        <button type="button" class="slug-chip" data-slug="crash">Crash</button>
+      </div>
+      <div class="slug-add-row">
+        <input type="text" id="custom-slug-input" placeholder="e.g. keno, hacksaw" autocomplete="off" />
+        <button type="button" class="btn btn-ghost" id="btn-add-slug">Add</button>
+      </div>
+      <div class="slug-registry" id="slug-registry" aria-label="Active blocked game slugs"></div>
+    </div>
+  </section>
+
+  <hr />
+
   <div class="section-head">
-    <span class="section-title">Temptation Filters</span>
+    <span class="section-title">Dashboard sync (Discord)</span>
     <button class="btn btn-ghost" id="btn-add-toggle" style="padding:5px 10px; font-size:11px">
       Manage in dashboard
     </button>
   </div>
-  <p style="margin-bottom:12px; font-size:11px; color:var(--muted);">Summary only here. The dashboard owns durable game, category, provider, and casino filters. The extension just enforces them on-page.</p>
+  <p style="margin-bottom:12px; font-size:11px; color:var(--muted);">Server-backed exclusions when Discord is linked. Local guards above work without login.</p>
 
   <!-- List -->
   <div id="exclusion-list-wrap">

--- a/apps/chrome-extension/src/popup.ts
+++ b/apps/chrome-extension/src/popup.ts
@@ -1,5 +1,20 @@
 // © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
 import { EXT_CONFIG, getDiscordLoginUrl } from './config.js';
+import {
+  addCustomSlug,
+  clampDurationMs,
+  clampRisk,
+  formatDurationLabel,
+  loadGameBlockUiState,
+  loadTouchGrassUiState,
+  riskLabel,
+  saveBlockedGames,
+  saveGameBlockOptIn,
+  saveRiskThreshold,
+  saveTouchGrassDurationMs,
+  saveTouchGrassOptIn,
+  toggleSlugInList,
+} from './popup-settings.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -402,6 +417,147 @@ function renderExclusions() {
 }
 
 // ---------------------------------------------------------------------------
+// Guards settings (Touch Grass + strategic blocklist)
+// ---------------------------------------------------------------------------
+
+let guardSlugs: string[] = [];
+
+function setTouchGrassControlsEnabled(enabled: boolean): void {
+  const fieldset = $<HTMLFieldSetElement>('slider-controls');
+  fieldset.disabled = !enabled;
+}
+
+function setGameBlockControlsEnabled(enabled: boolean): void {
+  const container = $<HTMLDivElement>('game-block-controls-container');
+  container.style.opacity = enabled ? '1' : '0.45';
+  container.style.pointerEvents = enabled ? 'auto' : 'none';
+}
+
+function syncRiskSliderUi(value: number): void {
+  const clamped = clampRisk(value);
+  $<HTMLInputElement>('risk-threshold-slider').value = String(clamped);
+  $('risk-threshold-label').textContent = `${clamped} — ${riskLabel(clamped)}`;
+}
+
+function syncDurationSliderUi(ms: number): void {
+  const clamped = clampDurationMs(ms);
+  const sec = Math.round(clamped / 1000);
+  $<HTMLInputElement>('duration-slider').value = String(sec);
+  $('duration-label').textContent = formatDurationLabel(clamped);
+}
+
+function renderSlugRegistry(): void {
+  const registry = $('slug-registry');
+  if (guardSlugs.length === 0) {
+    registry.innerHTML = '<span class="guard-note" style="margin:0">No slugs armed.</span>';
+  } else {
+    registry.innerHTML = guardSlugs
+      .map(
+        (slug) =>
+          `<span class="registry-chip">${slug}<button type="button" data-remove-slug="${slug}" aria-label="Remove ${slug}">×</button></span>`
+      )
+      .join('');
+  }
+
+  document.querySelectorAll<HTMLButtonElement>('.slug-chip[data-slug]').forEach((btn) => {
+    const slug = btn.dataset['slug'] ?? '';
+    btn.classList.toggle('active', guardSlugs.includes(slug));
+  });
+}
+
+async function refreshGuardSettingsUi(): Promise<void> {
+  const touch = await loadTouchGrassUiState();
+  $<HTMLInputElement>('opt-in-checkbox').checked = touch.optIn;
+  setTouchGrassControlsEnabled(touch.optIn);
+  syncRiskSliderUi(touch.riskThreshold);
+  syncDurationSliderUi(touch.durationMs);
+
+  const game = await loadGameBlockUiState();
+  $<HTMLInputElement>('game-block-master-toggle').checked = game.optIn;
+  guardSlugs = [...game.slugs];
+  setGameBlockControlsEnabled(game.optIn);
+  renderSlugRegistry();
+}
+
+function initGuardSettingsPanel(): void {
+  void refreshGuardSettingsUi();
+
+  $<HTMLInputElement>('opt-in-checkbox').addEventListener('change', async (e) => {
+    const enabled = (e.target as HTMLInputElement).checked;
+    await saveTouchGrassOptIn(enabled);
+    setTouchGrassControlsEnabled(enabled);
+    toast(enabled ? 'Touch Grass enforcement armed.' : 'Touch Grass enforcement off.');
+  });
+
+  $<HTMLInputElement>('risk-threshold-slider').addEventListener('input', async (e) => {
+    const value = Number((e.target as HTMLInputElement).value);
+    syncRiskSliderUi(value);
+    await saveRiskThreshold(value);
+  });
+
+  $<HTMLInputElement>('duration-slider').addEventListener('input', async (e) => {
+    const sec = Number((e.target as HTMLInputElement).value);
+    const ms = clampDurationMs(sec * 1000);
+    syncDurationSliderUi(ms);
+    await saveTouchGrassDurationMs(ms);
+  });
+
+  $<HTMLInputElement>('game-block-master-toggle').addEventListener('change', async (e) => {
+    const enabled = (e.target as HTMLInputElement).checked;
+    await saveGameBlockOptIn(enabled);
+    setGameBlockControlsEnabled(enabled);
+    toast(enabled ? 'Strategic filters armed.' : 'Strategic filters off.');
+  });
+
+  document.querySelectorAll<HTMLButtonElement>('.slug-chip[data-slug]').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      if (!$<HTMLInputElement>('game-block-master-toggle').checked) return;
+      const slug = btn.dataset['slug'] ?? '';
+      guardSlugs = toggleSlugInList(guardSlugs, slug);
+      await saveBlockedGames(guardSlugs);
+      renderSlugRegistry();
+    });
+  });
+
+  $('btn-add-slug').addEventListener('click', async () => {
+    if (!$<HTMLInputElement>('game-block-master-toggle').checked) return;
+    const input = $<HTMLInputElement>('custom-slug-input');
+    const next = addCustomSlug(guardSlugs, input.value);
+    if (next.length === guardSlugs.length) {
+      toast('Invalid slug. Use letters and numbers only.', true);
+      return;
+    }
+    guardSlugs = next;
+    input.value = '';
+    await saveBlockedGames(guardSlugs);
+    renderSlugRegistry();
+    toast('Slug added.');
+  });
+
+  $('slug-registry').addEventListener('click', async (e) => {
+    const target = e.target as HTMLElement;
+    const remove = target.closest<HTMLButtonElement>('[data-remove-slug]');
+    if (!remove || !$<HTMLInputElement>('game-block-master-toggle').checked) return;
+    const slug = remove.dataset['removeSlug'] ?? '';
+    guardSlugs = guardSlugs.filter((s) => s !== slug);
+    await saveBlockedGames(guardSlugs);
+    renderSlugRegistry();
+  });
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== 'local') return;
+    const keys = Object.keys(changes);
+    if (
+      keys.some((k) =>
+        k.startsWith('tiltcheck_') && k !== 'activityFeed'
+      )
+    ) {
+      void refreshGuardSettingsUi();
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Tabs
 // ---------------------------------------------------------------------------
 
@@ -563,10 +719,12 @@ async function init() {
   // Activity refresh
   $('btn-refresh-feed').addEventListener('click', loadFeed);
 
-  // Settings (open options page if it exists, else dashboard)
+  // Settings gear opens Guards tab (local circuit breaker + strategic filters)
   $('btn-settings').addEventListener('click', () => {
-    openDashboardTab('profile');
+    activateTab('block');
   });
+
+  initGuardSettingsPanel();
 
   // Vault listeners
   initVaultListeners();

--- a/apps/chrome-extension/src/pro-monolith-bootstrap.ts
+++ b/apps/chrome-extension/src/pro-monolith-bootstrap.ts
@@ -153,8 +153,6 @@ let fairnessPlayObserver: MutationObserver | null = null;
 let proMonolithActive = false;
 let injectionDisabled = false;
 let lastAnalysisBlockMessage: string | null = null;
-const FULL_SIDEBAR_WIDTH = 340;
-const MINIMIZED_SIDEBAR_WIDTH = 40;
 const SIDEBAR_VISIBILITY_KEY = 'tiltcheck_sidebar_visible';
 const SITE_REDEEM_THRESHOLDS_KEY = 'tiltcheck_site_thresholds';
 const SUPPORT_INTERVENTION_COOLDOWN_MS = 10 * 60 * 1000;
@@ -323,9 +321,11 @@ async function restoreSidebarVisibility(defaultVisible: boolean) {
 function toggleSidebarVisibility(): boolean {
   const sidebarEl = document.getElementById('tiltcheck-sidebar');
   if (!sidebarEl) {
-    sidebar = initSidebar(disableInjectionFromHud);
-    if (sidebar) persistSidebarVisibility(true);
-    return !!sidebar;
+    const created = initSidebar(disableInjectionFromHud);
+    sidebar = created;
+    const sidebarCreated = created !== null;
+    if (sidebarCreated) persistSidebarVisibility(true);
+    return sidebarCreated;
   }
   const currentlyVisible = sidebarEl.style.display !== 'none';
   const visible = setSidebarVisibility(!currentlyVisible);
@@ -1149,6 +1149,11 @@ function startTiltMonitoring() {
         risk: tiltRisk,
         indicators,
       });
+    }
+
+    const generated = tiltDetector.generateInterventions();
+    if (generated.length > 0) {
+      handleInterventions(generated as RuntimeIntervention[]);
     }
   }, 5000); // Check every 5 seconds
 }

--- a/apps/chrome-extension/src/pro-monolith-bootstrap.ts
+++ b/apps/chrome-extension/src/pro-monolith-bootstrap.ts
@@ -321,11 +321,9 @@ async function restoreSidebarVisibility(defaultVisible: boolean) {
 function toggleSidebarVisibility(): boolean {
   const sidebarEl = document.getElementById('tiltcheck-sidebar');
   if (!sidebarEl) {
-    const created = initSidebar(disableInjectionFromHud);
-    sidebar = created;
-    const sidebarCreated = created !== null;
-    if (sidebarCreated) persistSidebarVisibility(true);
-    return sidebarCreated;
+    sidebar = initSidebar(disableInjectionFromHud);
+    persistSidebarVisibility(true);
+    return true;
   }
   const currentlyVisible = sidebarEl.style.display !== 'none';
   const visible = setSidebarVisibility(!currentlyVisible);
@@ -978,6 +976,9 @@ function handleSpinEvent(spinData: SpinEvent, session: { sessionId: string, user
   // Record in tilt detector
   if (tiltDetector) {
     tiltDetector.recordBet(bet, payout);
+    window.dispatchEvent(
+      new CustomEvent('tiltcheck-core-record-bet', { detail: { bet, payout } })
+    );
     if (typeof spinData.balance === 'number') {
       tiltDetector.updateBalance(spinData.balance);
     }
@@ -1792,7 +1793,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         .catch((err) => {
           sendResponse({ success: false, error: err instanceof Error ? err.message : 'Runtime toggle failed' });
         });
-      break;
+      return true;
     }
 
     case 'open_sidebar': {
@@ -1809,17 +1810,16 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         .catch((err) => {
           sendResponse({ success: false, error: err instanceof Error ? err.message : 'Runtime open failed' });
         });
-      break;
+      return true;
     }
 
     case 'get_sidebar_state':
       sendResponse(getSidebarState());
-      break;
+      return true;
 
     default:
-      sendResponse({ error: 'Unknown message type' });
+      return false;
   }
-  return true;
 });
 
 /**

--- a/apps/chrome-extension/src/pro-monolith-bootstrap.ts
+++ b/apps/chrome-extension/src/pro-monolith-bootstrap.ts
@@ -1,0 +1,1932 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-08 */
+
+/**
+ * Enhanced Content Script - TiltCheck + License Verification
+ * 
+ * Monitors:
+ * - Casino license legitimacy
+ * - Tilt indicators (rage betting, chasing losses, etc.)
+ * - RTP/fairness analysis
+ * 
+ * Provides:
+ * - Real-time interventions
+ * - Vault recommendations
+ * - Real-world spending reminders
+ */
+
+/**
+ * Check if hostname matches a domain (handles subdomains correctly)
+ */
+function isDomain(hostname: string, domain: string): boolean {
+  // Exact match or subdomain match (e.g., "www.discord.com" matches "discord.com")
+  return hostname === domain || hostname.endsWith('.' + domain);
+}
+
+// Early exit if on Discord or localhost API - BEFORE any imports or code runs
+const hostname = window.location.hostname.toLowerCase();
+const pathname = window.location.pathname.toLowerCase();
+const isDiscordAuthRoute = pathname.startsWith('/auth/discord');
+
+const isExcludedDomain =
+  isDomain(hostname, 'discord.com') ||
+  (hostname === 'localhost' && window.location.port === '3333') ||
+  (hostname === 'localhost' && window.location.port === '3001' && isDiscordAuthRoute) ||
+  (isDomain(hostname, 'api.tiltcheck.me') && isDiscordAuthRoute);
+
+if (isExcludedDomain) {
+  if (process.env.NODE_ENV !== 'production') console.log('[TiltCheck] Skipping - excluded domain:', hostname);
+}
+
+// Only import and run on allowed casino sites
+import { CasinoDataExtractor, AnalyzerClient, SpinEvent } from './extractor.js';
+import { TiltDetector } from './tilt-detector.js';
+import { CasinoLicenseVerifier, getAnalysisBlockMessage } from './license-verifier.js';
+import { updateMobileLicenseHud } from './mobile-license-hud.js';
+import { initSidebar } from './sidebar/index.js';
+import { SidebarUI } from './sidebar/types.js';
+import { INJECTION_DISABLED_KEY } from './sidebar/constants.js';
+import { Analyzer } from './analyzer.js';
+import { FairnessService } from './FairnessService.js';
+import { postRoundTelemetry, postWinSecureTelemetry } from './telemetry-client.js';
+import { GameBlocker } from './game-blocker.js';
+import { LocalGameBlocker } from './pro/local-game-blocker.js';
+import { isInsideTiltcheckSafetyRoot, mutationsOnlyTouchSafetyRoots } from './pro/containment.js';
+import { triggerTouchGrassTimeout } from './touch-grass-timeout.js';
+import type { CasinoVerification } from './license-verifier.js';
+import {
+  attachMarketingSiteStorageListener,
+  syncMarketingSiteTokenFromExtensionStorage,
+} from './web-app-session-sync.js';
+
+interface StoredUserData {
+  id?: string;
+  discordId?: string;
+}
+
+interface UserStorageSnapshot {
+  userData?: StoredUserData;
+  tiltguard_user_id?: string;
+}
+
+interface CooldownInterventionData {
+  duration: number;
+}
+
+interface VaultPromptData {
+  suggestedAmount: number;
+}
+
+interface SpendingReminderData {
+  message: string;
+  cost: number;
+}
+
+interface StopLossData {
+  reason: string;
+}
+
+interface RedeemNudgeData {
+  message: string;
+  amount: number;
+}
+
+type RuntimeIntervention =
+  | { type: 'cooldown'; data: CooldownInterventionData }
+  | { type: 'vault_balance'; data: VaultPromptData }
+  | { type: 'spending_reminder'; data: { realWorldComparison: SpendingReminderData } }
+  | { type: 'stop_loss_triggered'; data: StopLossData }
+  | { type: 'phone_friend'; data?: Record<string, unknown> }
+  | { type: 'session_break'; data?: Record<string, unknown> }
+  | { type: 'redeem_nudge'; data: RedeemNudgeData };
+
+type FairnessSpinData = SpinEvent & {
+  rows?: number | null;
+  hash?: string | null;
+};
+
+interface FairnessCommitment {
+  blockHash?: string;
+  discordId: string;
+  clientSeed: string;
+  timestamp: number;
+}
+
+type SidebarStatsUpdate = {
+  startTime: number;
+  totalBets: number;
+  totalWagered: number;
+  totalWon: number;
+};
+
+type TiltCheckWindow = Window & {
+  TiltCheckSidebar?: {
+    updateStats?: (stats: SidebarStatsUpdate) => void;
+  };
+  /** Set by core content.ts when the lean circuit breaker is active. */
+  __tiltcheckCoreShieldActive?: boolean;
+};
+
+// Configuration
+const ANALYZER_WS_URL = 'wss://api.tiltcheck.me/analyzer';
+
+// State
+let extractor: CasinoDataExtractor | null = null;
+let tiltDetector: TiltDetector | null = null;
+let licenseVerifier: CasinoLicenseVerifier | null = null;
+let client: AnalyzerClient | null = null;
+let sessionId: string | null = null;
+let stopObserving: (() => void) | null = null;
+let isMonitoring = false;
+let casinoVerification: CasinoVerification | null = null;
+let analyzer: Analyzer | null = null;
+let fairness: FairnessService | null = null;
+let tiltMonitoringInterval: ReturnType<typeof setInterval> | null = null;
+let sidebar: SidebarUI | null = null;
+let gameBlocker: GameBlocker | null = null;
+let localGameBlocker: LocalGameBlocker | null = null;
+let analysisRuntimeReady = false;
+let initializationComplete = false;
+let runtimeBootPromise: Promise<void> | null = null;
+let runtimeListenersAttached = false;
+let spaResumeWatchInstalled = false;
+let fairnessPlayObserver: MutationObserver | null = null;
+let proMonolithActive = false;
+let injectionDisabled = false;
+let lastAnalysisBlockMessage: string | null = null;
+const FULL_SIDEBAR_WIDTH = 340;
+const MINIMIZED_SIDEBAR_WIDTH = 40;
+const SIDEBAR_VISIBILITY_KEY = 'tiltcheck_sidebar_visible';
+const SITE_REDEEM_THRESHOLDS_KEY = 'tiltcheck_site_thresholds';
+const SUPPORT_INTERVENTION_COOLDOWN_MS = 10 * 60 * 1000;
+
+// Intervention state
+let cooldownEndTime: number | null = null;
+let lastRedeemNudgeBalance: number | null = null;
+let lastRedeemNudgeThreshold = 0;
+const lastSupportInterventionByType: Record<string, number> = {};
+
+function normalizeInterventionData(data: unknown): Record<string, unknown> {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return {};
+  }
+
+  return data as Record<string, unknown>;
+}
+
+function isFairnessCommitment(value: unknown): value is FairnessCommitment {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return typeof record.discordId === 'string'
+    && typeof record.clientSeed === 'string'
+    && typeof record.timestamp === 'number';
+}
+
+function normalizeSiteHost(value: string): string {
+  return value.replace(/^www\./, '').toLowerCase();
+}
+
+function getStoredSiteRedeemThresholds(value: unknown): Record<string, number> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const thresholds: Record<string, number> = {};
+  for (const [host, rawValue] of Object.entries(value as Record<string, unknown>)) {
+    const threshold = Number(rawValue);
+    if (Number.isFinite(threshold) && threshold > 0) {
+      thresholds[normalizeSiteHost(host)] = threshold;
+    }
+  }
+
+  return thresholds;
+}
+
+function shouldShowRedeemNudge(data: { amount: number; threshold: number }): boolean {
+  if (document.getElementById('tiltcheck-redeem-nudge')) return false;
+
+  const threshold = Number(data.threshold) || 0;
+  if (threshold <= 0) return false;
+
+  const amount = Number(data.amount) || 0;
+  const thresholdChanged = threshold !== lastRedeemNudgeThreshold;
+  // Re-fire if this is the first nudge (null), threshold changed, or a meaningful gain occurred.
+  const meaningfulGain = lastRedeemNudgeBalance !== null &&
+    amount >= lastRedeemNudgeBalance + Math.max(5, threshold * 0.1);
+
+  if (thresholdChanged || lastRedeemNudgeBalance === null || meaningfulGain) {
+    lastRedeemNudgeThreshold = threshold;
+    lastRedeemNudgeBalance = amount;
+    return true;
+  }
+
+  return false;
+}
+
+function refreshLicenseVerification() {
+  if (!licenseVerifier) {
+    licenseVerifier = new CasinoLicenseVerifier();
+  }
+  casinoVerification = licenseVerifier.verifyCasino();
+  sidebar?.updateLicense(casinoVerification);
+  updateMobileLicenseHud(casinoVerification);
+  if (initializationComplete) {
+    applyAnalysisGate(casinoVerification);
+  }
+  return casinoVerification;
+}
+
+function ensureAnalysisRuntime() {
+  if (analysisRuntimeReady) {
+    return;
+  }
+
+  analyzer = new Analyzer();
+  fairness = new FairnessService();
+  setupFairnessListeners();
+  analysisRuntimeReady = true;
+}
+
+function applyAnalysisGate(verification: CasinoVerification) {
+  const blockMessage = getAnalysisBlockMessage(verification);
+  if (!blockMessage) {
+    lastAnalysisBlockMessage = null;
+
+    if (!analysisRuntimeReady) {
+      ensureAnalysisRuntime();
+    }
+
+    if (!isMonitoring) {
+      void startMonitoring().catch((err) => {
+        console.warn('[TiltCheck] Auto-start monitoring failed:', err);
+      });
+    }
+
+    return;
+  }
+
+  if (isMonitoring) {
+    _stopMonitoring();
+  } else {
+    sidebar?.updateRealityCheck(false);
+  }
+
+  const statusType = verification.verdict === 'suspicious' ? 'danger' : 'warning';
+  sidebar?.updateStatus(blockMessage, statusType);
+  if (lastAnalysisBlockMessage !== blockMessage) {
+    sidebar?.addFeedMessage(blockMessage);
+    lastAnalysisBlockMessage = blockMessage;
+  }
+}
+
+function notifySupportIntervention(type: string, data: Record<string, unknown>): boolean {
+  const lastSentAt = lastSupportInterventionByType[type] || 0;
+  if (Date.now() - lastSentAt < SUPPORT_INTERVENTION_COOLDOWN_MS) {
+    return false;
+  }
+
+  lastSupportInterventionByType[type] = Date.now();
+  sidebar?.notifyBuddy('intervention', { type, data });
+  return true;
+}
+
+function setSidebarVisibility(visible: boolean): boolean {
+  const sidebar = document.getElementById('tiltcheck-sidebar');
+  if (!sidebar) return false;
+  sidebar.style.display = visible ? 'block' : 'none';
+  return visible;
+}
+
+function persistSidebarVisibility(visible: boolean) {
+  try {
+    chrome.storage.local.set({ [SIDEBAR_VISIBILITY_KEY]: visible });
+  } catch {
+    // Ignore persistence failures; UI still works in-memory.
+  }
+}
+
+async function restoreSidebarVisibility(defaultVisible: boolean) {
+  try {
+    const stored = await chrome.storage.local.get([SIDEBAR_VISIBILITY_KEY]);
+    if (typeof stored[SIDEBAR_VISIBILITY_KEY] === 'boolean') {
+      setSidebarVisibility(stored[SIDEBAR_VISIBILITY_KEY]);
+      return;
+    }
+  } catch {
+    // Fall back to default visibility.
+  }
+  setSidebarVisibility(defaultVisible);
+}
+
+function toggleSidebarVisibility(): boolean {
+  const sidebarEl = document.getElementById('tiltcheck-sidebar');
+  if (!sidebarEl) {
+    sidebar = initSidebar(disableInjectionFromHud);
+    if (sidebar) persistSidebarVisibility(true);
+    return !!sidebar;
+  }
+  const currentlyVisible = sidebarEl.style.display !== 'none';
+  const visible = setSidebarVisibility(!currentlyVisible);
+  persistSidebarVisibility(visible);
+  return visible;
+}
+
+function getSidebarState() {
+  const sidebar = document.getElementById('tiltcheck-sidebar');
+  return {
+    exists: !!sidebar,
+    visible: !!sidebar && sidebar.style.display !== 'none',
+    injectionDisabled,
+  };
+}
+
+async function getStoredInjectionDisabled(): Promise<boolean> {
+  try {
+    const stored = await chrome.storage.local.get([INJECTION_DISABLED_KEY]);
+    return stored[INJECTION_DISABLED_KEY] === true;
+  } catch {
+    return false;
+  }
+}
+
+async function setInjectionDisabled(disabled: boolean): Promise<void> {
+  injectionDisabled = disabled;
+  try {
+    await chrome.storage.local.set({ [INJECTION_DISABLED_KEY]: disabled });
+  } catch {
+    // In-memory state still protects this page when extension storage is unavailable.
+  }
+}
+
+function waitForDocumentEnd(): Promise<void> {
+  if (document.readyState !== 'loading' && document.body) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    const resolveWhenReady = () => {
+      if (document.body) {
+        document.removeEventListener('DOMContentLoaded', resolveWhenReady);
+        resolve();
+      }
+    };
+    document.addEventListener('DOMContentLoaded', resolveWhenReady, { once: true });
+    setTimeout(resolveWhenReady, 0);
+  });
+}
+
+const PRO_UI_ROOT_IDS = [
+  'tiltcheck-sidebar',
+  'tiltcheck-sidebar-root',
+  'tiltcheck-sidebar-container',
+  'tiltcheck-game-block-overlay',
+  'tiltcheck-local-game-block-overlay',
+  'tiltcheck-cooldown-overlay',
+  'tiltcheck-redeem-nudge',
+  'tiltcheck-mobile-license-hud',
+] as const;
+
+function removeProUiSurfaces(): void {
+  for (const id of PRO_UI_ROOT_IDS) {
+    document.getElementById(id)?.remove();
+  }
+}
+
+function teardownInjectedRuntime(): void {
+  if (isMonitoring) {
+    _stopMonitoring();
+  }
+
+  if (fairnessPlayObserver) {
+    fairnessPlayObserver.disconnect();
+    fairnessPlayObserver = null;
+  }
+
+  gameBlocker?.destroy();
+  gameBlocker = null;
+  localGameBlocker?.destroy();
+  localGameBlocker = null;
+  extractor = null;
+  tiltDetector = null;
+  casinoVerification = null;
+  sessionId = null;
+  initializationComplete = false;
+  lastAnalysisBlockMessage = null;
+  analysisRuntimeReady = false;
+  analyzer = null;
+  fairness = null;
+
+  removeProUiSurfaces();
+  sidebar = null;
+}
+
+async function disableInjectionFromHud(): Promise<void> {
+  await setInjectionDisabled(true);
+  teardownInjectedRuntime();
+}
+
+async function resumeRuntimeAfterNavigation(source: string): Promise<void> {
+  if (isExcludedDomain || injectionDisabled) {
+    return;
+  }
+
+  if (!initializationComplete) {
+    await startRuntimeAtDocumentEnd();
+    return;
+  }
+
+  if (!document.getElementById('tiltcheck-sidebar')) {
+    sidebar = initSidebar(disableInjectionFromHud);
+    const defaultVisible = !isDomain(hostname, 'tiltcheck.me');
+    void restoreSidebarVisibility(defaultVisible);
+  }
+
+  syncMarketingSiteTokenFromExtensionStorage();
+  attachMarketingSiteStorageListener();
+  const verification = refreshLicenseVerification();
+  applyAnalysisGate(verification);
+  gameBlocker?.resume(source);
+  localGameBlocker?.resume(source);
+}
+
+function installSpaResumeWatch(): void {
+  if (spaResumeWatchInstalled) {
+    return;
+  }
+
+  spaResumeWatchInstalled = true;
+  let lastUrl = window.location.href;
+  let pending = false;
+
+  const queueResume = (source: string) => {
+    if (pending) {
+      return;
+    }
+
+    pending = true;
+    queueMicrotask(() => {
+      pending = false;
+      const currentUrl = window.location.href;
+      if (currentUrl === lastUrl && source !== 'pageshow') {
+        return;
+      }
+      lastUrl = currentUrl;
+      void resumeRuntimeAfterNavigation(source);
+    });
+  };
+
+  const patchHistoryMethod = (method: 'pushState' | 'replaceState') => {
+    const original = window.history[method] as (...args: unknown[]) => unknown;
+    if ((original as { __tiltcheckPatched?: boolean }).__tiltcheckPatched) {
+      return;
+    }
+
+    const patched = function patchedHistoryMethod(this: History, ...args: unknown[]) {
+      const result = original.apply(this, args);
+      queueResume(method);
+      return result;
+    };
+    Object.defineProperty(patched, '__tiltcheckPatched', { value: true });
+    window.history[method] = patched as typeof window.history[typeof method];
+  };
+
+  patchHistoryMethod('pushState');
+  patchHistoryMethod('replaceState');
+  window.addEventListener('popstate', () => queueResume('popstate'));
+  window.addEventListener('hashchange', () => queueResume('hashchange'));
+  window.addEventListener('pageshow', () => queueResume('pageshow'));
+}
+
+async function startRuntimeAtDocumentEnd(options: { forceEnable?: boolean } = {}): Promise<void> {
+  if (isExcludedDomain) {
+    return;
+  }
+
+  if (runtimeBootPromise) {
+    await runtimeBootPromise;
+    return;
+  }
+
+  runtimeBootPromise = (async () => {
+    await waitForDocumentEnd();
+    installSpaResumeWatch();
+
+    if (options.forceEnable) {
+      await setInjectionDisabled(false);
+    } else {
+      injectionDisabled = await getStoredInjectionDisabled();
+    }
+
+    if (injectionDisabled) {
+      teardownInjectedRuntime();
+      return;
+    }
+
+    initialize();
+  })().finally(() => {
+    runtimeBootPromise = null;
+  });
+
+  await runtimeBootPromise;
+}
+
+async function openRuntimeFromToolbar(): Promise<{ success: true; visible: boolean; injectionDisabled: boolean }> {
+  if (injectionDisabled || await getStoredInjectionDisabled()) {
+    await startRuntimeAtDocumentEnd({ forceEnable: true });
+    const sidebarEl = document.getElementById('tiltcheck-sidebar');
+    if (!sidebarEl) {
+      sidebar = initSidebar(disableInjectionFromHud);
+    }
+    const visible = setSidebarVisibility(true);
+    persistSidebarVisibility(true);
+    return { success: true, visible, injectionDisabled: false };
+  }
+
+  const visible = toggleSidebarVisibility();
+  return { success: true, visible, injectionDisabled: false };
+}
+
+/**
+ * Visual Picker for selecting elements
+ */
+class VisualPicker {
+  private overlay: HTMLElement | null = null;
+  private active = false;
+  private callback: ((selector: string) => void) | null = null;
+
+  start(callback: (selector: string) => void) {
+    if (this.active) return;
+    this.active = true;
+    this.callback = callback;
+
+    // Create overlay for highlighting
+    this.overlay = document.createElement('div');
+    this.overlay.style.cssText = `
+      position: fixed;
+      pointer-events: none;
+      background: rgba(0, 255, 136, 0.2);
+      border: 2px solid #00ff88;
+      z-index: 2147483647;
+      transition: all 0.1s;
+      display: none;
+      border-radius: 4px;
+    `;
+    document.body.appendChild(this.overlay);
+
+    document.addEventListener('mousemove', this.onHover, true);
+    document.addEventListener('click', this.onClick, true);
+    document.body.style.cursor = 'crosshair';
+  }
+
+  stop() {
+    this.active = false;
+    this.callback = null;
+    if (this.overlay) this.overlay.remove();
+    document.removeEventListener('mousemove', this.onHover, true);
+    document.removeEventListener('click', this.onClick, true);
+    document.body.style.cursor = '';
+  }
+
+  private onHover = (e: MouseEvent) => {
+    if (!this.overlay) return;
+    const target = e.target as HTMLElement;
+    if (target === this.overlay || target.closest('#tiltcheck-sidebar')) return;
+
+    const rect = target.getBoundingClientRect();
+    this.overlay.style.display = 'block';
+    this.overlay.style.top = rect.top + 'px';
+    this.overlay.style.left = rect.left + 'px';
+    this.overlay.style.width = rect.width + 'px';
+    this.overlay.style.height = rect.height + 'px';
+  }
+
+  private onClick = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const target = e.target as HTMLElement;
+    if (target.closest('#tiltcheck-sidebar')) return;
+
+    const selector = this.generateSelector(target);
+    if (this.callback) this.callback(selector);
+    this.stop();
+  }
+
+  private generateSelector(el: HTMLElement): string {
+    // 1. ID (if valid and unique)
+    if (el.id && /^[a-z][a-z0-9_-]*$/i.test(el.id) && document.querySelectorAll(`#${el.id}`).length === 1) {
+      return `#${el.id}`;
+    }
+
+    // 2. Data Attributes (High priority for testing/scraping)
+    const dataAttrs = ['data-test', 'data-testid', 'data-qa', 'data-automation-id'];
+    for (const attr of dataAttrs) {
+      if (el.hasAttribute(attr)) {
+        return `[${attr}="${el.getAttribute(attr)}"]`;
+      }
+    }
+
+    // 3. Unique Class Combination
+    if (el.className && typeof el.className === 'string') {
+      const classes = el.className.trim().split(/\s+/).filter(c => c && !c.includes(':'));
+      if (classes.length > 0) {
+        // Try single classes
+        for (const cls of classes) {
+          if (document.querySelectorAll(`.${cls}`).length === 1) return `.${cls}`;
+        }
+      }
+    }
+
+    // 4. Fallback: Path with nth-of-type
+    const path: string[] = [];
+    let current: HTMLElement | null = el;
+
+    while (current && current !== document.body && current !== document.documentElement) {
+      let selector = current.tagName.toLowerCase();
+
+      if (current.id && /^[a-z][a-z0-9_-]*$/i.test(current.id)) {
+        selector = `#${current.id}`;
+        path.unshift(selector);
+        break; // Stop at ID
+      } else {
+        // Calculate nth-of-type
+        let sibling = current;
+        let nth = 1;
+        while (sibling.previousElementSibling) {
+          sibling = sibling.previousElementSibling as HTMLElement;
+          if (sibling.tagName === current.tagName) nth++;
+        }
+
+        if (nth > 1) selector += `:nth-of-type(${nth})`;
+      }
+
+      path.unshift(selector);
+      current = current.parentElement;
+    }
+
+    return path.join(' > ');
+  }
+}
+
+/**
+ * Highlighter for testing selectors
+ */
+class Highlighter {
+  private overlay: HTMLElement | null = null;
+
+  highlight(selector: string) {
+    this.clear();
+    try {
+      const el = document.querySelector(selector) as HTMLElement;
+      if (!el) {
+        console.warn('[TiltCheck] Element not found for highlighting');
+        return;
+      }
+
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+      const rect = el.getBoundingClientRect();
+      this.overlay = document.createElement('div');
+      this.overlay.style.cssText = `
+        position: fixed;
+        top: ${rect.top}px;
+        left: ${rect.left}px;
+        width: ${rect.width}px;
+        height: ${rect.height}px;
+        background: rgba(0, 255, 136, 0.2);
+        border: 2px solid #00ff88;
+        z-index: 2147483647;
+        pointer-events: none;
+        transition: all 0.3s;
+        border-radius: 4px;
+        box-shadow: 0 0 15px rgba(0, 255, 136, 0.4);
+      `;
+      document.body.appendChild(this.overlay);
+
+      // Remove after 2 seconds
+      setTimeout(() => this.clear(), 2000);
+
+    } catch (e) {
+      console.error('Invalid selector', e);
+    }
+  }
+
+  clear() {
+    if (this.overlay) {
+      this.overlay.remove();
+      this.overlay = null;
+    }
+  }
+}
+
+/**
+ * Initialize on page load
+ */
+function initialize() {
+  if (initializationComplete) {
+    return;
+  }
+
+  if (process.env.NODE_ENV !== 'production') console.log('[TiltCheck] Initializing on:', window.location.hostname);
+
+  syncMarketingSiteTokenFromExtensionStorage();
+  attachMarketingSiteStorageListener();
+
+  // Create sidebar UI
+  sidebar = initSidebar(disableInjectionFromHud);
+  // Default hidden on TiltCheck-owned pages, visible on supported casino pages.
+  const defaultVisible = !isDomain(hostname, 'tiltcheck.me');
+  void restoreSidebarVisibility(defaultVisible);
+  if (process.env.NODE_ENV !== 'production') console.log('[TiltCheck] Sidebar created:', !!sidebar);
+
+  updateMobileLicenseHud(null);
+
+  // Check casino license from footer/legal sections and refresh after delayed page content loads.
+  const initialLicenseStatus = refreshLicenseVerification();
+  if (process.env.NODE_ENV !== 'production') console.log('[TiltCheck] License verification:', initialLicenseStatus);
+  setTimeout(() => refreshLicenseVerification(), 3000);
+  setTimeout(() => refreshLicenseVerification(), 8000);
+
+  if (!runtimeListenersAttached) {
+    runtimeListenersAttached = true;
+
+    // Setup Visual Picker Listener
+    const picker = new VisualPicker();
+    window.addEventListener('tg-start-picker', ((e: CustomEvent) => {
+      picker.start((selector) => {
+        // Send result back to sidebar via event
+        window.dispatchEvent(new CustomEvent('tg-picker-result', { detail: { field: e.detail.field, selector } }));
+      });
+    }) as EventListener);
+
+    // Setup Highlighter Listener
+    const highlighter = new Highlighter();
+    window.addEventListener('tg-test-selector', ((e: CustomEvent) => {
+      highlighter.highlight(e.detail.selector);
+    }) as EventListener);
+
+    window.addEventListener('tg-redeem-threshold-updated', ((e: CustomEvent<{ hostname?: string; threshold?: number }>) => {
+      if (!tiltDetector) return;
+
+      const updatedHost = normalizeSiteHost(e.detail?.hostname || '');
+      if (updatedHost && updatedHost !== normalizeSiteHost(window.location.hostname)) {
+        return;
+      }
+
+      const threshold = Number(e.detail?.threshold) || 0;
+      tiltDetector.setRedeemThreshold(threshold > 0 ? threshold : null);
+      lastRedeemNudgeBalance = 0;
+      lastRedeemNudgeThreshold = 0;
+    }) as EventListener);
+
+    // Setup Fairness Calculator Listener
+    window.addEventListener('tg-calc-fairness', (async (e: CustomEvent) => {
+      if (!fairness) return;
+      const { serverSeed, clientSeed, nonce } = e.detail;
+      try {
+        const hash = await fairness.verifyCasinoResult(serverSeed, clientSeed, parseInt(nonce));
+        const float = fairness.hashToFloat(hash);
+
+        window.dispatchEvent(new CustomEvent('tg-fairness-result', {
+          detail: {
+            hash,
+            float,
+            dice: fairness.getDiceResult(float),
+            limbo: fairness.getLimboResult(float)
+          }
+        }));
+      } catch (err) {
+        console.error('Fairness calc error', err);
+      }
+    }) as EventListener);
+  }
+
+  initializationComplete = true;
+  applyAnalysisGate(initialLicenseStatus);
+
+  // Local strategic filter (storage-only blocklist; no API).
+  if (!localGameBlocker) {
+    localGameBlocker = new LocalGameBlocker();
+    localGameBlocker.init().catch((err) => {
+      console.warn('[TiltCheck] Local game blocker init failed:', err);
+    });
+  }
+
+  // Surgical Self-Exclusion (API profile): init after auth storage is ready.
+  setTimeout(() => {
+    Promise.all([
+      getLinkedDiscordId(),
+      chrome.storage.local.get(['authToken']),
+    ]).then(([discordId, authState]) => {
+      const authToken = typeof authState.authToken === 'string' ? authState.authToken : '';
+      if (!discordId || !authToken) {
+        return;
+      }
+
+      gameBlocker = new GameBlocker(discordId, authToken);
+      gameBlocker.init().catch((err) => {
+        console.warn('[TiltCheck] Game blocker init failed:', err);
+      });
+    }).catch(() => {
+      // No linked Discord session — skip blocker silently
+    });
+  }, 500);
+
+}
+
+/**
+ * Start monitoring
+ */
+async function startMonitoring() {
+  if (isMonitoring) return;
+
+  console.log('[TiltCheck] Starting monitoring...');
+
+  const verification = casinoVerification ?? refreshLicenseVerification();
+  const blockMessage = getAnalysisBlockMessage(verification);
+  if (blockMessage) {
+    sidebar?.updateRealityCheck(false);
+    sidebar?.updateStatus(blockMessage, verification?.verdict === 'suspicious' ? 'danger' : 'warning');
+    return;
+  }
+
+  // Update UI
+  sidebar?.updateRealityCheck(true);
+  isMonitoring = true;
+
+  // Get initial balance
+  extractor = new CasinoDataExtractor();
+  await extractor.initialize();
+  const initialBalance = extractor.extractBalance();
+
+  peakBalance = typeof initialBalance === 'number' ? initialBalance : 0;
+  zeroTriggered = false;
+  fumbleStrikes = 0;
+
+  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Initial balance:', initialBalance);
+
+  // Get risk level, redeem threshold, and auth token from storage
+  const storageResult = await chrome.storage.local.get(['riskLevel', 'redeemThreshold', 'authToken', SITE_REDEEM_THRESHOLDS_KEY]);
+  const riskLevel = (storageResult.riskLevel as 'conservative' | 'moderate' | 'degen') || 'moderate';
+  const siteThresholds = getStoredSiteRedeemThresholds(storageResult[SITE_REDEEM_THRESHOLDS_KEY]);
+  const siteHost = normalizeSiteHost(window.location.hostname);
+  const redeemThreshold = siteThresholds[siteHost] ?? (Number(storageResult.redeemThreshold) || 0);
+  const authToken = storageResult.authToken as string | undefined;
+
+  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Using profile:', { riskLevel, redeemThreshold, hasToken: !!authToken });
+
+  // Initialize tilt detector
+  tiltDetector = new TiltDetector(initialBalance, riskLevel, redeemThreshold);
+
+  if (authToken) {
+    const wsUrlWithAuth = `${ANALYZER_WS_URL}?token=${authToken}`;
+    client = new AnalyzerClient(wsUrlWithAuth, (error) => {
+      // Surface post-open disconnect/reconnect failures to UI and logs.
+      console.warn('[TiltGuard] Analyzer connection issue:', error);
+      sidebar?.updateRealityCheck(false);
+      window.dispatchEvent(
+        new CustomEvent('tg-status-update', {
+          detail: { message: 'Analyzer connection dropped. Reconnecting...', type: 'warning' }
+        })
+      );
+    });
+
+    try {
+      await client.connect();
+      if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Connected to analyzer server');
+      sidebar?.updateRealityCheck(true);
+    } catch {
+      if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Analyzer backend offline - tilt monitoring only');
+    }
+  } else {
+    if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Analyzer disabled until Discord auth is connected');
+    sidebar?.updateRealityCheck(false);
+  }
+
+  // Generate session ID using cryptographically secure random
+  const randomBytes = new Uint32Array(1);
+  crypto.getRandomValues(randomBytes);
+  sessionId = `session_${Date.now()}_${randomBytes[0].toString(36)}`;
+  const userId = await getUserId();
+  const casinoId = detectCasinoId();
+  const gameId = detectGameId();
+
+  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Session started:', { sessionId, userId, casinoId, gameId });
+
+  // Start tilt monitoring
+  startTiltMonitoring();
+
+  // Start observing
+  stopObserving = extractor.startObserving((spinData) => {
+    if (!spinData) return;
+
+    if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Spin detected:', spinData);
+
+    // Check if sessionId is valid before using
+    if (!sessionId) {
+      console.warn('[TiltGuard] Session not started, cannot record spin');
+      return;
+    }
+
+    handleSpinEvent(spinData, { sessionId, userId, casinoId, gameId });
+  });
+
+  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Monitoring started successfully');
+}
+
+/**
+ * Stop monitoring
+ */
+function _stopMonitoring() {
+  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Stopping monitoring...');
+
+  if (stopObserving) {
+    stopObserving();
+    stopObserving = null;
+  }
+
+  if (client) {
+    client.disconnect();
+    client = null;
+  }
+  if (tiltMonitoringInterval) {
+    clearInterval(tiltMonitoringInterval);
+    tiltMonitoringInterval = null;
+  }
+
+  isMonitoring = false;
+  sidebar?.updateRealityCheck(false);
+
+  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Monitoring stopped');
+}
+
+/**
+ * Handle spin event
+ */
+function handleSpinEvent(spinData: SpinEvent, session: { sessionId: string, userId: string, casinoId: string, gameId: string }) {
+  // Null means verification has not completed yet; allow analysis until verdict arrives.
+  // Only block when verification has explicitly flagged shouldAnalyze = false.
+  if (casinoVerification != null && !casinoVerification.shouldAnalyze) {
+    return;
+  }
+
+  const bet = spinData.bet || 0;
+  const payout = spinData.win || 0;
+
+  // Record in tilt detector
+  if (tiltDetector) {
+    tiltDetector.recordBet(bet, payout);
+    if (typeof spinData.balance === 'number') {
+      tiltDetector.updateBalance(spinData.balance);
+    }
+
+    // Get session summary for accurate stats
+    const sessionSummary = tiltDetector.getSessionSummary();
+
+    // Update sidebar stats
+    // Note: sessionSummary.duration is the session duration in ms
+    // netProfit represents total winnings (payouts - bets)
+    const stats = {
+      startTime: sessionSummary.startTime || Date.now(),
+      totalBets: sessionSummary.totalBets || 0,
+      totalWagered: sessionSummary.totalWagered || 0,
+      totalWon: sessionSummary.totalWon || 0
+    };
+    (window as TiltCheckWindow).TiltCheckSidebar?.updateStats?.(stats);
+
+    const redeemOpportunity = tiltDetector.detectRedeemOpportunity();
+    if (redeemOpportunity) {
+      if (shouldShowRedeemNudge(redeemOpportunity)) {
+        showRedeemNudge(redeemOpportunity);
+      }
+    } else {
+      // Balance is below the redeem threshold. Reset so the nudge can re-fire if
+      // the player recovers and crosses the threshold again.
+      lastRedeemNudgeBalance = null;
+      lastRedeemNudgeThreshold = 0;
+    }
+
+    // Check for tilt immediately after bet
+    const tiltSigns = tiltDetector.detectAllTiltSigns();
+    const tiltRisk = tiltDetector.getTiltRiskScore();
+    const indicators = tiltSigns.map(sign => sign.description);
+
+    // Update sidebar tilt score
+    sidebar?.updateTilt(tiltRisk, indicators);
+  }
+
+  // Send to analyzer (if connected)
+  if (client && sessionId) {
+    client.sendSpin({
+      sessionId: session.sessionId,
+      casinoId: session.casinoId,
+      gameId: session.gameId,
+      userId: session.userId,
+      bet,
+      payout,
+      gameResult: spinData.gameResult,
+      symbols: spinData.symbols,
+      bonusRound: spinData.bonusActive,
+      freeSpins: (spinData.freeSpins || 0) > 0
+    });
+  }
+
+  // NEW: Push to Hub Relay for Discord Activity
+  postRoundTelemetry({
+    userId: session.userId,
+    bet,
+    win: payout,
+    sessionId: session.sessionId,
+    casinoId: session.casinoId,
+    gameId: session.gameId,
+    timestamp: spinData.timestamp,
+  }).catch(err => console.warn('[TiltCheck] Hub relay failed:', err));
+
+  // Check for Bag Fumble or Zero Balance Intervention
+  if (tiltDetector) {
+    checkBagFumble(spinData.balance, tiltDetector.getSessionSummary().initialBalance);
+  }
+
+  // Auto-increment Nonce for Fairness Verifier
+  const currentNonce = parseInt(localStorage.getItem('tiltcheck_nonce') || '0');
+  const nextNonce = currentNonce + 1;
+  localStorage.setItem('tiltcheck_nonce', nextNonce.toString());
+
+  // Notify Sidebar (Visual Indicator)
+  window.dispatchEvent(new CustomEvent('tg-nonce-update', { detail: { nonce: nextNonce, source: 'spin' } }));
+
+  // Update Status Bar
+  window.dispatchEvent(new CustomEvent('tg-status-update', { detail: { message: 'Analyzing spin...', type: 'thinking' } }));
+
+  // Verify Provably Fair (Check Yourself)
+  verifySpinFairness(spinData, session.gameId);
+}
+
+/**
+ * Monitor Bag Fumbling (Buddy System)
+ * Triggers if user was up significantly and is now blowing their bag, or if they zero out completely.
+ */
+let peakBalance = 0;
+let zeroTriggered = false;
+let fumbleStrikes = 0;
+
+function checkBagFumble(balance: number | null, initialBalance: number | null) {
+  if (balance === null || initialBalance <= 0) return;
+
+  if (balance > peakBalance) {
+    peakBalance = balance;
+  }
+
+  const hadBigBag = peakBalance >= initialBalance * 1.5;
+  const isBlowingIt = hadBigBag && balance <= (initialBalance * 1.1) && balance < (peakBalance * 0.5);
+  const isZero = balance < 0.05;
+
+  if ((isBlowingIt || isZero) && !zeroTriggered) {
+    zeroTriggered = true;
+    fumbleStrikes++;
+
+    if (fumbleStrikes === 1) {
+      // Strike 1
+      showInteractiveNotification(
+        isZero ? 
+        "0 BALANCE DETECTED. Hey, stop it. You're gonna be mad if you deposit again. Close the tab and go touch grass." :
+        "BAG FUMBLE DETECTED. You were up and now you're giving it all back. Stop spinning before you ruin your week. Go touch grass.",
+        [
+          { text: "Close Tab", action: () => { window.close(); } },
+          { text: "I Won't Deposit (Lie)", action: () => { } }
+        ]
+      );
+    } else {
+      // Strike 2+ (Continued zeroing out / fumbling)
+      showInteractiveNotification(
+        "REPEATED FUMBLES. You obviously aren't going to stop yourself, so I just pinged the Discord. Get in the 'degen-accountability' VC for a lifeline before you do something stupid.",
+        [
+          { text: "Get Yelled At (Join VC)", action: () => { window.open('https://discord.gg/gdBsEJfCar', '_blank'); } },
+          { text: "Ignore Me", action: () => { } }
+        ]
+      );
+      
+      notifySupportIntervention('phone_friend_discord', {
+        message: 'Repeated fumble detected. Get them into the accountability voice room.',
+        supportActions: ['tell them to stop depositing', 'tell them to cash out', 'pull them into voice'],
+        balance,
+        initialBalance,
+        peakBalance,
+        strikeCount: fumbleStrikes,
+      });
+    }
+  } else if (balance >= initialBalance * 1.2 && !isBlowingIt) {
+    // Reset trigger if they actually recover (Strikes persist)
+    zeroTriggered = false;
+  }
+}
+
+/**
+ * Periodic tilt monitoring
+ */
+function startTiltMonitoring() {
+  if (tiltMonitoringInterval) {
+    clearInterval(tiltMonitoringInterval);
+  }
+  tiltMonitoringInterval = setInterval(() => {
+    if (!tiltDetector || !isMonitoring) return;
+
+    const tiltSigns = tiltDetector.detectAllTiltSigns();
+    const tiltRisk = tiltDetector.getTiltRiskScore();
+    const indicators = tiltSigns.map(sign => sign.description);
+
+    // Update sidebar
+    sidebar?.updateTilt(tiltRisk, indicators);
+
+    // Check for critical tilt (Touch Grass lockout owned by Core when shield is active)
+    const coreOwnsTouchGrass = (window as TiltCheckWindow).__tiltcheckCoreShieldActive === true;
+    if (tiltRisk >= 80 && !coreOwnsTouchGrass) {
+      triggerTouchGrassTimeout('Critical tilt detected.');
+      notifySupportIntervention('critical_tilt', {
+        message: 'Critical tilt detected from live extension telemetry.',
+        risk: tiltRisk,
+        indicators,
+      });
+    }
+  }, 5000); // Check every 5 seconds
+}
+
+/**
+ * Handle interventions
+ */
+function handleInterventions(interventions: RuntimeIntervention[]) {
+  for (const intervention of interventions) {
+    if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Intervention:', intervention);
+
+    switch (intervention.type) {
+      case 'cooldown':
+        startCooldown(intervention.data.duration);
+        break;
+
+      case 'vault_balance':
+        showVaultPrompt(intervention.data);
+        break;
+
+      case 'spending_reminder':
+        showSpendingReminder(intervention.data.realWorldComparison);
+        break;
+
+      case 'stop_loss_triggered':
+        triggerStopLoss(intervention.data);
+        break;
+
+      case 'phone_friend':
+        showPhoneFriendPrompt();
+        break;
+
+      case 'session_break':
+        showBreakPrompt();
+        break;
+
+      case 'redeem_nudge':
+        showRedeemNudge(intervention.data);
+        break;
+    }
+
+    notifySupportIntervention(intervention.type, normalizeInterventionData(intervention.data));
+  }
+}
+
+/**
+ * Start cooldown period
+ */
+function startCooldown(duration: number) {
+  cooldownEndTime = Date.now() + duration;
+
+  // Block betting UI
+  blockBettingUI(true);
+
+  // Show overlay
+  showCooldownOverlay(duration);
+
+  // Countdown
+  const countdown = setInterval(() => {
+    if (!cooldownEndTime) {
+      clearInterval(countdown);
+      return;
+    }
+
+    const remaining = cooldownEndTime - Date.now();
+    if (remaining <= 0) {
+      clearInterval(countdown);
+      endCooldown();
+    } else {
+      updateCooldownOverlay(remaining);
+    }
+  }, 1000);
+}
+
+/**
+ * End cooldown
+ */
+function endCooldown() {
+  cooldownEndTime = null;
+  blockBettingUI(false);
+  removeCooldownOverlay();
+  showNotification('Cooldown complete. Play responsibly.', 'success');
+}
+
+/**
+ * Block betting UI during cooldown
+ */
+function blockBettingUI(block: boolean) {
+  // Find common bet buttons
+  const betButtons = document.querySelectorAll<HTMLElement>(
+    'button[class*="bet"], button[class*="spin"], [data-action="bet"], [data-action="spin"]'
+  );
+
+  betButtons.forEach((btn) => {
+    if (block) {
+      if (btn instanceof HTMLButtonElement) {
+        btn.disabled = true;
+      }
+      btn.style.opacity = '0.5';
+      btn.style.cursor = 'not-allowed';
+      btn.dataset.tiltguardBlocked = 'true';
+    } else if (btn.dataset.tiltguardBlocked) {
+      if (btn instanceof HTMLButtonElement) {
+        btn.disabled = false;
+      }
+      btn.style.opacity = '';
+      btn.style.cursor = '';
+      delete btn.dataset.tiltguardBlocked;
+    }
+  });
+}
+
+/**
+ * Show cooldown overlay
+ */
+function showCooldownOverlay(duration: number) {
+  const overlay = document.createElement('div');
+  overlay.id = 'tiltcheck-cooldown-overlay';
+  overlay.style.cssText = `
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.9);
+    z-index: 999999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    color: white;
+    font-family: Arial, sans-serif;
+  `;
+
+  overlay.innerHTML = `
+    <div style="text-align: center;">
+      <h1 style="font-size: 48px; margin-bottom: 20px;">STOP</h1>
+      <h2 style="font-size: 32px; margin-bottom: 10px;">Cooldown Period</h2>
+      <p style="font-size: 18px; color: #ffaa00; margin-bottom: 30px;">
+        Tilt detected. Take a break.
+      </p>
+      <div id="cooldown-timer" style="font-size: 72px; font-weight: bold; color: #00ff88;">
+        ${Math.ceil(duration / 1000)}
+      </div>
+      <p style="font-size: 14px; margin-top: 20px; color: rgba(255, 255, 255, 0.7);">
+        Betting will resume when the timer reaches zero.
+      </p>
+    </div>
+  `;
+
+  document.body.appendChild(overlay);
+}
+
+/**
+ * Update cooldown overlay
+ */
+function updateCooldownOverlay(remaining: number) {
+  const timer = document.getElementById('cooldown-timer');
+  if (timer) {
+    timer.textContent = Math.ceil(remaining / 1000).toString();
+  }
+}
+
+/**
+ * Remove cooldown overlay
+ */
+function removeCooldownOverlay() {
+  const overlay = document.getElementById('tiltcheck-cooldown-overlay');
+  if (overlay) overlay.remove();
+}
+
+/**
+ * Show vault prompt
+ */
+function showVaultPrompt(vaultData: VaultPromptData) {
+  const message = `Your balance is ${vaultData.suggestedAmount.toFixed(2)}. Consider vaulting to protect your winnings.`;
+  showInteractiveNotification(message, [
+    { text: 'Vault Now', action: () => openVaultInterface(vaultData.suggestedAmount) },
+    { text: 'Later', action: () => { } }
+  ]);
+}
+
+/**
+ * Show spending reminder
+ */
+function showSpendingReminder(comparison: SpendingReminderData) {
+  showInteractiveNotification(comparison.message, [
+    { text: 'Vault & Buy', action: () => openVaultInterface(comparison.cost) },
+    { text: 'Remind Me Later', action: () => { } }
+  ]);
+}
+
+/**
+ * Trigger stop loss
+ */
+function triggerStopLoss(data: StopLossData) {
+  triggerTouchGrassTimeout(data.reason);
+}
+
+/**
+ * Show phone a friend prompt
+ */
+function showPhoneFriendPrompt() {
+  showInteractiveNotification(
+    'Multiple tilt signs detected. Consider calling someone before continuing.',
+    [
+      { text: 'Take Break', action: () => startCooldown(5 * 60 * 1000) },
+      { text: 'Continue', action: () => { } }
+    ]
+  );
+}
+
+/**
+ * Show break prompt
+ */
+function showBreakPrompt() {
+  showInteractiveNotification(
+    'You have been playing for a while. How about a quick break?',
+    [
+      { text: '5 Min Break', action: () => startCooldown(5 * 60 * 1000) },
+      { text: 'Keep Playing', action: () => { } }
+    ]
+  );
+}
+
+/**
+ * Open vault interface (integrate with LockVault)
+ */
+function openVaultInterface(amount: number) {
+  // Send vault request to background script for processing
+  chrome.runtime.sendMessage({
+    type: 'open_vault',
+    data: { suggestedAmount: amount }
+  }, (response) => {
+    if (response?.success) {
+      showNotification('✓ Vault interface opened', 'success');
+    } else if (response?.error) {
+      showNotification(`✗ Vault error: ${response.error}`, 'error');
+    }
+  });
+}
+
+/**
+ * Show persistent warning (reserved for future use)
+ */
+function _showPersistentWarning(message: string) {
+  const warning = document.createElement('div');
+  warning.style.cssText = `
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    background: linear-gradient(135deg, #ff3838 0%, #cc0000 100%);
+    color: white;
+    padding: 15px;
+    text-align: center;
+    font-family: Arial, sans-serif;
+    font-size: 14px;
+    font-weight: bold;
+    z-index: 999998;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  `;
+  warning.textContent = message;
+  document.body.appendChild(warning);
+}
+
+/**
+ * Show interactive notification
+ */
+function showInteractiveNotification(message: string, actions: Array<{ text: string; action: () => void }>) {
+  const notification = document.createElement('div');
+  notification.className = 'tiltguard-notification';
+  notification.style.cssText = `
+    position: fixed;
+    top: 80px;
+    right: 20px;
+    background: rgba(0, 0, 0, 0.95);
+    color: white;
+    padding: 20px;
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0, 255, 136, 0.3);
+    z-index: 999999;
+    max-width: 350px;
+    font-family: Arial, sans-serif;
+    border: 2px solid #00ff88;
+  `;
+
+  const messageEl = document.createElement('p');
+  messageEl.style.cssText = 'margin-bottom: 15px; font-size: 14px; line-height: 1.4;';
+  messageEl.textContent = message;
+  notification.appendChild(messageEl);
+
+  const actionsContainer = document.createElement('div');
+  actionsContainer.style.cssText = 'display: flex; gap: 10px;';
+
+  for (const actionDef of actions) {
+    const button = document.createElement('button');
+    button.textContent = actionDef.text;
+    button.style.cssText = `
+      flex: 1;
+      padding: 10px;
+      border: none;
+      border-radius: 6px;
+      font-size: 12px;
+      font-weight: bold;
+      cursor: pointer;
+      background: linear-gradient(135deg, #00ff88 0%, #00ccff 100%);
+      color: black;
+    `;
+
+    button.addEventListener('click', () => {
+      actionDef.action();
+      notification.remove();
+    });
+
+    actionsContainer.appendChild(button);
+  }
+
+  notification.appendChild(actionsContainer);
+  document.body.appendChild(notification);
+
+  // Auto-remove after 30 seconds
+  setTimeout(() => notification.remove(), 30000);
+}
+
+/**
+ * Show notification message
+ */
+function showNotification(message: string, type: 'success' | 'warning' | 'error' = 'success') {
+  const notification = document.createElement('div');
+  const bgColors = {
+    success: 'linear-gradient(135deg, #10b981 0%, #059669 100%)',
+    warning: 'linear-gradient(135deg, #f59e0b 0%, #d97706 100%)',
+    error: 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)'
+  };
+
+  notification.style.cssText = `
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    background: ${bgColors[type]};
+    color: white;
+    padding: 15px 20px;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    z-index: 999999;
+    max-width: 350px;
+    font-family: Arial, sans-serif;
+    font-size: 14px;
+    animation: slideIn 0.3s ease;
+  `;
+  notification.textContent = message;
+  document.body.appendChild(notification);
+
+  // Auto-remove after 5 seconds
+  setTimeout(() => {
+    notification.style.animation = 'slideOut 0.3s ease';
+    setTimeout(() => notification.remove(), 300);
+  }, 5000);
+}
+
+/**
+ * Detect casino ID from hostname
+ */
+function detectCasinoId(): string {
+  const hostname = window.location.hostname.toLowerCase();
+
+  // Use isDomain for secure domain matching
+  if (isDomain(hostname, 'stake.com') || isDomain(hostname, 'stake.us')) return 'stake';
+  if (isDomain(hostname, 'roobet.com')) return 'roobet';
+  if (isDomain(hostname, 'bc.game')) return 'bc-game';
+  if (isDomain(hostname, 'duelbits.com')) return 'duelbits';
+  if (isDomain(hostname, 'rollbit.com')) return 'rollbit';
+  if (isDomain(hostname, 'shuffle.com')) return 'shuffle';
+  if (isDomain(hostname, 'gamdom.com')) return 'gamdom';
+  if (isDomain(hostname, 'csgoempire.com')) return 'csgoempire';
+
+  // Extract domain name as fallback
+  const parts = hostname.replace('www.', '').split('.');
+  return parts[0] || 'unknown';
+}
+
+/**
+ * Detect game ID from URL or page content
+ */
+function detectGameId(): string {
+  const pathname = window.location.pathname.toLowerCase();
+  const href = window.location.href.toLowerCase();
+
+  // Try to extract from URL patterns
+  // e.g., /casino/slots/game-name, /games/sweet-bonanza
+  const patterns = [
+    /\/casino\/slots\/([a-z0-9-]+)/,
+    /\/games?\/([a-z0-9-]+)/,
+    /\/slots?\/([a-z0-9-]+)/,
+    /\/play\/([a-z0-9-]+)/
+  ];
+
+  for (const pattern of patterns) {
+    const match = pathname.match(pattern) || href.match(pattern);
+    if (match && match[1]) {
+      return match[1];
+    }
+  }
+
+  // Try to get from page title
+  const pageTitle = document.title.toLowerCase();
+  if (pageTitle.includes('sweet bonanza')) return 'sweet-bonanza';
+  if (pageTitle.includes('gates of olympus')) return 'gates-of-olympus';
+  if (pageTitle.includes('sugar rush')) return 'sugar-rush';
+  if (pageTitle.includes('starlight princess')) return 'starlight-princess';
+  if (pageTitle.includes('wild west gold')) return 'wild-west-gold';
+  if (pageTitle.includes('dog house')) return 'dog-house';
+  if (pageTitle.includes('book of dead')) return 'book-of-dead';
+  if (pageTitle.includes('fire joker')) return 'fire-joker';
+
+  return 'unknown-game';
+}
+
+/**
+ * Get user ID from storage or generate one
+ */
+async function getUserId(): Promise<string> {
+  const createUserId = () => {
+    const rand = crypto.getRandomValues(new Uint32Array(1))[0].toString(36);
+    return `user_${Date.now()}_${rand}`;
+  };
+  return new Promise((resolve) => {
+    try {
+      // 1. Prefer authenticated Discord ID if available
+      chrome.storage.local.get(['userData', 'tiltguard_user_id'], (result: UserStorageSnapshot) => {
+        if (result.userData?.id) {
+          resolve(result.userData.id as string);
+        } else if (result.tiltguard_user_id) {
+          resolve(result.tiltguard_user_id as string);
+        } else {
+          // Generate new user ID
+          const newId = createUserId();
+          chrome.storage.local.set({ tiltguard_user_id: newId });
+          resolve(newId as string);
+        }
+      });
+    } catch {
+      // Fallback to localStorage
+      const storedUserData = localStorage.getItem('userData');
+      if (storedUserData) {
+        try {
+          const user = JSON.parse(storedUserData);
+          if (user.id) return resolve(user.id);
+        } catch { /* ignore */ }
+      }
+      
+      let userId = localStorage.getItem('tiltguard_user_id');
+      if (!userId) {
+        userId = createUserId();
+        localStorage.setItem('tiltguard_user_id', userId);
+      }
+      resolve(userId);
+    }
+  });
+}
+
+async function getLinkedDiscordId(): Promise<string | null> {
+  return new Promise((resolve) => {
+    try {
+      chrome.storage.local.get(['userData'], (result: UserStorageSnapshot) => {
+        resolve(typeof result.userData?.discordId === 'string' ? result.userData.discordId : null);
+      });
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+/**
+ * Setup listeners for "Play" button to capture commitment
+ */
+function setupFairnessListeners() {
+  if (fairnessPlayObserver) {
+    fairnessPlayObserver.disconnect();
+  }
+
+  fairnessPlayObserver = new MutationObserver((mutations) => {
+    if (typeof document === 'undefined' || !document.body) {
+      return;
+    }
+    if (mutationsOnlyTouchSafetyRoots(mutations)) {
+      return;
+    }
+
+    // Generic selector for bet buttons - refine per casino
+    const playBtns = document.querySelectorAll('[data-testid="bet-button"], .bet-button, button[class*="bet"]');
+
+    playBtns.forEach((btn) => {
+      if (!(btn instanceof HTMLElement) || isInsideTiltcheckSafetyRoot(btn)) {
+        return;
+      }
+      if (!btn.dataset.tiltCheckAttached) {
+        btn.dataset.tiltCheckAttached = "true";
+        btn.addEventListener('click', async () => {
+          try {
+            const discordId = await getUserId();
+            const clientSeed = localStorage.getItem('tiltcheck_client_seed') || 'default-seed';
+
+            sessionStorage.setItem('tiltcheck_pending_commitment', JSON.stringify({
+              discordId,
+              clientSeed,
+              timestamp: Date.now()
+            }));
+          } catch (err) {
+            console.error("[TiltCheck] Commitment Error:", err);
+          }
+        });
+      }
+    });
+  });
+
+  fairnessPlayObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+/**
+ * Verify the fairness of a finished spin
+ */
+async function verifySpinFairness(spinData: FairnessSpinData, gameId: string) {
+  // Null means verification has not completed yet; allow analysis until verdict arrives.
+  if (casinoVerification != null && !casinoVerification.shouldAnalyze) {
+    return;
+  }
+
+  if (!fairness || !analyzer) return;
+
+  const storedCommitment = sessionStorage.getItem('tiltcheck_pending_commitment');
+  if (!storedCommitment) return; // No commitment made for this spin
+
+  try {
+    const parsedCommitment: unknown = JSON.parse(storedCommitment);
+    if (!isFairnessCommitment(parsedCommitment)) {
+      return;
+    }
+    const commitment = parsedCommitment;
+
+    // Clear immediately to prevent reusing for next spin
+    sessionStorage.removeItem('tiltcheck_pending_commitment');
+
+    if (typeof commitment.blockHash !== 'string' || commitment.blockHash.trim() === '') {
+      console.warn('[TiltCheck] Missing block hash for fairness verification');
+      return;
+    }
+
+    // 1. Calculate the "Source of Truth" from the commitment
+    const expectedHash = await fairness.generateHash(
+      commitment.blockHash,
+      commitment.discordId,
+      commitment.clientSeed
+    );
+    const expectedFloat = fairness.hashToFloat(expectedHash);
+
+    // 2. Normalize based on Game ID
+    let expectedResult: number | string = expectedFloat;
+    let gameType = 'standard';
+
+    if (gameId.includes('dice')) {
+      gameType = 'dice';
+      expectedResult = fairness.getDiceResult(expectedFloat);
+    } else if (gameId.includes('limbo') || gameId.includes('crash')) {
+      gameType = 'limbo';
+      expectedResult = fairness.getLimboResult(expectedFloat);
+    } else if (gameId.includes('plinko')) {
+      gameType = 'plinko';
+      // Default to 16 rows if unknown, or extract from spinData if available
+      const rows = spinData.rows || 16;
+      expectedResult = fairness.getPlinkoPath(expectedHash, rows).join(',');
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(`[TiltCheck] Fair Result Calculated (${gameType}):`, expectedResult);
+      console.log(`[TiltCheck] Server Hash:`, expectedHash);
+    }
+
+    // 3. Verify against Casino Data
+    // If the casino provided the hash in the metadata, we can verify strictly
+    if (spinData.hash) {
+      const isHashValid = spinData.hash === expectedHash;
+      if (isHashValid) {
+        window.dispatchEvent(new CustomEvent('tg-status-update', { detail: { message: 'Fairness Verified (Hash Match)', type: 'success' } }));
+        showNotification("Fair Game Verified (Hash Match)", "success");
+      } else {
+        showNotification("Fairness Hash Mismatch!", "error");
+        console.warn(`[TiltCheck] Hash Mismatch! Expected: ${expectedHash}, Got: ${spinData.hash}`);
+      }
+    } else if (spinData.gameResult !== null && spinData.gameResult !== undefined) {
+      // Automated check against scraped result
+      const resultVal = Number(spinData.gameResult);
+
+      // Only compare if expectedResult is a number (skip Plinko paths for now)
+      if (typeof expectedResult === 'number') {
+        // Use a reasonable tolerance (e.g. 0.05 for dice/crash rounding)
+        if (Math.abs(resultVal - expectedResult) < 0.05) {
+          window.dispatchEvent(new CustomEvent('tg-status-update', { detail: { message: `Fairness Verified (Result: ${resultVal})`, type: 'success' } }));
+          showNotification(`Fair Game Verified (Result: ${resultVal})`, "success");
+          if (process.env.NODE_ENV !== 'production') {
+            console.log(`[TiltCheck] Scraped result ${resultVal} matches expected ${expectedResult}`);
+          }
+        } else {
+          console.warn(`[TiltCheck] Result Mismatch! Expected: ${expectedResult}, Scraped: ${resultVal}`);
+        }
+      }
+    } else {
+      // If no hash provided, we rely on the user checking the console or UI overlay
+      // In a full implementation, we would use Analyzer.waitForResult() here to scrape the visual result
+      if (process.env.NODE_ENV !== 'production') {
+        console.log(`[TiltCheck] Visual Verify: Does the screen show ${expectedResult}?`);
+      }
+      window.dispatchEvent(new CustomEvent('tg-status-update', { detail: { message: `Visual Check: Expecting ${expectedResult}`, type: 'info' } }));
+    }
+
+  } catch (err) {
+    console.error("[TiltCheck] Verification Error:", err);
+  }
+}
+
+// Listen for extension messages
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Message received:', message.type);
+
+  // Keep excluded domains isolated even if content script is injected.
+  if (isExcludedDomain && message.type !== 'get_sidebar_state') {
+    sendResponse({ error: 'Feature disabled on this domain' });
+    return true;
+  }
+
+  switch (message.type) {
+    case 'toggle_sidebar': {
+      void openRuntimeFromToolbar()
+        .then(sendResponse)
+        .catch((err) => {
+          sendResponse({ success: false, error: err instanceof Error ? err.message : 'Runtime toggle failed' });
+        });
+      break;
+    }
+
+    case 'open_sidebar': {
+      void startRuntimeAtDocumentEnd({ forceEnable: true })
+        .then(() => {
+          const sidebarEl = document.getElementById('tiltcheck-sidebar');
+          if (!sidebarEl) {
+            sidebar = initSidebar(disableInjectionFromHud);
+          }
+          const visible = setSidebarVisibility(true);
+          persistSidebarVisibility(true);
+          sendResponse({ success: true, visible, injectionDisabled: false });
+        })
+        .catch((err) => {
+          sendResponse({ success: false, error: err instanceof Error ? err.message : 'Runtime open failed' });
+        });
+      break;
+    }
+
+    case 'get_sidebar_state':
+      sendResponse(getSidebarState());
+      break;
+
+    default:
+      sendResponse({ error: 'Unknown message type' });
+  }
+  return true;
+});
+
+/**
+ * Show high-intensity Redeem Nudge
+ */
+function showRedeemNudge(data: RedeemNudgeData) {
+  const existing = document.getElementById('tiltcheck-redeem-nudge');
+  if (existing) {
+    existing.remove();
+  }
+
+  const overlay = document.createElement('div');
+  overlay.id = 'tiltcheck-redeem-nudge';
+  overlay.style.cssText = `
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.95);
+    z-index: 1000000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    color: white;
+    font-family: 'Inter', sans-serif;
+    text-align: center;
+  `;
+
+  overlay.innerHTML = `
+    <div style="max-width: 500px; padding: 40px; border: 2px solid #00ff88; border-radius: 20px; background: rgba(0, 255, 136, 0.05); box-shadow: 0 0 50px rgba(0, 255, 136, 0.2);">
+      <h1 style="font-size: 64px; margin-bottom: 10px;">WIN</h1>
+      <h2 style="font-size: 28px; color: #00ff88; text-transform: uppercase; letter-spacing: 2px;">WIN SECURED</h2>
+      <p style="font-size: 20px; margin: 20px 0; line-height: 1.5;">${data.message}</p>
+      <div style="font-size: 48px; font-weight: 800; margin-bottom: 30px;">$${Number(data.amount).toFixed(2)}</div>
+      
+      <div style="display: flex; gap: 15px; justify-content: center;">
+        <button id="redeem-btn" style="background: #00ff88; color: black; border: none; padding: 15px 30px; border-radius: 10px; font-weight: 900; cursor: pointer; font-size: 18px; text-transform: uppercase;">
+          Redeem Now & Quit
+        </button>
+        <button id="later-btn" style="background: transparent; color: white; border: 1px solid rgba(255,255,255,0.2); padding: 15px 30px; border-radius: 10px; font-weight: 600; cursor: pointer; font-size: 14px;">
+          Maybe Later (Risk It)
+        </button>
+      </div>
+      
+      <div style="margin-top: 30px; font-size: 11px; opacity: 0.5; text-transform: uppercase; letter-spacing: 1px;">
+        Made for Degens. By Degens.
+      </div>
+    </div>
+  `;
+
+  document.body.appendChild(overlay);
+
+  document.getElementById('redeem-btn')?.addEventListener('click', (evt) => {
+    const btn = evt.currentTarget as HTMLButtonElement;
+    btn.disabled = true;
+    btn.textContent = 'Securing win...';
+
+    relayWinSecure(data.amount)
+      .then(() => {
+        overlay.remove();
+        window.close(); // Hard exit
+      })
+      .catch(() => {
+        btn.disabled = false;
+        btn.textContent = 'Redeem Now & Quit';
+        const errEl = document.createElement('p');
+        errEl.style.cssText = 'margin-top: 12px; color: #ff4444; font-size: 13px; font-weight: 600;';
+        errEl.textContent = 'Win relay failed. Screenshot this and contact support.';
+        btn.parentElement?.insertAdjacentElement('afterend', errEl);
+      });
+  });
+
+  document.getElementById('later-btn')?.addEventListener('click', () => {
+    overlay.remove();
+  });
+}
+
+async function relayWinSecure(amount: number) {
+  const userId = await getUserId();
+  const response = await postWinSecureTelemetry({ amount, userId });
+
+  if (!response.ok) {
+    console.error('[TiltCheck] Win secure relay returned non-OK status:', response.status);
+    throw new Error(`Win secure relay failed with status ${response.status}`);
+  }
+}
+
+/**
+ * Aggressive teardown when Pro is disabled or storage flag flips off.
+ * Does not remove Core Touch Grass lockdown (`#tiltcheck-lockdown-root`).
+ */
+export function deactivateProMonolith(): void {
+  teardownInjectedRuntime();
+  proMonolithActive = false;
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('[TiltCheck Pro] Monolith surface safely defused. Core shield remains active.');
+  }
+}
+
+/**
+ * Pro monolith bootstrap — full sidebar, extractor, fairness, telemetry, game blocker.
+ * Loaded only when `tiltcheck_pro_monolith_enabled` is true in chrome.storage.local.
+ */
+export async function startProMonolith(): Promise<void> {
+  if (proMonolithActive) {
+    await startRuntimeAtDocumentEnd();
+    return;
+  }
+  await startRuntimeAtDocumentEnd();
+  proMonolithActive = true;
+}
+
+if (process.env.NODE_ENV !== 'production') console.log('[TiltGuard] Pro monolith bootstrap module loaded');

--- a/apps/chrome-extension/src/pro/blocked-games-options.ts
+++ b/apps/chrome-extension/src/pro/blocked-games-options.ts
@@ -1,0 +1,63 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+
+/**
+ * Local strategic game filter — storage schema for Pro-only self-exclusion.
+ * Popup/options should write `tiltcheck_blocked_games` after explicit user opt-in.
+ */
+
+export const TILTCHECK_BLOCKED_GAMES_KEY = 'tiltcheck_blocked_games';
+
+/** Master switch for local strategic filters (popup must set after explicit opt-in). */
+export const TILTCHECK_GAME_BLOCK_OPT_IN_KEY = 'tiltcheck_game_block_opt_in';
+
+const MAX_BLOCKED_ENTRIES = 64;
+const MAX_SLUG_LENGTH = 48;
+
+/**
+ * Normalize user input to a URL/DOM-safe slug (e.g. "Plinko" → "plinko").
+ */
+export function normalizeBlockedGameSlug(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (!slug || slug.length > MAX_SLUG_LENGTH) return null;
+  return slug;
+}
+
+/**
+ * Sanitize a stored array into unique slugs.
+ */
+export function normalizeBlockedGamesList(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of raw) {
+    const slug = normalizeBlockedGameSlug(item);
+    if (!slug || seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(slug);
+    if (out.length >= MAX_BLOCKED_ENTRIES) break;
+  }
+  return out;
+}
+
+export async function loadBlockedGameSlugs(): Promise<string[]> {
+  try {
+    const stored = await chrome.storage.local.get(TILTCHECK_BLOCKED_GAMES_KEY);
+    return normalizeBlockedGamesList(stored[TILTCHECK_BLOCKED_GAMES_KEY]);
+  } catch {
+    return [];
+  }
+}
+
+export async function loadGameBlockOptIn(): Promise<boolean> {
+  try {
+    const stored = await chrome.storage.local.get(TILTCHECK_GAME_BLOCK_OPT_IN_KEY);
+    return stored[TILTCHECK_GAME_BLOCK_OPT_IN_KEY] === true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/chrome-extension/src/pro/containment.ts
+++ b/apps/chrome-extension/src/pro/containment.ts
@@ -1,0 +1,49 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+
+/**
+ * DOM roots owned by Core / Pro safety surfaces. Mutation scanners must not
+ * sanitize or redact nodes inside these hosts.
+ */
+export const TILTCHECK_SAFETY_ROOT_IDS = [
+  'tiltcheck-lockdown-root',
+  'tiltcheck-local-game-block-overlay',
+  'tiltcheck-cooldown-overlay',
+  'tiltcheck-game-block-overlay',
+  'tiltcheck-redeem-nudge',
+  'tiltcheck-sidebar',
+  'tiltcheck-mobile-license-hud',
+] as const;
+
+export function isInsideTiltcheckSafetyRoot(node: Node | null): boolean {
+  if (!node || typeof Element === 'undefined' || !(node instanceof Element)) {
+    return false;
+  }
+  for (const id of TILTCHECK_SAFETY_ROOT_IDS) {
+    if (node.closest(`#${id}`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** True when every added/changed node in the batch is inside a safety root. */
+export function mutationsOnlyTouchSafetyRoots(mutations: MutationRecord[]): boolean {
+  const nodes: Node[] = [];
+  for (const m of mutations) {
+    for (const n of m.addedNodes) {
+      nodes.push(n);
+    }
+    if (m.target) {
+      nodes.push(m.target);
+    }
+  }
+  if (nodes.length === 0) {
+    return false;
+  }
+  return nodes.every((n) => {
+    if (typeof Element === 'undefined' || !(n instanceof Element)) {
+      return true;
+    }
+    return isInsideTiltcheckSafetyRoot(n);
+  });
+}

--- a/apps/chrome-extension/src/pro/local-game-blocker.ts
+++ b/apps/chrome-extension/src/pro/local-game-blocker.ts
@@ -1,0 +1,302 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+
+/**
+ * Pro-only strategic game filter — persistent local blocklist (no API).
+ * URL hard-stop + DOM grid redaction. Does not run in core content.ts.
+ */
+
+import {
+  loadBlockedGameSlugs,
+  loadGameBlockOptIn,
+  TILTCHECK_BLOCKED_GAMES_KEY,
+  TILTCHECK_GAME_BLOCK_OPT_IN_KEY,
+} from './blocked-games-options.js';
+import { isInsideTiltcheckSafetyRoot, mutationsOnlyTouchSafetyRoots } from './containment.js';
+
+const LOCAL_OVERLAY_ID = 'tiltcheck-local-game-block-overlay';
+const SANITIZED_ATTR = 'data-tiltcheck-local-blocked';
+const PLACEHOLDER_LABEL = '[ GAME EXCLUDED ]';
+
+export class LocalGameBlocker {
+  private blockedSlugs: string[] = [];
+  private enforcementEnabled = false;
+  private observer: MutationObserver | null = null;
+  private scanScheduled = false;
+  private storageListenerAttached = false;
+
+  private readonly handleStorageChange = (
+    changes: Record<string, chrome.storage.StorageChange>,
+    area: string
+  ) => {
+    if (area !== 'local') return;
+    if (changes[TILTCHECK_BLOCKED_GAMES_KEY] || changes[TILTCHECK_GAME_BLOCK_OPT_IN_KEY]) {
+      void this.reloadAndScan();
+    }
+  };
+
+  async init(): Promise<void> {
+    await this.reloadAndScan();
+    this.startObserver();
+    this.attachStorageListener();
+  }
+
+  resume(_source = 'navigation'): void {
+    void this.reloadAndScan();
+  }
+
+  destroy(): void {
+    this.observer?.disconnect();
+    this.observer = null;
+    if (this.storageListenerAttached) {
+      try {
+        chrome.storage.onChanged.removeListener(this.handleStorageChange);
+      } catch {
+        // ignore
+      }
+      this.storageListenerAttached = false;
+    }
+    this.removeUrlOverlay();
+  }
+
+  private attachStorageListener(): void {
+    if (this.storageListenerAttached) return;
+    try {
+      chrome.storage.onChanged.addListener(this.handleStorageChange);
+      this.storageListenerAttached = true;
+    } catch {
+      // ignore in test harness
+    }
+  }
+
+  private async reloadAndScan(): Promise<void> {
+    this.enforcementEnabled = await loadGameBlockOptIn();
+    this.blockedSlugs = this.enforcementEnabled ? await loadBlockedGameSlugs() : [];
+    this.scan();
+  }
+
+  private scheduleScan(): void {
+    if (this.scanScheduled) return;
+    this.scanScheduled = true;
+    const run = () => {
+      this.scanScheduled = false;
+      this.scan();
+    };
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(run);
+    } else {
+      setTimeout(run, 0);
+    }
+  }
+
+  private scan(): void {
+    if (this.blockedSlugs.length === 0) {
+      this.removeUrlOverlay();
+      return;
+    }
+
+    const urlHit = this.matchUrl(window.location.href, this.blockedSlugs);
+    if (urlHit) {
+      this.injectUrlOverlay(urlHit);
+      return;
+    }
+
+    this.removeUrlOverlay();
+    this.redactDomMatches();
+  }
+
+  /** Returns matched slug when URL path/search references a blocked game. */
+  matchUrl(href: string, slugs: readonly string[] = this.blockedSlugs): string | null {
+    let pathSearch = '';
+    try {
+      const u = new URL(href, window.location.origin);
+      pathSearch = `${u.pathname}${u.search}`.toLowerCase();
+    } catch {
+      pathSearch = href.toLowerCase();
+    }
+
+    for (const slug of slugs) {
+      if (this.pathContainsSlug(pathSearch, slug)) {
+        return slug;
+      }
+    }
+    return null;
+  }
+
+  private pathContainsSlug(pathSearch: string, slug: string): boolean {
+    if (pathSearch.includes(`/${slug}/`) || pathSearch.includes(`/${slug}`)) {
+      return true;
+    }
+    if (pathSearch.includes(`games/${slug}`) || pathSearch.includes(`game/${slug}`)) {
+      return true;
+    }
+    const segmentMatch = pathSearch.split(/[/?#&=_-]+/).includes(slug);
+    return segmentMatch;
+  }
+
+  private redactDomMatches(): void {
+    for (const slug of this.blockedSlugs) {
+      const nodes = this.findGameNodes(slug);
+      for (const node of nodes) {
+        this.sanitizeNode(node, slug);
+      }
+    }
+  }
+
+  private findGameNodes(slug: string): HTMLElement[] {
+    const out = new Set<HTMLElement>();
+    const lower = slug.toLowerCase();
+
+    const tryAdd = (el: Element | null) => {
+      if (!el || !(el instanceof HTMLElement)) return;
+      if (isInsideTiltcheckSafetyRoot(el)) return;
+      if (el.closest(`#${LOCAL_OVERLAY_ID}`)) return;
+      const card = el.closest('a, button, [role="button"], article, li, div') as HTMLElement | null;
+      out.add(card ?? el);
+    };
+
+    for (const anchor of document.querySelectorAll<HTMLAnchorElement>('a[href]')) {
+      const href = anchor.getAttribute('href') ?? '';
+      if (href.toLowerCase().includes(lower)) {
+        tryAdd(anchor);
+      }
+    }
+
+    for (const el of document.querySelectorAll<HTMLElement>(
+      '[data-game-name], [data-game-id], [data-game], [data-testid*="game"]'
+    )) {
+      const blob = [
+        el.getAttribute('data-game-name'),
+        el.getAttribute('data-game-id'),
+        el.getAttribute('data-game'),
+        el.getAttribute('data-testid'),
+        el.textContent,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      if (blob.includes(lower)) {
+        tryAdd(el);
+      }
+    }
+
+    return [...out];
+  }
+
+  private sanitizeNode(target: HTMLElement, slug: string): void {
+    if (target.getAttribute(SANITIZED_ATTR) === slug) return;
+
+    const placeholder = document.createElement('div');
+    placeholder.setAttribute(SANITIZED_ATTR, slug);
+    placeholder.setAttribute('aria-label', `Game excluded: ${slug}`);
+    placeholder.style.cssText = `
+      background: #1a1d24;
+      color: #ff4a4a;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 72px;
+      height: 100%;
+      width: 100%;
+      font-family: ui-monospace, monospace;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      border: 1px dashed #ff4a4a;
+      border-radius: 4px;
+      box-sizing: border-box;
+      pointer-events: none;
+      user-select: none;
+    `;
+    placeholder.textContent = PLACEHOLDER_LABEL;
+
+    if (target.tagName === 'A') {
+      const wrap = document.createElement('div');
+      wrap.setAttribute(SANITIZED_ATTR, slug);
+      wrap.style.pointerEvents = 'none';
+      wrap.appendChild(placeholder);
+      target.replaceChildren(wrap);
+      target.removeAttribute('href');
+      target.style.pointerEvents = 'none';
+      target.setAttribute(SANITIZED_ATTR, slug);
+      return;
+    }
+
+    target.replaceChildren(placeholder);
+    target.style.pointerEvents = 'none';
+    target.setAttribute(SANITIZED_ATTR, slug);
+  }
+
+  private injectUrlOverlay(slug: string): void {
+    if (document.getElementById(LOCAL_OVERLAY_ID)) return;
+
+    const overlay = document.createElement('div');
+    overlay.id = LOCAL_OVERLAY_ID;
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-label', `Access denied: ${slug} is on your exclusion list`);
+    Object.assign(overlay.style, {
+      position: 'fixed',
+      inset: '0',
+      zIndex: '2147483646',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: 'rgba(10, 12, 16, 0.97)',
+      fontFamily: 'ui-monospace, monospace',
+      color: '#f5f5f5',
+      padding: '24px',
+      boxSizing: 'border-box',
+    });
+
+    overlay.innerHTML = `
+      <div style="max-width: 420px; text-align: center; border: 1px solid #333; border-radius: 12px; padding: 32px 24px; background: #111;">
+        <div style="color: #ff4a4a; font-size: 11px; font-weight: 800; letter-spacing: 0.2em; margin-bottom: 12px;">STRATEGIC FILTER</div>
+        <h2 style="margin: 0 0 12px; font-size: 22px; font-weight: 900; color: #fff;">Access denied.</h2>
+        <p style="margin: 0 0 8px; font-size: 14px; line-height: 1.5; color: #aaa;">
+          <strong style="color: #ff4a4a;">${slug}</strong> is on your local exclusion list.
+        </p>
+        <p style="margin: 0 0 20px; font-size: 12px; line-height: 1.45; color: #666;">
+          Past-you removed this game type from your interface. Edit the list in extension settings (Pro).
+        </p>
+        <button type="button" id="tiltcheck-local-block-back" style="
+          background: transparent;
+          border: 1px solid #444;
+          color: #ccc;
+          padding: 10px 18px;
+          border-radius: 8px;
+          font-size: 12px;
+          font-weight: 700;
+          cursor: pointer;
+          text-transform: uppercase;
+          letter-spacing: 0.06em;
+        ">Go back</button>
+        <footer style="margin-top: 20px; font-size: 10px; color: #444;">Made for Degens. By Degens.</footer>
+      </div>
+    `;
+
+    document.body.appendChild(overlay);
+
+    document.getElementById('tiltcheck-local-block-back')?.addEventListener('click', () => {
+      if (window.history.length > 1) {
+        window.history.back();
+      } else {
+        window.location.assign('/');
+      }
+    });
+  }
+
+  private removeUrlOverlay(): void {
+    document.getElementById(LOCAL_OVERLAY_ID)?.remove();
+  }
+
+  private startObserver(): void {
+    if (!document.body) return;
+    this.observer = new MutationObserver((mutations) => {
+      if (mutationsOnlyTouchSafetyRoots(mutations)) {
+        return;
+      }
+      this.scheduleScan();
+    });
+    this.observer.observe(document.body, { childList: true, subtree: true });
+  }
+}

--- a/apps/chrome-extension/src/pro/local-game-blocker.ts
+++ b/apps/chrome-extension/src/pro/local-game-blocker.ts
@@ -134,30 +134,37 @@ export class LocalGameBlocker {
   }
 
   private redactDomMatches(): void {
-    for (const slug of this.blockedSlugs) {
-      const nodes = this.findGameNodes(slug);
+    const nodesBySlug = this.collectBlockedNodes();
+    for (const [slug, nodes] of nodesBySlug) {
       for (const node of nodes) {
         this.sanitizeNode(node, slug);
       }
     }
   }
 
-  private findGameNodes(slug: string): HTMLElement[] {
-    const out = new Set<HTMLElement>();
-    const lower = slug.toLowerCase();
+  /** Single-pass DOM scan: map each blocked slug to nodes that reference it. */
+  private collectBlockedNodes(): Map<string, HTMLElement[]> {
+    const buckets = new Map<string, Set<HTMLElement>>();
+    for (const slug of this.blockedSlugs) {
+      buckets.set(slug, new Set());
+    }
 
-    const tryAdd = (el: Element | null) => {
+    const tryAdd = (el: Element | null, slug: string) => {
       if (!el || !(el instanceof HTMLElement)) return;
       if (isInsideTiltcheckSafetyRoot(el)) return;
       if (el.closest(`#${LOCAL_OVERLAY_ID}`)) return;
       const card = el.closest('a, button, [role="button"], article, li, div') as HTMLElement | null;
-      out.add(card ?? el);
+      buckets.get(slug)?.add(card ?? el);
     };
 
+    const slugLowers = this.blockedSlugs.map((s) => ({ slug: s, lower: s.toLowerCase() }));
+
     for (const anchor of document.querySelectorAll<HTMLAnchorElement>('a[href]')) {
-      const href = anchor.getAttribute('href') ?? '';
-      if (href.toLowerCase().includes(lower)) {
-        tryAdd(anchor);
+      const href = (anchor.getAttribute('href') ?? '').toLowerCase();
+      for (const { slug, lower } of slugLowers) {
+        if (href.includes(lower)) {
+          tryAdd(anchor, slug);
+        }
       }
     }
 
@@ -174,12 +181,31 @@ export class LocalGameBlocker {
         .filter(Boolean)
         .join(' ')
         .toLowerCase();
-      if (blob.includes(lower)) {
-        tryAdd(el);
+      for (const { slug, lower } of slugLowers) {
+        if (blob.includes(lower)) {
+          tryAdd(el, slug);
+        }
       }
     }
 
-    return [...out];
+    const result = new Map<string, HTMLElement[]>();
+    for (const [slug, set] of buckets) {
+      if (set.size > 0) {
+        result.set(slug, [...set]);
+      }
+    }
+    return result;
+  }
+
+  private disableInteractiveTarget(target: HTMLElement): void {
+    target.style.pointerEvents = 'none';
+    if (target instanceof HTMLButtonElement) {
+      target.disabled = true;
+    }
+    if (target.getAttribute('role') === 'button') {
+      target.setAttribute('aria-disabled', 'true');
+      target.tabIndex = -1;
+    }
   }
 
   private sanitizeNode(target: HTMLElement, slug: string): void {
@@ -216,13 +242,13 @@ export class LocalGameBlocker {
       wrap.appendChild(placeholder);
       target.replaceChildren(wrap);
       target.removeAttribute('href');
-      target.style.pointerEvents = 'none';
+      this.disableInteractiveTarget(target);
       target.setAttribute(SANITIZED_ATTR, slug);
       return;
     }
 
     target.replaceChildren(placeholder);
-    target.style.pointerEvents = 'none';
+    this.disableInteractiveTarget(target);
     target.setAttribute(SANITIZED_ATTR, slug);
   }
 

--- a/apps/chrome-extension/src/tilt-detector.ts
+++ b/apps/chrome-extension/src/tilt-detector.ts
@@ -67,6 +67,19 @@ export interface InterventionAction {
   data?: any;
 }
 
+export type RiskProfile = 'conservative' | 'moderate' | 'degen';
+
+const PROFILE_MULTIPLIERS: Record<RiskProfile, number> = {
+  conservative: 1.2,
+  moderate: 1.0,
+  degen: 0.8,
+};
+
+/** Typical reel / animation loop window on instant games (ms). */
+const ANIMATION_LOOP_MS = 500;
+/** Retain click timestamps for micro-pacing trend analysis. */
+const MICRO_PACING_RETENTION_MS = 60_000;
+
 export class TiltDetector {
   private bets: BetEvent[] = [];
   private clicks: number[] = []; // Timestamps of clicks
@@ -78,6 +91,7 @@ export class TiltDetector {
   private currentBalance: number | null = null;
   private initialBalance: number | null = null;
   private redeemThreshold: number | null = null;
+  private riskProfile: RiskProfile = 'moderate';
 
   // Configuration
   private config = {
@@ -117,11 +131,20 @@ export class TiltDetector {
     ]
   };
 
-  constructor(initialBalance: number | null, riskLevel: 'conservative' | 'moderate' | 'degen' = 'moderate', redeemThreshold?: number) {
+  constructor(initialBalance: number | null, riskLevel: RiskProfile = 'moderate', redeemThreshold?: number) {
     this.currentBalance = initialBalance;
     this.initialBalance = initialBalance;
     this.redeemThreshold = redeemThreshold || null;
-    this.applyRiskProfile(riskLevel);
+    this.setRiskProfile(riskLevel);
+  }
+
+  setRiskProfile(level: RiskProfile): void {
+    this.riskProfile = level;
+    this.applyRiskProfile(level);
+  }
+
+  getRiskProfile(): RiskProfile {
+    return this.riskProfile;
   }
 
   private classifyBetResult(bet: number, payout: number): BetEvent['result'] {
@@ -212,9 +235,100 @@ export class TiltDetector {
   recordClick(): void {
     const now = Date.now();
     this.clicks.push(now);
+    this.clicks = this.clicks.filter((t) => now - t < MICRO_PACING_RETENTION_MS);
+  }
 
-    // Keep only recent clicks (within window)
-    this.clicks = this.clicks.filter(t => now - t < this.config.clickWindow);
+  /** Recent inter-click deltas (ms), oldest first. */
+  private computeRecentClickDeltas(maxDeltas = 8): number[] {
+    const sorted = [...this.clicks].sort((a, b) => a - b);
+    const deltas: number[] = [];
+    for (let i = 1; i < sorted.length && deltas.length < maxDeltas; i++) {
+      deltas.push(sorted[i] - sorted[i - 1]);
+    }
+    return deltas;
+  }
+
+  getLastClickDeltaMs(): number | null {
+    const deltas = this.computeRecentClickDeltas();
+    return deltas.length > 0 ? deltas[deltas.length - 1] : null;
+  }
+
+  /**
+   * Continuous velocity contribution (0–45) from compressing click pacing.
+   */
+  private getMicroPacingComponent(): number {
+    const deltas = this.computeRecentClickDeltas();
+    if (deltas.length < 2) return 0;
+
+    const lastDelta = deltas[deltas.length - 1];
+    const recent = deltas.slice(-4);
+    const avgDelta = recent.reduce((sum, d) => sum + d, 0) / recent.length;
+
+    let velocity = 0;
+    if (lastDelta < ANIMATION_LOOP_MS) {
+      velocity += ((ANIMATION_LOOP_MS - lastDelta) / ANIMATION_LOOP_MS) * 28;
+    }
+    if (avgDelta < ANIMATION_LOOP_MS) {
+      velocity += ((ANIMATION_LOOP_MS - avgDelta) / ANIMATION_LOOP_MS) * 12;
+    }
+
+    let compressingSteps = 0;
+    for (let i = 1; i < recent.length; i++) {
+      if (recent[i] < recent[i - 1] * 0.92) {
+        compressingSteps++;
+      }
+    }
+    if (compressingSteps >= 2 && lastDelta < ANIMATION_LOOP_MS + 100) {
+      velocity += compressingSteps * 6;
+    }
+
+    return Math.min(45, velocity);
+  }
+
+  /**
+   * Exponential loss-streak weight when pacing is hot (co-occurrence required).
+   */
+  private getLossStreakCompoundComponent(): number {
+    if (this.consecutiveLosses <= 3) return 0;
+
+    const pacingHot =
+      this.getMicroPacingComponent() >= 10 ||
+      (this.getLastClickDeltaMs() !== null && this.getLastClickDeltaMs()! < ANIMATION_LOOP_MS);
+
+    if (!pacingHot) return 0;
+
+    const streakExcess = this.consecutiveLosses - 3;
+    const exponential = Math.pow(1.35, streakExcess);
+    const linear = streakExcess * 7;
+    return Math.min(35, linear * Math.min(2.5, exponential / 1.8));
+  }
+
+  private getIndicatorCompositeScore(): number {
+    const tiltSigns = this.detectAllTiltSigns();
+    const weights: Record<string, number> = {
+      rage_betting: 22,
+      chasing_losses: 26,
+      fast_clicks: 12,
+      bet_escalation: 18,
+      duration_warning: 8,
+      emotional_pattern: 16,
+      fatigue: 12,
+      martingale: 20,
+    };
+    const severityMultipliers = {
+      low: 0.5,
+      medium: 1.0,
+      high: 1.5,
+      critical: 2.0,
+    };
+
+    let score = 0;
+    for (const sign of tiltSigns) {
+      const weight = weights[sign.type] ?? 10;
+      const multiplier = severityMultipliers[sign.severity];
+      score += weight * multiplier * sign.confidence;
+    }
+    return Math.min(55, score);
   }
 
   /**
@@ -642,36 +756,15 @@ export class TiltDetector {
   }
 
   /**
-   * Get current tilt risk score (0-100)
+   * Composite tilt risk (0–100): indicators + micro-pacing + loss-streak compound, scaled by profile.
    */
   getTiltRiskScore(): number {
-    const tiltSigns = this.detectAllTiltSigns();
-
-    const weights = {
-      rage_betting: 25,
-      chasing_losses: 30,
-      fast_clicks: 15,
-      bet_escalation: 20,
-      duration_warning: 10,
-      emotional_pattern: 20,
-      fatigue: 15
-    };
-
-    const severityMultipliers = {
-      low: 0.5,
-      medium: 1.0,
-      high: 1.5,
-      critical: 2.0
-    };
-
-    let score = 0;
-    for (const sign of tiltSigns) {
-      const weight = weights[sign.type] || 10;
-      const multiplier = severityMultipliers[sign.severity];
-      score += weight * multiplier * sign.confidence;
-    }
-
-    return Math.min(100, Math.round(score));
+    const indicatorScore = this.getIndicatorCompositeScore();
+    const velocityScore = this.getMicroPacingComponent();
+    const lossCompound = this.getLossStreakCompoundComponent();
+    const raw = indicatorScore + velocityScore + lossCompound;
+    const profileMu = PROFILE_MULTIPLIERS[this.riskProfile];
+    return Math.min(100, Math.round(raw * profileMu));
   }
 
   /**

--- a/apps/chrome-extension/src/touch-grass-timeout.ts
+++ b/apps/chrome-extension/src/touch-grass-timeout.ts
@@ -1,0 +1,370 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+
+/**
+ * Touch Grass Timeout — fullscreen, non-dismissible pause until duration elapses.
+ * 8s breathing pacer, 20s forensic/mindfulness rotation, local-only (no network).
+ *
+ * Risk: undismissable by design — future popup settings must require explicit opt-in
+ * for duration and policy (accessibility + platform ToS posture).
+ */
+
+export const TOUCH_GRASS_DURATION_MS = 120_000;
+
+/** Forensic / mindfulness ticker cadence (ms). */
+export const MESSAGE_ROTATE_MS = 20_000;
+
+/** Fade between ticker lines (ms); keep shorter than MESSAGE_ROTATE_MS. */
+const MESSAGE_FADE_SWAP_MS = 450;
+
+export const BREAK_MESSAGES: readonly string[] = [
+  'Click velocity anomaly detected. Your brain is scrambling to patch a sudden dopamine drop, not a mathematical edge.',
+  'Fact: Fast-clicking alters nothing but the speed at which the house edge resolves against your balance.',
+  "House algorithms monitor pacing. When you accelerate play, you transition from choice to pure execution of the machine's loop.",
+  'Drop your shoulders. Unclench your jaw. Exhale completely. Mechanically cut the physical adrenaline loop.',
+  'The platform has a memory; house telemetry tracks your live click-velocity to categorize your risk and volatility tolerance in real time.',
+  "Turbo spins and short-cycling cut off your brain's natural evaluation window. The house relies on your auto-pilot.",
+  'Prefrontal cortex (rational limit) is offline. Amygdala (fight-or-flight) is driving. You cannot out-gamble a system while hijacked.',
+  'Inhale for 4 seconds. Exhale for 4 seconds. Let the neural chemical spike clear before the layout unlocks.',
+];
+
+const LOCKDOWN_ROOT_ID = 'tiltcheck-lockdown-root';
+const MESSAGE_EL_ID = 'tiltcheck-lockdown-message';
+const TIMER_ID = 'lockdown-timer';
+
+let overlayActive = false;
+
+export function blockBettingUI(block: boolean): void {
+  const betButtons = document.querySelectorAll<HTMLElement>(
+    'button[class*="bet"], button[class*="spin"], [data-action="bet"], [data-action="spin"]'
+  );
+
+  betButtons.forEach((btn) => {
+    if (block) {
+      if (btn instanceof HTMLButtonElement) {
+        btn.disabled = true;
+      }
+      btn.style.opacity = '0.5';
+      btn.style.cursor = 'not-allowed';
+      btn.dataset.tiltguardBlocked = 'true';
+    } else if (btn.dataset.tiltguardBlocked) {
+      if (btn instanceof HTMLButtonElement) {
+        btn.disabled = false;
+      }
+      btn.style.opacity = '';
+      btn.style.cursor = '';
+      delete btn.dataset.tiltguardBlocked;
+    }
+  });
+}
+
+function injectLockdownStyles(root: HTMLElement): void {
+  const style = document.createElement('style');
+  style.textContent = `
+    #${LOCKDOWN_ROOT_ID} {
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      width: 100vw !important;
+      height: 100vh !important;
+      background: #0f1115 !important;
+      z-index: 2147483647 !important;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      font-family: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+      color: #ff4a4a;
+      box-sizing: border-box;
+      padding: 1.5rem;
+      overflow-y: auto;
+      user-select: none;
+    }
+
+    #${LOCKDOWN_ROOT_ID} .tiltcheck-lockdown-inner {
+      width: 100%;
+      max-width: 32rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+    }
+
+    #${LOCKDOWN_ROOT_ID} .tiltcheck-eyebrow {
+      font-size: 0.6875rem;
+      font-weight: 800;
+      letter-spacing: 0.28em;
+      text-transform: uppercase;
+      color: #ff4a4a;
+      margin-bottom: 0.75rem;
+    }
+
+    #${LOCKDOWN_ROOT_ID} .tiltcheck-lockdown-headline {
+      font-size: 1.625rem;
+      font-weight: 900;
+      letter-spacing: -0.02em;
+      color: #ffffff;
+      margin: 0 0 0.75rem;
+      line-height: 1.15;
+    }
+
+    #${LOCKDOWN_ROOT_ID} .tiltcheck-lockdown-reason {
+      font-size: 0.875rem;
+      line-height: 1.45;
+      color: rgba(255, 255, 255, 0.82);
+      margin: 0 0 1.25rem;
+      max-width: 28rem;
+    }
+
+    /* Center stage: pacer ring + timer digits */
+    .tiltcheck-pacer-stage {
+      position: relative;
+      width: 250px;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 2rem 0;
+    }
+
+    .tiltcheck-breath-pacer {
+      position: absolute;
+      width: 200px;
+      height: 200px;
+      border: 4px solid #ff4a4a;
+      border-radius: 50%;
+      box-shadow: 0 0 15px rgba(255, 74, 74, 0.2);
+      animation: tiltcheck-breath-pacer 8s ease-in-out infinite;
+      pointer-events: none;
+    }
+
+    #${TIMER_ID} {
+      font-size: 3.5rem;
+      font-weight: bold;
+      color: #ffffff;
+      z-index: 10;
+      font-variant-numeric: tabular-nums;
+      line-height: 1;
+      text-shadow: 0 2px 20px rgba(0, 0, 0, 0.5);
+    }
+
+    @keyframes tiltcheck-breath-pacer {
+      0%, 100% {
+        transform: scale(0.6);
+        opacity: 0.3;
+        box-shadow: 0 0 10px rgba(255, 74, 74, 0.1);
+      }
+      50% {
+        transform: scale(1.1);
+        opacity: 0.9;
+        border-color: #4affb4;
+        box-shadow: 0 0 30px rgba(74, 255, 180, 0.4);
+      }
+    }
+
+    #${LOCKDOWN_ROOT_ID} .tiltcheck-breath-hint {
+      position: absolute;
+      bottom: -2.25rem;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 18rem;
+      font-size: 0.625rem;
+      opacity: 0.55;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.55);
+    }
+
+    #${LOCKDOWN_ROOT_ID} .tiltcheck-signal-label {
+      font-size: 0.625rem;
+      font-weight: 800;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: rgba(255, 74, 74, 0.65);
+      margin-bottom: 0.5rem;
+      align-self: stretch;
+      text-align: left;
+    }
+
+    #${MESSAGE_EL_ID} {
+      font-size: 0.875rem;
+      line-height: 1.5;
+      margin: 0;
+      text-align: left;
+      min-height: 4.5em;
+      align-self: stretch;
+      color: rgba(245, 245, 245, 0.94);
+      transition: opacity 0.45s ease;
+    }
+
+    #${LOCKDOWN_ROOT_ID} .tiltcheck-lockdown-foot {
+      font-size: 0.6875rem;
+      line-height: 1.45;
+      color: rgba(255, 255, 255, 0.45);
+      margin: 1.25rem 0 0;
+      max-width: 26rem;
+    }
+  `;
+  root.insertBefore(style, root.firstChild);
+}
+
+/**
+ * Full-viewport lock. Undismissable until the countdown completes.
+ */
+export function triggerTouchGrassTimeout(reason: string, durationMs: number = TOUCH_GRASS_DURATION_MS): void {
+  if (overlayActive) {
+    return;
+  }
+  overlayActive = true;
+
+  blockBettingUI(true);
+
+  const existing = document.getElementById(LOCKDOWN_ROOT_ID);
+  if (existing) {
+    existing.remove();
+  }
+
+  const root = document.createElement('div');
+  root.id = LOCKDOWN_ROOT_ID;
+  root.setAttribute('role', 'dialog');
+  root.setAttribute('aria-modal', 'true');
+  root.setAttribute(
+    'aria-label',
+    'Touch Grass timeout — session pause with breathing pacer and rotating guidance'
+  );
+
+  injectLockdownStyles(root);
+
+  const inner = document.createElement('div');
+  inner.className = 'tiltcheck-lockdown-inner';
+
+  const eyebrow = document.createElement('div');
+  eyebrow.className = 'tiltcheck-eyebrow';
+  eyebrow.textContent = 'Touch Grass Timeout';
+
+  const headline = document.createElement('h1');
+  headline.className = 'tiltcheck-lockdown-headline';
+  headline.textContent = 'Hold the line. Recalibrate.';
+
+  const reasonEl = document.createElement('p');
+  reasonEl.className = 'tiltcheck-lockdown-reason';
+  reasonEl.textContent = reason;
+
+  const stage = document.createElement('div');
+  stage.className = 'tiltcheck-pacer-stage';
+
+  const breathRing = document.createElement('div');
+  breathRing.className = 'tiltcheck-breath-pacer';
+  breathRing.setAttribute('aria-hidden', 'true');
+
+  const timerWrap = document.createElement('div');
+  timerWrap.id = TIMER_ID;
+  timerWrap.setAttribute('aria-live', 'polite');
+  timerWrap.setAttribute('aria-atomic', 'true');
+
+  const breathHint = document.createElement('div');
+  breathHint.className = 'tiltcheck-breath-hint';
+  breathHint.textContent = 'Inhale as the ring expands — exhale as it releases.';
+
+  const signalLabel = document.createElement('div');
+  signalLabel.className = 'tiltcheck-signal-label';
+  signalLabel.textContent = 'Signal';
+
+  const messageRegion = document.createElement('div');
+  messageRegion.className = 'tiltcheck-signal-region';
+  messageRegion.setAttribute('role', 'region');
+  messageRegion.setAttribute('aria-label', 'System message updates every 20 seconds');
+
+  const messageEl = document.createElement('p');
+  messageEl.id = MESSAGE_EL_ID;
+  messageEl.setAttribute('aria-live', 'off');
+  messageEl.textContent = BREAK_MESSAGES[0] ?? '';
+
+  const foot = document.createElement('p');
+  foot.className = 'tiltcheck-lockdown-foot';
+  foot.textContent =
+    'This tab stays locked until the counter hits zero. No dismiss. Future settings: explicit opt-in for duration and policy.';
+
+  stage.appendChild(breathRing);
+  stage.appendChild(timerWrap);
+  stage.appendChild(breathHint);
+
+  inner.appendChild(eyebrow);
+  inner.appendChild(headline);
+  inner.appendChild(reasonEl);
+  inner.appendChild(stage);
+  messageRegion.appendChild(messageEl);
+  inner.appendChild(signalLabel);
+  inner.appendChild(messageRegion);
+  inner.appendChild(foot);
+  root.appendChild(inner);
+  document.body.appendChild(root);
+
+  const stopBlocking = (e: Event) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const captureOpts = { capture: true };
+  root.addEventListener('click', stopBlocking, captureOpts);
+  root.addEventListener('mousedown', stopBlocking, captureOpts);
+  root.addEventListener('mouseup', stopBlocking, captureOpts);
+  root.addEventListener('keydown', stopBlocking, captureOpts);
+  root.addEventListener('touchstart', stopBlocking, captureOpts);
+  document.addEventListener('keydown', stopBlocking, captureOpts);
+
+  let messageIndex = 0;
+  let pendingFadeTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const clearPendingFade = () => {
+    if (pendingFadeTimeout !== null) {
+      clearTimeout(pendingFadeTimeout);
+      pendingFadeTimeout = null;
+    }
+  };
+
+  const messageRotateIntervalId = window.setInterval(() => {
+    if (!document.getElementById(LOCKDOWN_ROOT_ID) || !messageEl.isConnected) {
+      clearInterval(messageRotateIntervalId);
+      return;
+    }
+    messageIndex = (messageIndex + 1) % BREAK_MESSAGES.length;
+    messageEl.style.opacity = '0';
+    clearPendingFade();
+    pendingFadeTimeout = window.setTimeout(() => {
+      pendingFadeTimeout = null;
+      if (!messageEl.isConnected) return;
+      messageEl.textContent = BREAK_MESSAGES[messageIndex] ?? '';
+      messageEl.style.opacity = '1';
+    }, MESSAGE_FADE_SWAP_MS);
+  }, MESSAGE_ROTATE_MS);
+
+  let countdownIntervalId: ReturnType<typeof setInterval> | null = null;
+  const started = Date.now();
+
+  const finish = () => {
+    if (countdownIntervalId !== null) {
+      clearInterval(countdownIntervalId);
+      countdownIntervalId = null;
+    }
+    clearInterval(messageRotateIntervalId);
+    clearPendingFade();
+    root.remove();
+    document.removeEventListener('keydown', stopBlocking, captureOpts);
+    blockBettingUI(false);
+    overlayActive = false;
+  };
+
+  const tick = () => {
+    const left = Math.max(0, durationMs - (Date.now() - started));
+    const sec = Math.ceil(left / 1000);
+    timerWrap.textContent = `${sec}`;
+
+    if (left <= 0) {
+      finish();
+    }
+  };
+
+  tick();
+  countdownIntervalId = window.setInterval(tick, 250);
+}

--- a/apps/chrome-extension/tests/unit/blocked-games-options.test.ts
+++ b/apps/chrome-extension/tests/unit/blocked-games-options.test.ts
@@ -1,0 +1,34 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+import { describe, expect, it, vi } from 'vitest';
+import {
+  loadBlockedGameSlugs,
+  normalizeBlockedGameSlug,
+  normalizeBlockedGamesList,
+  TILTCHECK_BLOCKED_GAMES_KEY,
+} from '../../src/pro/blocked-games-options.js';
+
+describe('blocked-games-options', () => {
+  it('normalizes slugs', () => {
+    expect(normalizeBlockedGameSlug('  Plinko  ')).toBe('plinko');
+    expect(normalizeBlockedGameSlug('')).toBeNull();
+  });
+
+  it('dedupes and caps list length', () => {
+    const list = normalizeBlockedGamesList(['plinko', 'PLINKO', 'mines', 42, '']);
+    expect(list).toEqual(['plinko', 'mines']);
+  });
+
+  it('loads from chrome.storage.local', async () => {
+    vi.stubGlobal('chrome', {
+      storage: {
+        local: {
+          get: vi.fn().mockResolvedValue({
+            [TILTCHECK_BLOCKED_GAMES_KEY]: ['plinko', 'slots'],
+          }),
+        },
+      },
+    });
+    const slugs = await loadBlockedGameSlugs();
+    expect(slugs).toEqual(['plinko', 'slots']);
+  });
+});

--- a/apps/chrome-extension/tests/unit/containment.test.ts
+++ b/apps/chrome-extension/tests/unit/containment.test.ts
@@ -1,0 +1,45 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  isInsideTiltcheckSafetyRoot,
+  mutationsOnlyTouchSafetyRoots,
+} from '../../src/pro/containment.js';
+
+describe('containment safety roots', () => {
+  it('detects nodes inside lockdown and local block overlays', () => {
+    document.body.innerHTML = `
+      <div id="tiltcheck-lockdown-root"><span id="inner">x</span></div>
+      <div id="tiltcheck-local-game-block-overlay"></div>
+    `;
+    expect(isInsideTiltcheckSafetyRoot(document.getElementById('inner')!)).toBe(true);
+    expect(isInsideTiltcheckSafetyRoot(document.getElementById('tiltcheck-local-game-block-overlay')!)).toBe(
+      true
+    );
+    expect(isInsideTiltcheckSafetyRoot(document.body)).toBe(false);
+  });
+
+  it('treats mutations that only touch safety roots as ignorable', () => {
+    const host = document.createElement('div');
+    host.id = 'tiltcheck-lockdown-root';
+    document.body.appendChild(host);
+    const child = document.createElement('p');
+    host.appendChild(child);
+
+    const record: MutationRecord = {
+      type: 'childList',
+      target: host,
+      addedNodes: [child] as unknown as NodeList,
+      removedNodes: [] as unknown as NodeList,
+      previousSibling: null,
+      nextSibling: null,
+      attributeName: null,
+      attributeNamespace: null,
+      oldValue: null,
+    };
+
+    expect(mutationsOnlyTouchSafetyRoots([record])).toBe(true);
+  });
+});

--- a/apps/chrome-extension/tests/unit/content.test.ts
+++ b/apps/chrome-extension/tests/unit/content.test.ts
@@ -1,10 +1,11 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-09 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
 /**
  * @vitest-environment jsdom
+ * Core content script — TiltDetector + Touch Grass path when Pro monolith is off.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-type OnMessageHandler = (message: any, sender: any, sendResponse: (response: any) => void) => boolean | void;
+type OnMessageHandler = (message: unknown, sender: unknown, sendResponse: (response: unknown) => void) => boolean | void;
 
 const flush = async () => {
   await Promise.resolve();
@@ -24,14 +25,14 @@ function createChromeMock(initialStorage: Record<string, unknown> = {}) {
     },
     storage: {
       local: {
-        get: vi.fn((keys: string[] | string, callback?: (value: any) => void) => {
+        get: vi.fn((keys: string[] | string, callback?: (value: unknown) => void) => {
           const result = Array.isArray(keys)
             ? Object.fromEntries(keys.map((k) => [k, storageState[k] ?? null]))
             : { [keys]: storageState[keys] ?? null };
           if (callback) callback(result);
           return Promise.resolve(result);
         }),
-        set: vi.fn((data: any, callback?: () => void) => {
+        set: vi.fn((data: Record<string, unknown>, callback?: () => void) => {
           Object.assign(storageState, data);
           callback?.();
           return Promise.resolve();
@@ -39,96 +40,11 @@ function createChromeMock(initialStorage: Record<string, unknown> = {}) {
       },
     },
   };
-  (globalThis as any).chrome = chromeMock;
+  (globalThis as unknown as { chrome: typeof chromeMock }).chrome = chromeMock;
   return { chromeMock, listeners, storageState };
 }
 
-function mockHeavyDependencies(options?: {
-  extractBalance?: number | null;
-  tiltDetectorSpy?: ReturnType<typeof vi.fn>;
-  verification?: Record<string, unknown>;
-  sidebarStub?: Record<string, ReturnType<typeof vi.fn>>;
-}) {
-  const extractorInitialize = vi.fn().mockResolvedValue(undefined);
-  const tiltDetectorSpy = options?.tiltDetectorSpy ?? vi.fn();
-  const sidebarStub = options?.sidebarStub ?? {
-    updateLicense: vi.fn(),
-    updateStatus: vi.fn(),
-    updateRealityCheck: vi.fn(),
-    addFeedMessage: vi.fn(),
-    updateTilt: vi.fn(),
-    updateStats: vi.fn(),
-    notifyBuddy: vi.fn(),
-  };
-  const verification = {
-    isLegitimate: true,
-    licenseInfo: {
-      found: true,
-      issuingAuthority: 'Malta Gaming Authority',
-      jurisdiction: 'Malta',
-      verified: true,
-      source: 'Current page footer scan',
-      lastVerifiedAt: '2026-05-09T00:00:00.000Z',
-      warnings: [],
-    },
-    verdict: 'legitimate',
-    shouldAnalyze: true,
-    ...options?.verification,
-  };
-  vi.doMock('../../src/extractor.js', () => ({
-    AnalyzerClient: class {
-      connect = vi.fn().mockResolvedValue(undefined);
-      disconnect = vi.fn();
-      sendSpin = vi.fn();
-    },
-    CasinoDataExtractor: class {
-      initialize = extractorInitialize;
-      extractBalance = vi.fn().mockReturnValue(options?.extractBalance ?? 100);
-      startObserving = vi.fn().mockReturnValue(() => {});
-    },
-  }));
-  vi.doMock('../../src/tilt-detector.js', () => ({
-    TiltDetector: class {
-      constructor(...args: unknown[]) {
-        tiltDetectorSpy(...args);
-      }
-      recordBet = vi.fn();
-      getSessionSummary = vi.fn().mockReturnValue({ currentBalance: 100, startTime: Date.now(), totalBets: 0, totalWagered: 0, totalWon: 0 });
-      detectAllTiltSigns = vi.fn().mockReturnValue([]);
-      getTiltRiskScore = vi.fn().mockReturnValue(0);
-      generateInterventions = vi.fn().mockReturnValue([]);
-      updateBalance = vi.fn();
-    },
-  }));
-  vi.doMock('../../src/license-verifier.js', () => ({
-    CasinoLicenseVerifier: class {
-      verifyCasino = vi.fn().mockReturnValue(verification);
-    },
-    buildLicensePresentation: vi.fn().mockImplementation((verification) => ({
-      summary: verification?.warningMessage ?? 'License verified: Malta Gaming Authority',
-      tone: verification?.shouldAnalyze === false ? 'risk' : 'verified',
-      details: ['Source: test registry', 'Last verified: test run', 'Not legal advice.'],
-    })),
-    getAnalysisBlockMessage: vi.fn().mockImplementation((verification) => verification?.shouldAnalyze === false ? verification.warningMessage : null),
-  }));
-  vi.doMock('../../src/sidebar/index.js', () => ({
-    initSidebar: vi.fn(() => {
-      let sidebar = document.getElementById('tiltcheck-sidebar');
-      if (!sidebar) {
-        sidebar = document.createElement('div');
-        sidebar.id = 'tiltcheck-sidebar';
-        document.body.appendChild(sidebar);
-      }
-      return sidebarStub;
-    }),
-  }));
-  vi.doMock('../../src/analyzer.js', () => ({ Analyzer: class {} }));
-  vi.doMock('../../src/FairnessService.js', () => ({ FairnessService: class {} }));
-  vi.doMock('@tiltcheck/utils', () => ({ SolanaProvider: class { getLatestBlockHash = vi.fn().mockResolvedValue('hash'); } }));
-  return { extractorInitialize, tiltDetectorSpy };
-}
-
-describe('content script readiness contracts', () => {
+describe('core content script contracts', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
@@ -136,178 +52,52 @@ describe('content script readiness contracts', () => {
     document.body.innerHTML = '';
   });
 
-  it('registers runtime message handler and supports sidebar state/toggle', async () => {
+  it('registers a runtime message handler', async () => {
     const { listeners } = createChromeMock();
-    mockHeavyDependencies();
-    (window as any).TiltCheckSidebar = {
-      create: vi.fn(() => {
-        const div = document.createElement('div');
-        div.id = 'tiltcheck-sidebar';
-        div.style.display = 'none';
-        document.body.appendChild(div);
-        return div;
-      }),
-      updateLicense: vi.fn(),
-      updateGuardian: vi.fn(),
-      updateStats: vi.fn(),
-      updateTilt: vi.fn(),
-      notifyBuddy: vi.fn(),
-    };
-
     await import('../../src/content.ts');
     await flush();
     expect(listeners).toHaveLength(1);
+  });
 
-    const onMessage = listeners[0];
+  it('returns core-only sidebar state when Pro monolith storage flag is unset', async () => {
+    const { listeners } = createChromeMock();
+    await import('../../src/content.ts');
+    await flush();
+
     const getState = vi.fn();
-    onMessage({ type: 'get_sidebar_state' }, null, getState);
-    expect(getState).toHaveBeenCalledWith(expect.objectContaining({ exists: true }));
-    const initialVisible = Boolean(getState.mock.calls[0]?.[0]?.visible);
+    listeners[0]!({ type: 'get_sidebar_state' }, null, getState);
+    expect(getState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        exists: false,
+        visible: false,
+        coreOnly: true,
+      })
+    );
+  });
 
-    const toggle = vi.fn();
-    onMessage({ type: 'toggle_sidebar' }, null, toggle);
-    await vi.waitFor(() => {
-      expect(toggle).toHaveBeenCalled();
-    });
-    expect(toggle).toHaveBeenCalledWith(expect.objectContaining({ success: true, visible: !initialVisible }));
+  it('toggle_sidebar explains core-only mode', async () => {
+    const { listeners } = createChromeMock();
+    await import('../../src/content.ts');
+    await flush();
+
+    const send = vi.fn();
+    listeners[0]!({ type: 'toggle_sidebar' }, null, send);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        coreOnly: true,
+        hint: expect.stringContaining('tiltcheck_pro_monolith_enabled'),
+      })
+    );
   });
 
   it('returns explicit error for unknown runtime message type', async () => {
     const { listeners } = createChromeMock();
-    mockHeavyDependencies();
-    (window as any).TiltCheckSidebar = {
-      create: vi.fn(() => null),
-      updateLicense: vi.fn(),
-      updateGuardian: vi.fn(),
-      updateStats: vi.fn(),
-      updateTilt: vi.fn(),
-      notifyBuddy: vi.fn(),
-    };
     await import('../../src/content.ts');
     await flush();
 
     const response = vi.fn();
-    listeners[0]({ type: 'unknown_message' }, null, response);
+    listeners[0]!({ type: 'unknown_message' }, null, response);
     expect(response).toHaveBeenCalledWith({ error: 'Unknown message type' });
-  });
-
-  it('blocks auto analysis when the site is unlicensed', async () => {
-    const sidebarStub = {
-      syncAccountUi: vi.fn(),
-      showMainContent: vi.fn(),
-      addFeedMessage: vi.fn(),
-      getStorage: vi.fn().mockResolvedValue({}),
-      setStorage: vi.fn().mockResolvedValue(undefined),
-      updateStatus: vi.fn(),
-      updateRealityCheck: vi.fn(),
-      updateLicense: vi.fn(),
-      updateTilt: vi.fn(),
-      updateStats: vi.fn(),
-      notifyBuddy: vi.fn(),
-      openPremium: vi.fn().mockResolvedValue(undefined),
-    };
-    const { extractorInitialize } = mockHeavyDependencies({
-      sidebarStub,
-      verification: {
-        isLegitimate: false,
-        licenseInfo: {
-          found: false,
-          verified: false,
-          source: 'Current page DOM scan',
-          lastVerifiedAt: '2026-05-09T00:00:00.000Z',
-          warnings: [],
-        },
-        verdict: 'unlicensed',
-        shouldAnalyze: false,
-        warningMessage: 'No valid gambling license found yet. Normal TiltCheck analysis is disabled on this site.',
-      },
-    });
-
-    await import('../../src/content.ts');
-    await flush();
-
-    expect(extractorInitialize).not.toHaveBeenCalled();
-    expect(sidebarStub.updateLicense).toHaveBeenCalledWith(expect.objectContaining({
-      verdict: 'unlicensed',
-      shouldAnalyze: false,
-    }));
-    const mobileHud = document.getElementById('tiltcheck-mobile-license-hud');
-    expect(mobileHud?.dataset.status).toBe('risk');
-    expect(mobileHud?.textContent).toBe('No valid gambling license found yet. Normal TiltCheck analysis is disabled on this site. | Made for Degens. By Degens.');
-    expect(sidebarStub.updateStatus).toHaveBeenCalledWith(
-      'No valid gambling license found yet. Normal TiltCheck analysis is disabled on this site.',
-      'warning',
-    );
-    expect(sidebarStub.updateRealityCheck).toHaveBeenCalledWith(false);
-  });
-
-  it('passes through honest zero balances without fabricating a starting amount', async () => {
-    const { listeners } = createChromeMock();
-    const tiltDetectorSpy = vi.fn();
-    mockHeavyDependencies({ extractBalance: 0, tiltDetectorSpy });
-    (window as any).TiltCheckSidebar = {
-      create: vi.fn(() => {
-        const div = document.createElement('div');
-        div.id = 'tiltcheck-sidebar';
-        document.body.appendChild(div);
-        return div;
-      }),
-      updateLicense: vi.fn(),
-      updateGuardian: vi.fn(),
-      updateStats: vi.fn(),
-      updateTilt: vi.fn(),
-      notifyBuddy: vi.fn(),
-    };
-
-    await import('../../src/content.ts');
-    await flush();
-
-    expect(listeners).toHaveLength(1);
-    expect(tiltDetectorSpy).toHaveBeenCalledWith(0, 'moderate', 0);
-  });
-
-  it('honors the persisted injection off-switch until the toolbar wakes it back up', async () => {
-    const { listeners, storageState } = createChromeMock({ tiltcheck_injection_disabled: true });
-    const sidebarStub = {
-      syncAccountUi: vi.fn(),
-      showMainContent: vi.fn(),
-      addFeedMessage: vi.fn(),
-      getStorage: vi.fn().mockResolvedValue({}),
-      setStorage: vi.fn().mockResolvedValue(undefined),
-      updateStatus: vi.fn(),
-      updateRealityCheck: vi.fn(),
-      updateLicense: vi.fn(),
-      updateTilt: vi.fn(),
-      updateStats: vi.fn(),
-      notifyBuddy: vi.fn(),
-      openPremium: vi.fn().mockResolvedValue(undefined),
-    };
-    const initSidebar = vi.fn(() => sidebarStub);
-    vi.doMock('../../src/sidebar/index.js', () => ({ initSidebar }));
-    mockHeavyDependencies();
-
-    await import('../../src/content.ts');
-    await flush();
-
-    expect(initSidebar).not.toHaveBeenCalled();
-    const getState = vi.fn();
-    listeners[0]({ type: 'get_sidebar_state' }, null, getState);
-    expect(getState).toHaveBeenCalledWith(expect.objectContaining({
-      exists: false,
-      injectionDisabled: true,
-    }));
-
-    const toggle = vi.fn();
-    listeners[0]({ type: 'toggle_sidebar' }, null, toggle);
-
-    await vi.waitFor(() => {
-      expect(toggle).toHaveBeenCalledWith(expect.objectContaining({
-        success: true,
-        visible: true,
-        injectionDisabled: false,
-      }));
-    });
-    expect(storageState.tiltcheck_injection_disabled).toBe(false);
-    // Runtime may attach the sidebar via `initialize()` after force-enable; do not require the mocked `initSidebar` hook.
   });
 });

--- a/apps/chrome-extension/tests/unit/content.test.ts
+++ b/apps/chrome-extension/tests/unit/content.test.ts
@@ -91,13 +91,14 @@ describe('core content script contracts', () => {
     );
   });
 
-  it('returns explicit error for unknown runtime message type', async () => {
+  it('does not claim unknown runtime messages (allows other listeners to respond)', async () => {
     const { listeners } = createChromeMock();
     await import('../../src/content.ts');
     await flush();
 
     const response = vi.fn();
-    listeners[0]!({ type: 'unknown_message' }, null, response);
-    expect(response).toHaveBeenCalledWith({ error: 'Unknown message type' });
+    const handled = listeners[0]!({ type: 'unknown_message' }, null, response);
+    expect(handled).toBe(false);
+    expect(response).not.toHaveBeenCalled();
   });
 });

--- a/apps/chrome-extension/tests/unit/core-options.test.ts
+++ b/apps/chrome-extension/tests/unit/core-options.test.ts
@@ -1,0 +1,62 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_RISK_PROFILE,
+  DEFAULT_RISK_THRESHOLD,
+  DEFAULT_TOUCH_GRASS_COOLDOWN_MS,
+  DEFAULT_TOUCH_GRASS_DURATION_MS,
+  loadCoreCircuitBreakerOptions,
+  TILTCHECK_RISK_PROFILE_KEY,
+  TILTCHECK_RISK_THRESHOLD_KEY,
+  TILTCHECK_TOUCH_GRASS_OPT_IN_KEY,
+} from '../../src/core-options.js';
+
+describe('loadCoreCircuitBreakerOptions', () => {
+  beforeEach(() => {
+    vi.stubGlobal('chrome', {
+      storage: {
+        local: {
+          get: vi.fn().mockResolvedValue({}),
+        },
+      },
+    });
+  });
+
+  it('returns defaults when storage is empty', async () => {
+    const opts = await loadCoreCircuitBreakerOptions();
+    expect(opts.riskThreshold).toBe(DEFAULT_RISK_THRESHOLD);
+    expect(opts.touchGrassDurationMs).toBe(DEFAULT_TOUCH_GRASS_DURATION_MS);
+    expect(opts.touchGrassCooldownMs).toBe(DEFAULT_TOUCH_GRASS_COOLDOWN_MS);
+    expect(opts.enforcementEnabled).toBe(true);
+    expect(opts.riskProfile).toBe(DEFAULT_RISK_PROFILE);
+  });
+
+  it('loads risk profile from tiltcheck_risk_profile with riskLevel fallback', async () => {
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      [TILTCHECK_RISK_PROFILE_KEY]: 'degen',
+      riskLevel: 'conservative',
+    });
+    const opts = await loadCoreCircuitBreakerOptions();
+    expect(opts.riskProfile).toBe('degen');
+  });
+
+  it('clamps risk threshold and honors custom duration/cooldown', async () => {
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      [TILTCHECK_RISK_THRESHOLD_KEY]: 200,
+      tiltcheck_touch_grass_duration_ms: 90_000,
+      tiltcheck_touch_grass_cooldown_ms: 100_000,
+    });
+    const opts = await loadCoreCircuitBreakerOptions();
+    expect(opts.riskThreshold).toBe(100);
+    expect(opts.touchGrassDurationMs).toBe(90_000);
+    expect(opts.touchGrassCooldownMs).toBe(100_000);
+  });
+
+  it('disables enforcement when opt-in is explicitly false', async () => {
+    (chrome.storage.local.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      [TILTCHECK_TOUCH_GRASS_OPT_IN_KEY]: false,
+    });
+    const opts = await loadCoreCircuitBreakerOptions();
+    expect(opts.enforcementEnabled).toBe(false);
+  });
+});

--- a/apps/chrome-extension/tests/unit/local-game-blocker.test.ts
+++ b/apps/chrome-extension/tests/unit/local-game-blocker.test.ts
@@ -1,0 +1,124 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  TILTCHECK_BLOCKED_GAMES_KEY,
+  TILTCHECK_GAME_BLOCK_OPT_IN_KEY,
+} from '../../src/pro/blocked-games-options.js';
+
+function stubChromeStorage(initial: Record<string, unknown> = {}) {
+  const storagePayload: Record<string, unknown> = {
+    [TILTCHECK_BLOCKED_GAMES_KEY]: ['plinko'],
+    [TILTCHECK_GAME_BLOCK_OPT_IN_KEY]: true,
+    ...initial,
+  };
+  vi.stubGlobal('chrome', {
+    storage: {
+      local: {
+        get: vi.fn(async (keys?: string | string[]) => {
+          if (!keys) return { ...storagePayload };
+          const keyList = typeof keys === 'string' ? [keys] : keys;
+          return Object.fromEntries(
+            keyList.map((k) => [k, storagePayload[k] ?? null])
+          );
+        }),
+        set: vi.fn(async (data: Record<string, unknown>) => {
+          Object.assign(storagePayload, data);
+        }),
+      },
+      onChanged: {
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      },
+    },
+  });
+  return storagePayload;
+}
+
+describe('LocalGameBlocker', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+    stubChromeStorage();
+  });
+
+  it('matches blocked game in URL path', async () => {
+    const { LocalGameBlocker } = await import('../../src/pro/local-game-blocker.ts');
+    const blocker = new LocalGameBlocker();
+    expect(blocker.matchUrl('https://stake.us/casino/games/plinko', ['plinko'])).toBe('plinko');
+    expect(blocker.matchUrl('https://stake.us/casino/lobby', ['plinko'])).toBeNull();
+  });
+
+  it('does not block when game-block opt-in is false', async () => {
+    stubChromeStorage({
+      [TILTCHECK_BLOCKED_GAMES_KEY]: ['plinko'],
+      [TILTCHECK_GAME_BLOCK_OPT_IN_KEY]: false,
+    });
+    const { LocalGameBlocker } = await import('../../src/pro/local-game-blocker.ts');
+    window.history.pushState({}, '', '/casino/games/plinko');
+    const blocker = new LocalGameBlocker();
+    await blocker.init();
+    expect(document.getElementById('tiltcheck-local-game-block-overlay')).toBeNull();
+    blocker.destroy();
+  });
+
+  it('injects URL overlay when navigating to a blocked game', async () => {
+    const { LocalGameBlocker } = await import('../../src/pro/local-game-blocker.ts');
+    window.history.pushState({}, '', '/casino/games/plinko');
+
+    const blocker = new LocalGameBlocker();
+    await blocker.init();
+
+    expect(document.getElementById('tiltcheck-local-game-block-overlay')).toBeTruthy();
+    blocker.destroy();
+  });
+
+  it('does not scan when mutations only touch the lockdown overlay', async () => {
+    const { LocalGameBlocker } = await import('../../src/pro/local-game-blocker.ts');
+    window.history.pushState({}, '', '/casino');
+
+    document.body.innerHTML = `
+      <a href="/casino/games/plinko" data-testid="game-card-plinko">Plinko</a>
+      <div id="tiltcheck-lockdown-root"></div>
+    `;
+
+    const blocker = new LocalGameBlocker();
+    await blocker.init();
+
+    const plinkoLink = document.querySelector('a[data-testid="game-card-plinko"]') as HTMLAnchorElement;
+    expect(plinkoLink?.getAttribute('data-tiltcheck-local-blocked')).toBe('plinko');
+
+    const lockdown = document.getElementById('tiltcheck-lockdown-root')!;
+    lockdown.appendChild(document.createElement('span'));
+
+    expect(plinkoLink?.getAttribute('data-tiltcheck-local-blocked')).toBe('plinko');
+    blocker.destroy();
+  });
+
+  it('redacts game cards in the lobby grid', async () => {
+    const { LocalGameBlocker } = await import('../../src/pro/local-game-blocker.ts');
+    window.history.pushState({}, '', '/casino');
+
+    document.body.innerHTML = `
+      <a href="/casino/games/plinko" data-testid="game-card-plinko">Plinko</a>
+      <a href="/casino/games/blackjack">Blackjack</a>
+    `;
+
+    const blocker = new LocalGameBlocker();
+    await blocker.init();
+
+    const plinkoLink = document.querySelector('a[data-testid="game-card-plinko"]') as HTMLAnchorElement;
+    expect(plinkoLink?.getAttribute('data-tiltcheck-local-blocked')).toBe('plinko');
+    expect(plinkoLink?.textContent).toContain('[ GAME EXCLUDED ]');
+    expect(plinkoLink?.getAttribute('href')).toBeNull();
+
+    const blackjack = document.querySelector('a[href="/casino/games/blackjack"]');
+    expect(blackjack?.getAttribute('data-tiltcheck-local-blocked')).toBeNull();
+
+    blocker.destroy();
+  });
+});

--- a/apps/chrome-extension/tests/unit/message-contracts.test.ts
+++ b/apps/chrome-extension/tests/unit/message-contracts.test.ts
@@ -221,19 +221,18 @@ describe('Sidebar/content/page-bridge message contracts', () => {
     onMessage({ type: 'get_sidebar_state' }, null, getStateResponse);
     expect(getStateResponse).toHaveBeenCalledWith(
       expect.objectContaining({
-        exists: true,
+        exists: false,
+        coreOnly: true,
       }),
     );
-    const initialState = getStateResponse.mock.calls[0]?.[0];
-    expect(typeof initialState?.visible).toBe('boolean');
 
     const toggleResponse = vi.fn();
     onMessage({ type: 'toggle_sidebar' }, null, toggleResponse);
     await flush();
     expect(toggleResponse).toHaveBeenCalledWith(
       expect.objectContaining({
-        success: true,
-        visible: !initialState.visible,
+        success: false,
+        coreOnly: true,
       }),
     );
 
@@ -244,8 +243,8 @@ describe('Sidebar/content/page-bridge message contracts', () => {
     });
     expect(openResponse).toHaveBeenCalledWith(
       expect.objectContaining({
-        success: true,
-        visible: true,
+        success: false,
+        coreOnly: true,
       }),
     );
   });

--- a/apps/chrome-extension/tests/unit/popup-settings.test.ts
+++ b/apps/chrome-extension/tests/unit/popup-settings.test.ts
@@ -1,0 +1,36 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+import { describe, expect, it } from 'vitest';
+import {
+  addCustomSlug,
+  clampDurationMs,
+  clampRisk,
+  formatDurationLabel,
+  riskLabel,
+  toggleSlugInList,
+} from '../../src/popup-settings.js';
+
+describe('popup-settings helpers', () => {
+  it('clamps risk and duration', () => {
+    expect(clampRisk(40)).toBe(50);
+    expect(clampRisk(120)).toBe(100);
+    expect(clampDurationMs(10_000)).toBe(30_000);
+    expect(clampDurationMs(999_999)).toBe(300_000);
+  });
+
+  it('toggles slugs with normalization', () => {
+    const first = toggleSlugInList([], 'Plinko');
+    expect(first).toEqual(['plinko']);
+    const second = toggleSlugInList(first, 'plinko');
+    expect(second).toEqual([]);
+  });
+
+  it('adds custom slugs safely', () => {
+    expect(addCustomSlug(['mines'], '  Keno  ')).toEqual(['mines', 'keno']);
+    expect(addCustomSlug(['mines'], '!!!')).toEqual(['mines']);
+  });
+
+  it('formats labels', () => {
+    expect(formatDurationLabel(90_000)).toBe('1m 30s');
+    expect(riskLabel(55)).toBe('Strict');
+  });
+});

--- a/apps/chrome-extension/tests/unit/pro-monolith-bootstrap.test.ts
+++ b/apps/chrome-extension/tests/unit/pro-monolith-bootstrap.test.ts
@@ -1,0 +1,299 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+/**
+ * @vitest-environment jsdom
+ * Pro monolith bootstrap — sidebar, extractor, license gate, injection toggle.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const flush = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+function mockHeavyDependencies(options?: {
+  extractBalance?: number | null;
+  tiltDetectorSpy?: ReturnType<typeof vi.fn>;
+  verification?: Record<string, unknown>;
+  sidebarStub?: Record<string, ReturnType<typeof vi.fn>>;
+}) {
+  const extractorInitialize = vi.fn().mockResolvedValue(undefined);
+  const tiltDetectorSpy = options?.tiltDetectorSpy ?? vi.fn();
+  const sidebarStub = options?.sidebarStub ?? {
+    updateLicense: vi.fn(),
+    updateStatus: vi.fn(),
+    updateRealityCheck: vi.fn(),
+    addFeedMessage: vi.fn(),
+    updateTilt: vi.fn(),
+    updateStats: vi.fn(),
+    notifyBuddy: vi.fn(),
+  };
+  const verification = {
+    isLegitimate: true,
+    licenseInfo: {
+      found: true,
+      issuingAuthority: 'Malta Gaming Authority',
+      jurisdiction: 'Malta',
+      verified: true,
+      source: 'Current page footer scan',
+      lastVerifiedAt: '2026-05-09T00:00:00.000Z',
+      warnings: [],
+    },
+    verdict: 'legitimate',
+    shouldAnalyze: true,
+    ...options?.verification,
+  };
+  vi.doMock('../../src/extractor.js', () => ({
+    AnalyzerClient: class {
+      connect = vi.fn().mockResolvedValue(undefined);
+      disconnect = vi.fn();
+      sendSpin = vi.fn();
+    },
+    CasinoDataExtractor: class {
+      initialize = extractorInitialize;
+      extractBalance = vi.fn().mockReturnValue(options?.extractBalance ?? 100);
+      startObserving = vi.fn().mockReturnValue(() => {});
+    },
+  }));
+  vi.doMock('../../src/tilt-detector.js', () => ({
+    TiltDetector: class {
+      constructor(...args: unknown[]) {
+        tiltDetectorSpy(...args);
+      }
+      recordBet = vi.fn();
+      getSessionSummary = vi.fn().mockReturnValue({
+        currentBalance: 100,
+        startTime: Date.now(),
+        totalBets: 0,
+        totalWagered: 0,
+        totalWon: 0,
+      });
+      detectAllTiltSigns = vi.fn().mockReturnValue([]);
+      getTiltRiskScore = vi.fn().mockReturnValue(0);
+      generateInterventions = vi.fn().mockReturnValue([]);
+      updateBalance = vi.fn();
+    },
+  }));
+  vi.doMock('../../src/license-verifier.js', () => ({
+    CasinoLicenseVerifier: class {
+      verifyCasino = vi.fn().mockReturnValue(verification);
+    },
+    buildLicensePresentation: vi.fn().mockImplementation((v) => ({
+      summary: v?.warningMessage ?? 'License verified: Malta Gaming Authority',
+      tone: v?.shouldAnalyze === false ? 'risk' : 'verified',
+      details: ['Source: test registry', 'Last verified: test run', 'Not legal advice.'],
+    })),
+    getAnalysisBlockMessage: vi.fn().mockImplementation((v) =>
+      v?.shouldAnalyze === false ? v.warningMessage : null
+    ),
+  }));
+  vi.doMock('../../src/sidebar/index.js', () => ({
+    initSidebar: vi.fn(() => {
+      let sidebar = document.getElementById('tiltcheck-sidebar');
+      if (!sidebar) {
+        sidebar = document.createElement('div');
+        sidebar.id = 'tiltcheck-sidebar';
+        document.body.appendChild(sidebar);
+      }
+      return sidebarStub;
+    }),
+  }));
+  vi.doMock('../../src/analyzer.js', () => ({ Analyzer: class {} }));
+  vi.doMock('../../src/FairnessService.js', () => ({ FairnessService: class {} }));
+  vi.doMock('@tiltcheck/utils', () => ({
+    SolanaProvider: class {
+      getLatestBlockHash = vi.fn().mockResolvedValue('hash');
+    },
+  }));
+  return { extractorInitialize, tiltDetectorSpy };
+}
+
+describe('pro-monolith-bootstrap', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+
+    vi.stubGlobal('chrome', {
+      runtime: {
+        onMessage: {
+          addListener: vi.fn(),
+        },
+        sendMessage: vi.fn(),
+      },
+      storage: {
+        local: {
+          get: vi.fn((keys: string | string[], callback?: (value: unknown) => void) => {
+            const keyList = typeof keys === 'string' ? [keys] : keys;
+            const result = Object.fromEntries(keyList.map((k) => [k, null]));
+            callback?.(result);
+            return Promise.resolve(result);
+          }),
+          set: vi.fn(() => Promise.resolve()),
+        },
+      },
+    });
+  });
+
+  it('blocks auto analysis when the site is unlicensed', async () => {
+    const sidebarStub = {
+      syncAccountUi: vi.fn(),
+      showMainContent: vi.fn(),
+      addFeedMessage: vi.fn(),
+      getStorage: vi.fn().mockResolvedValue({}),
+      setStorage: vi.fn().mockResolvedValue(undefined),
+      updateStatus: vi.fn(),
+      updateRealityCheck: vi.fn(),
+      updateLicense: vi.fn(),
+      updateTilt: vi.fn(),
+      updateStats: vi.fn(),
+      notifyBuddy: vi.fn(),
+      openPremium: vi.fn().mockResolvedValue(undefined),
+    };
+    const { extractorInitialize } = mockHeavyDependencies({
+      sidebarStub,
+      verification: {
+        isLegitimate: false,
+        licenseInfo: {
+          found: false,
+          verified: false,
+          source: 'Current page DOM scan',
+          lastVerifiedAt: '2026-05-09T00:00:00.000Z',
+          warnings: [],
+        },
+        verdict: 'unlicensed',
+        shouldAnalyze: false,
+        warningMessage:
+          'No valid gambling license found yet. Normal TiltCheck analysis is disabled on this site.',
+      },
+    });
+
+    const { startProMonolith } = await import('../../src/pro-monolith-bootstrap.ts');
+    await startProMonolith();
+    await flush();
+
+    expect(extractorInitialize).not.toHaveBeenCalled();
+    expect(sidebarStub.updateLicense).toHaveBeenCalledWith(
+      expect.objectContaining({
+        verdict: 'unlicensed',
+        shouldAnalyze: false,
+      })
+    );
+    const mobileHud = document.getElementById('tiltcheck-mobile-license-hud');
+    expect(mobileHud?.dataset.status).toBe('risk');
+    expect(mobileHud?.textContent).toBe(
+      'No valid gambling license found yet. Normal TiltCheck analysis is disabled on this site. | Made for Degens. By Degens.'
+    );
+    expect(sidebarStub.updateStatus).toHaveBeenCalledWith(
+      'No valid gambling license found yet. Normal TiltCheck analysis is disabled on this site.',
+      'warning'
+    );
+    expect(sidebarStub.updateRealityCheck).toHaveBeenCalledWith(false);
+  });
+
+  it('passes through honest zero balances without fabricating a starting amount', async () => {
+    const tiltDetectorSpy = vi.fn();
+    mockHeavyDependencies({ extractBalance: 0, tiltDetectorSpy });
+
+    const { startProMonolith } = await import('../../src/pro-monolith-bootstrap.ts');
+    await startProMonolith();
+    await flush();
+
+    expect(tiltDetectorSpy).toHaveBeenCalledWith(0, 'moderate', 0);
+  });
+
+  it('deactivateProMonolith removes sidebar and disconnects observers', async () => {
+    mockHeavyDependencies();
+    const { startProMonolith, deactivateProMonolith } = await import(
+      '../../src/pro-monolith-bootstrap.ts'
+    );
+    await startProMonolith();
+    await flush();
+
+    expect(document.getElementById('tiltcheck-sidebar')).toBeTruthy();
+
+    deactivateProMonolith();
+    expect(document.getElementById('tiltcheck-sidebar')).toBeNull();
+  });
+
+  it('honors the persisted injection off-switch until the toolbar wakes it back up', async () => {
+    type Listener = (
+      message: unknown,
+      sender: unknown,
+      sendResponse: (r: unknown) => void
+    ) => boolean | void;
+    const listeners: Listener[] = [];
+    const storageState: Record<string, unknown> = { tiltcheck_injection_disabled: true };
+
+    vi.stubGlobal('chrome', {
+      runtime: {
+        onMessage: {
+          addListener: vi.fn((handler: Listener) => listeners.push(handler)),
+        },
+        sendMessage: vi.fn(),
+      },
+      storage: {
+        local: {
+          get: vi.fn((keys: string | string[], callback?: (value: unknown) => void) => {
+            const keyList = typeof keys === 'string' ? [keys] : keys;
+            const result = Object.fromEntries(keyList.map((k) => [k, storageState[k] ?? null]));
+            if (callback) callback(result);
+            return Promise.resolve(result);
+          }),
+          set: vi.fn((data: Record<string, unknown>, callback?: () => void) => {
+            Object.assign(storageState, data);
+            callback?.();
+            return Promise.resolve();
+          }),
+        },
+      },
+    });
+
+    const sidebarStub = {
+      syncAccountUi: vi.fn(),
+      showMainContent: vi.fn(),
+      addFeedMessage: vi.fn(),
+      getStorage: vi.fn().mockResolvedValue({}),
+      setStorage: vi.fn().mockResolvedValue(undefined),
+      updateStatus: vi.fn(),
+      updateRealityCheck: vi.fn(),
+      updateLicense: vi.fn(),
+      updateTilt: vi.fn(),
+      updateStats: vi.fn(),
+      notifyBuddy: vi.fn(),
+      openPremium: vi.fn().mockResolvedValue(undefined),
+    };
+    const initSidebar = vi.fn(() => sidebarStub);
+    vi.doMock('../../src/sidebar/index.js', () => ({ initSidebar }));
+    mockHeavyDependencies();
+
+    const { startProMonolith } = await import('../../src/pro-monolith-bootstrap.ts');
+    await startProMonolith();
+    await flush();
+
+    expect(initSidebar).not.toHaveBeenCalled();
+    const getState = vi.fn();
+    listeners[0]!({ type: 'get_sidebar_state' }, null, getState);
+    expect(getState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        exists: false,
+        injectionDisabled: true,
+      })
+    );
+
+    const toggle = vi.fn();
+    listeners[0]!({ type: 'toggle_sidebar' }, null, toggle);
+
+    await vi.waitFor(() => {
+      expect(toggle).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          visible: true,
+          injectionDisabled: false,
+        })
+      );
+    });
+    expect(storageState.tiltcheck_injection_disabled).toBe(false);
+  });
+});

--- a/apps/chrome-extension/tests/unit/tilt-detector-fixtures.test.ts
+++ b/apps/chrome-extension/tests/unit/tilt-detector-fixtures.test.ts
@@ -1,0 +1,84 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TiltDetector } from '../../src/tilt-detector.ts';
+
+const THRESHOLD = 70;
+
+describe('TiltDetector — composite risk fixtures', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-20T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps a fast-paced but non-chasing session below the 70 threshold', () => {
+    const detector = new TiltDetector(100, 'moderate');
+
+    for (let i = 0; i < 12; i++) {
+      detector.recordClick();
+      vi.advanceTimersByTime(900);
+    }
+
+    expect(detector.getTiltRiskScore()).toBeLessThan(THRESHOLD);
+  });
+
+  it('crosses threshold 70 on loss-chasing spiral (compressing clicks + loss streak)', () => {
+    const detector = new TiltDetector(100, 'moderate');
+
+    const clickIntervals = [480, 460, 440, 420, 400, 380, 360, 340];
+    for (let i = 0; i < clickIntervals.length; i++) {
+      detector.recordClick();
+      detector.recordBet(10, 0);
+      vi.advanceTimersByTime(clickIntervals[i]);
+    }
+
+    expect(detector.getSessionSummary().consecutiveLosses).toBeGreaterThanOrEqual(4);
+    expect(detector.getLastClickDeltaMs()).not.toBeNull();
+    expect(detector.getLastClickDeltaMs()!).toBeLessThan(500);
+    expect(detector.getTiltRiskScore()).toBeGreaterThanOrEqual(THRESHOLD);
+  });
+
+  it('applies conservative profile multiplier (earlier trigger vs degen)', () => {
+    const conservative = new TiltDetector(100, 'conservative');
+    const degen = new TiltDetector(100, 'degen');
+
+    const intervals = [450, 430, 410, 390, 370, 350];
+    for (const detector of [conservative, degen]) {
+      for (const ms of intervals) {
+        detector.recordClick();
+        detector.recordBet(5, 0);
+        vi.advanceTimersByTime(ms);
+      }
+    }
+
+    expect(conservative.getTiltRiskScore()).toBeGreaterThanOrEqual(degen.getTiltRiskScore());
+  });
+
+  it('does not compound loss streak without hot micro-pacing', () => {
+    const detector = new TiltDetector(100, 'moderate');
+
+    for (let i = 0; i < 6; i++) {
+      detector.recordBet(10, 0);
+      vi.advanceTimersByTime(2_500);
+    }
+
+    expect(detector.getSessionSummary().consecutiveLosses).toBeGreaterThan(3);
+    expect(detector.getTiltRiskScore()).toBeLessThan(THRESHOLD);
+  });
+
+  it('conservative profile pushes marginal spiral above 70', () => {
+    const detector = new TiltDetector(100, 'conservative');
+    const intervals = [490, 470, 450, 430, 410, 390];
+
+    for (const ms of intervals) {
+      detector.recordClick();
+      detector.recordBet(10, 0);
+      vi.advanceTimersByTime(ms);
+    }
+
+    expect(detector.getTiltRiskScore()).toBeGreaterThanOrEqual(THRESHOLD);
+  });
+});

--- a/docs/SITEMAP.md
+++ b/docs/SITEMAP.md
@@ -1,4 +1,4 @@
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-09 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 -->
 
 # TiltCheck Site Map
 
@@ -10,6 +10,12 @@
 - **[Safety (TiltGuard)](/safety)**: Chrome extension and Discord bot safety tools.
 - **[JustTheTip](/justthetip)**: Non-custodial Discord tipping service.
 - **[User Profile](/user)**: Manage linked accounts and earnings.
+
+## Strategy & positioning (internal / docs site)
+- **[Player sovereignty & category strategy](product/player-sovereignty-category-strategy.md)** — thesis vs compliance-theater RG, pillars, risks.
+- **[TiltCheck positioning memo (one-pager)](product/tiltcheck-positioning-memo-one-pager.md)** — copy-ready blocks for web and briefings.
+- **[Monorepo roadmap pillars checklist](product/monorepo-roadmap-pillars-checklist.md)** — pillar backlog mapped to `apps/*` and packages.
+- **[Product strategy index](product/README.md)** — hub for the three docs above.
 
 ## RG v1 Discovery Lanes
 - **[RG Tools v1 Plan](product/rg-tools-v1-plan.md)**: Cross-surface discovery map, dashboard ownership rules, and "where do I click?" QA checklist.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,0 +1,13 @@
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 -->
+
+# Product strategy (index)
+
+Internal product narrative and execution checklists. These complement [competitive positioning vs Stake Cruncher / Stake Stats / RipGuard](../competitive/stake-cruncher-stake-stats-tiltcheck-positioning.md) and the [RG Tools v1 plan](./rg-tools-v1-plan.md).
+
+| Document | Purpose |
+| :--- | :--- |
+| [Player sovereignty & category strategy](./player-sovereignty-category-strategy.md) | Full thesis: live telemetry, non-custodial guardrails, trust economy, creator provenance; risks and boundaries. |
+| [TiltCheck positioning memo (one-pager)](./tiltcheck-positioning-memo-one-pager.md) | Copy-ready pillars for web, investor, and partner briefings. |
+| [Monorepo roadmap pillars checklist](./monorepo-roadmap-pillars-checklist.md) | Pillar-by-pillar tasks mapped to `apps/*`, `packages/*`, and `modules/*`. |
+
+Public URL (when web is built from monorepo `docs/`): `/docs/product/<slug>`.

--- a/docs/product/monorepo-roadmap-pillars-checklist.md
+++ b/docs/product/monorepo-roadmap-pillars-checklist.md
@@ -1,0 +1,102 @@
+---
+title: Monorepo roadmap pillars checklist
+category: Product
+description: Pillar backlog mapped to TiltCheck apps and packages. Checkboxes are planning aids; track owners in Linear or issues.
+date: 2026-05-20
+---
+
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 -->
+
+# Monorepo roadmap pillars checklist
+
+Maps the [player sovereignty strategy](./player-sovereignty-category-strategy.md) to concrete surfaces in this repository.  
+**Convention:** `pnpm --filter <name>` uses package names from each `package.json` (e.g. `web`, `@tiltcheck/api`).
+
+---
+
+## Pillar A — Live guardrails (velocity, tilt, session friction)
+
+| Status | Task | Primary owner |
+| :---: | :--- | :--- |
+| [ ] | Single injected / MV3 behavior spec: no fork between userscript and extension logic for vault + tilt (align with `@tiltcheck/chrome-extension`). | `apps/chrome-extension` |
+| [ ] | Dashboard durable rules + extension handoff URLs for safety and AutoVault review. | `apps/user-dashboard` |
+| [ ] | Optional Discord reinforcement (buddy pings, ack flows) without storing sensitive config in threads. | `apps/discord-bot` |
+| [ ] | API routes for settings sync and events **only** with explicit auth and minimal payloads. | `apps/api`, `packages/*` contracts |
+| [ ] | RG copy and limits: no medical claims; escalation paths documented. | `apps/web` (legal + product pages), `docs/legal/*` |
+
+**Risk / validation:** False-positive rate for pacing signals; ToS alignment for automated nudges; rate limits on Discord alerts.
+
+**Rollback:** Feature-flag injected friction; revert detection thresholds per cohort.
+
+---
+
+## Pillar B — Session forensics & RTP-adjacent transparency
+
+| Status | Task | Primary owner |
+| :---: | :--- | :--- |
+| [ ] | Session export and forensic views (user-owned history) on dashboard. | `apps/user-dashboard` |
+| [ ] | Public education and “what we can / cannot infer” pages; link from intel routes. | `apps/web` (`/intel/*`, `/tools/*`) |
+| [ ] | Trust rollup inputs: define which forensic aggregates may enter reputation (consent, aggregation windows). | `apps/trust-rollup`, `packages/trust-engines` (`@tiltcheck/trust-engines`) |
+| [ ] | Methodology doc: sample size, variance, game identity—avoid lab RTP claims without full pipeline. | `docs/product/*` |
+
+**Risk / validation:** Misleading drift badges; statistical review before public leaderboard use.
+
+**Rollback:** Display “experimental” or disable public aggregation for raw session RTP proxies.
+
+---
+
+## Pillar C — Independent trust economy
+
+| Status | Task | Primary owner |
+| :---: | :--- | :--- |
+| [ ] | Casino directory and trust signals with abuse-resistant inputs. | `apps/web`, `apps/api`, data scripts (`scripts/*`) |
+| [ ] | Rollup pruning / sliding windows (operational). | `apps/trust-rollup` (see [ROADMAP_2026](../ROADMAP_2026.md)) |
+| [ ] | Operator-facing verification flows without captive affiliate incentives. | `apps/web` (`/operators/*`), `apps/api` |
+| [ ] | Transparency: published scoring inputs and change logs where applicable. | `docs/`, public changelog |
+
+**Risk / validation:** Sybil and brigading; economic disclosure for any future monetization.
+
+**Rollback:** Score freeze; manual review queue for contested deltas.
+
+---
+
+## Pillar D — Creator provenance (hash / registry)
+
+| Status | Task | Primary owner |
+| :---: | :--- | :--- |
+| [ ] | CLI or web flow: hash asset bundles pre-submission; store metadata + timestamp. | `apps/web` or `packages/*` tooling |
+| [ ] | Optional public registry API and audit trail. | `apps/api`, `packages/database` |
+| [ ] | Legal playbook: hashes as evidence step, not automatic title. | `docs/legal/*` |
+
+**Risk / validation:** PII in bundles; secure upload paths.
+
+**Rollback:** Per-creator private manifests only.
+
+---
+
+## Cross-cutting platform inventory (quick reference)
+
+| Area | Packages / apps |
+| :--- | :--- |
+| Public acquisition & SEO pillars | `apps/web` |
+| In-session enforcement | `apps/chrome-extension` |
+| Durable user settings & history | `apps/user-dashboard` |
+| Gateway & trust APIs | `apps/api` |
+| Aggregation & signals | `apps/trust-rollup` |
+| Community & alerts | `apps/discord-bot`, `apps/justthetip-bot` (as needed) |
+| Internal ops | `apps/control-room` |
+| Edge / hub | `apps/hub` |
+| Shared types and DB | `packages/types`, `packages/database`, `@tiltcheck/shared` |
+| Deep logic modules | `modules/*` (e.g. tiltcheck-core, trust-engines) |
+
+---
+
+## Links
+
+- Engineering phases and security work: [ROADMAP_2026.md](../ROADMAP_2026.md)  
+- RG surface ownership: [RG Tools v1 plan](./rg-tools-v1-plan.md)  
+- Competitive JTBD: [Stake Cruncher / Stats / RipGuard](../competitive/stake-cruncher-stake-stats-tiltcheck-positioning.md)
+
+---
+
+**Note:** Checkboxes are planning aids only; assign owners and tickets outside this file when execution starts.

--- a/docs/product/player-sovereignty-category-strategy.md
+++ b/docs/product/player-sovereignty-category-strategy.md
@@ -1,0 +1,113 @@
+---
+title: Player sovereignty & category strategy
+category: Product
+description: Strategic thesis for live telemetry, non-custodial guardrails, session forensics, and independent trust—versus compliance-theater RG.
+date: 2026-05-20
+---
+
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 -->
+
+# Player sovereignty and a new product category
+
+## Executive summary
+
+**Industry default:** “Responsible gaming” is often compliance-driven theater: links buried in footers, reactive statistics, and operator-owned limit switches that vanish when policy, bugs, or incentives change.
+
+**TiltCheck thesis:** A **player-owned telemetry and guardrail layer** that runs closer to the session than the marketing site—prioritizing **interruption quality**, **durable non-custodial controls**, and **receipt-grade signals** over post-hoc “you lost fairly” theater.
+
+This document scopes **strategic pillars**, **flagship use cases**, **market whitespace**, **trust and legal boundaries**, and **links** to operational specs elsewhere in the repo.
+
+---
+
+## 1. Category definition
+
+TiltCheck is not “another RG menu item.” It is a **cross-surface system** for:
+
+1. **Active session intelligence** — pace, spend velocity, repeated loss-chasing patterns, and context (tabs, time-on-device), not only monthly statements.
+2. **User-configured enforcement** — friction, vault nudges, buddy / Discord accountability, and “hard exit” flows the **user** opted into; implementation stays **non-custodial** relative to casino balances.
+3. **Independent trust signals** — crowdsourced and machine-assisted reputation, change detection on terms and offers, and structured receipts when tied to observable session behavior.
+4. **Creator provenance (where scoped)** — cryptographic fingerprints and public registries for disputed ownership of submitted assets—**evidence**, not a substitute for legal strategy.
+
+**Boundary:** TiltCheck does not promise medical outcomes, regulatory approval, or guaranteed financial results. Language in product and marketing must stay aligned with [RG Tools v1](./rg-tools-v1-plan.md) and legal disclaimers.
+
+---
+
+## 2. Flagship use cases (product pillars)
+
+### 2.1 Live guardrails and “whale watch” patterns
+
+**Job:** High-attention and high-volume sessions are disproportionately targeted by retention pressure (speed, bonuses, UI rhythm). Users need **early** signals and **user-chosen** friction—not only a footer link after harm.
+
+**Mechanism (conceptual):** Client-side or injected observation of **session pacing** (e.g., rapid repeat actions, post-loss acceleration, anomalous click bursty periods). Triggers map to **pre-committed** rules: pause, vault nudge, buddy ping, dashboard deep-link—not silent remote shutoff by TiltCheck.
+
+**Moat:** Interruption **in the transaction path** competes on quality of detection + UX of restraint—not on replicating every SEO calculator hub.
+
+**Risk notes:** “Circuit breaker” framing can collide with **platform ToS**, **jurisdictional RG requirements**, and **false positives** (latency, touch, assistive tech). Ship as **user-configured** guardrails with clear override and review paths. Threat: false confidence leading to liability claims—copy and UX must avoid guaranteeing outcomes.
+
+### 2.2 Session forensics and RTP-adjacent signals
+
+**Job:** Players want to know whether their **observed session** diverges sharply from plausible expectations—not only whether one spin verified after the fact.
+
+**Mechanism:** Continuous logging of outcomes the user actually experienced (bets, returns, game identity where available), surfaced as **session forensic** views, drift indicators, and exportable summaries.
+
+**Honesty bar:** Short-window “RTP drift” is easily confounded by volatility, feature buys, game mixing, and selection bias. Position as **forensic anomaly cues and transparency**, not a certified lab RTP re-measurement unless inputs and statistics are formally validated.
+
+**Rollback:** If metrics mislead, disable public ranking use of raw drift until methodology is documented and tested.
+
+### 2.3 Creator shield (provenance)
+
+**Job:** Independent creators uploading math, assets, or modules need **timestamped, third-party-verifiable** fingerprints before platform review.
+
+**Mechanism:** Hash-and-anchor workflows (public registry, optional chain anchoring as an explicit product decision), tied to submission metadata.
+
+**Limit:** Hashes prove **what was committed when**, not automatic IP victory in court. Pair with process guidance and dispute playbooks.
+
+---
+
+## 3. Missed market opportunities (competitive whitespace)
+
+Aligned with [Stake Cruncher / Stake Stats / RipGuard analysis](../competitive/stake-cruncher-stake-stats-tiltcheck-positioning.md):
+
+| Failure mode (market) | TiltCheck wedge |
+| :--- | :--- |
+| **Past-only verification** (seed replay, history tools) | **While-it-is-happening** pacing and risk signals + user-owned limits |
+| **Operator-owned RG switches** | **Non-custodial** client-side and user-account settings with clear custody boundaries |
+| **Affiliate-captured “community” tools** | **Independent** trust layer with explicit economics and anti-gaming design for rankings |
+
+**RipGuard distinction:** On-chain time-locks and casino-session AutoVault solve adjacent emotional jobs; do not blur **mechanism or jurisdiction** in messaging without review.
+
+---
+
+## 4. Roadmap alignment (what to fund first)
+
+1. **Single behavioral spec** for extension vs injection paths—no long-term fork of vault / tilt logic (see competitive doc §3).
+2. **Indexed public pillars** on `web` (narrow acquisition): trust explainer, flagship verifier entry, how guardrails work—without building a calculator arms race.
+3. **Trust rollup + consent** model for any aggregated telemetry that leaves the device.
+4. **Dashboard** as durable settings and history owner; **Discord** for reinforcement; **API** only where it extends trust without forking enforcement logic.
+
+Detailed task mapping: [Monorepo roadmap pillars checklist](./monorepo-roadmap-pillars-checklist.md).
+
+---
+
+## 5. Risks and guardrails (non-exhaustive)
+
+| Area | Risk | Mitigation |
+| :--- | :--- | :--- |
+| Trust / rankings | Sybil and operator astroturfing | Rate limits, device graph hygiene, transparency on inputs, abuse reporting |
+| Statistics | Overclaiming RTP or “proof of unfairness” | Methodology docs, confidence bands, kill-switches for public scores |
+| Compliance | Implying licensure or medical RG | Legal review on regional copy; stay in user-empowerment lane |
+| Platform ToS | Aggressive automation | User consent, configurability, clear escalation to human review |
+
+---
+
+## 6. Related documents
+
+- [RG Tools v1 Plan](./rg-tools-v1-plan.md) — surface ownership and RG boundaries.
+- [Competitive positioning](../competitive/stake-cruncher-stake-stats-tiltcheck-positioning.md) — JTBD and parity traps.
+- [ROADMAP_2026.md](../ROADMAP_2026.md) — phased engineering roadmap (security, rollup, verification).
+- [TiltCheck docs hub](../tiltcheck/index.md) — ecosystem specs.
+
+---
+
+**Status:** Strategy approved for product and GTM alignment.  
+**Next:** Prioritize pillar backlog in engineering rituals; keep external claims aligned with verification in each pillar.

--- a/docs/product/tiltcheck-positioning-memo-one-pager.md
+++ b/docs/product/tiltcheck-positioning-memo-one-pager.md
@@ -1,0 +1,74 @@
+---
+title: TiltCheck positioning memo (one-pager)
+category: Product
+description: Copy-ready pillars for the site, investors, and partners. Not a legal disclaimer; pair with public legal pages.
+date: 2026-05-20
+---
+
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-20 -->
+
+# TiltCheck positioning memo (one-pager)
+
+**Audience:** Homepage / About / operator one-pagers.  
+**Use:** Pull quotes and section headings; adapt per region with counsel.  
+**Do not:** Substitute for Terms, Privacy, or jurisdiction-specific RG copy.
+
+---
+
+## One-line promise
+
+**TiltCheck puts live session intelligence and player-owned guardrails in the loop—not buried in a compliance footer.**
+
+---
+
+## The problem (why incumbents stall)
+
+Most “responsible gaming” experiences are built to **check boxes**: static links, after-the-fact stats, and limits that live entirely inside the operator’s stack. That design serves **retention economics** first. Players get theater; platforms keep the throttle.
+
+---
+
+## The category
+
+TiltCheck is building **player-sovereign telemetry**: read-the-session signals, user-chosen friction, and durable settings that do not require trusting a single operator’s database row to stay honest.
+
+---
+
+## Three proof points
+
+1. **Interrupt the session, not the monthly statement** — Pace and tilt-aware cues while play is active; handoffs to dashboard and Discord for accountability you configured.
+2. **Non-custodial posture** — TiltCheck does not hold casino balances; guardrails are anchored in **your** choices and **your** devices, with explicit boundaries on what (if anything) syncs beyond the machine.
+3. **Independent trust surface** — Crowdsourced and structured signals that track **behavior and change** (terms, offer drift, payout friction signals) instead of affiliate-branded “community” gloss.
+
+---
+
+## What we are not
+
+- Not a substitute for regulators, licensees, or medical advice.
+- Not a guarantee of winnings, fairness verdicts, or lab-grade RTP from casual session samples alone.
+- Not an on-chain bank lock product; **AutoVault** and similar features stay in the **casino-session, user-directed** lane unless explicitly scoped otherwise.
+
+---
+
+## Call to action (default funnel)
+
+Install the extension → enable the guardrails you pre-commit to → open the dashboard for durable rules → optional Discord for reinforcement.
+
+---
+
+## Competitor snapshot (internal alignment)
+
+- **History / seed verifiers** — Useful **after** money is gone; TiltCheck competes on **timing** and **interruption quality**.
+- **Calculator and SEO hubs** — Breadth is not the moat; **in-session behavioral truth** is.
+- **On-chain time-locks** — Different mechanism and promise; name the boundary in copy.
+
+Full map: [Competitive positioning](../competitive/stake-cruncher-stake-stats-tiltcheck-positioning.md).
+
+---
+
+## Extended narrative (optional long-form block)
+
+When you line TiltCheck up against how the industry usually ships “RG,” the gap is structural. Operators optimize for proof that the **math box** is consistent so players stay in the chair. TiltCheck uses the same technical tradition—telemetry, receipts, attention to sequence—but points it at **player visibility and agency**: what happened in **your** session, what patterns **you** asked to be warned about, and what **you** decided should happen next. That is not a feature bolt-on; it is a different product category: **player-owned operational technology** for digital gambling sessions.
+
+---
+
+**Canonical deep dive:** [Player sovereignty & category strategy](./player-sovereignty-category-strategy.md).

--- a/docs/tiltcheck/index.md
+++ b/docs/tiltcheck/index.md
@@ -50,6 +50,9 @@ Built by a degen, for degens. Fast reference to every internal spec, prompt, and
 - [18 Coding Standards](18-coding-standards.md)
 - [18 Dashboard Design](18-dashboard-design.md)
 - [19 Testing Strategy](19-testing-strategy.md)
+- [Player sovereignty & category strategy (product)](../product/player-sovereignty-category-strategy.md)
+- [Positioning memo (one-pager)](../product/tiltcheck-positioning-memo-one-pager.md)
+- [Monorepo pillars checklist](../product/monorepo-roadmap-pillars-checklist.md)
 
 ## Design Prompts & Enhancements
 - [Design Prompts](DESIGN_PROMPTS.md)


### PR DESCRIPTION
## Description
Splits the Chrome extension into an always-on **Core circuit breaker** (Touch Grass + tilt scoring) and a lazy-loaded **Pro monolith** (sidebar, extractor, strategic game filters). Adds a defense-first Guards popup, Pro teardown/containment, and continuous composite risk scoring aligned to user thresholds and risk profiles.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧹 Code refactoring
- [x] 📝 Documentation update
- [x] ⚡ Performance improvement

## Related Issues
Fixes #
Related to #

## Decision Gates (Required for Ambiguous Changes)
- [x] No ambiguous production-impacting choices left unresolved
- [ ] Decision log updated (`docs/migration/decision-log.md`) when applicable
- [ ] Approver noted for any new migration decision (`DEC-*`)

### Decision Entries Added/Updated
- (none)

## Changes Made
- Slim `content.ts`: always-on Core (capture-phase clicks, 2s poll, Touch Grass) + lazy Pro bootstrap with storage-driven teardown
- `pro-monolith-bootstrap.ts`, `touch-grass-timeout.ts`, `core-options.ts`, `LocalGameBlocker`, `pro/containment.ts`
- Guards popup: Touch Grass opt-in/sliders + strategic blocklist editor (`popup-settings.ts`)
- Hardened `getTiltRiskScore()`: micro-pacing, loss-streak compound, profile multipliers (`tiltcheck_risk_profile`)
- 95 extension unit tests (fixtures for deterministic risk timelines)
- Product strategy docs under `docs/product/`

## Module/Service Affected
- [x] TiltCheck Core
- [x] Documentation

## Testing
- [x] Tests pass locally (`pnpm test`)
- [ ] Linting passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing completed
- [ ] Accessibility audit passes (if UI changes)

### Test Details
- `pnpm -C apps/chrome-extension exec vitest run` — 95/95 passed
- `pnpm -C apps/chrome-extension build` — dist bundle OK

## Security Checklist
- [x] No secrets or sensitive data in code
- [x] Non-custodial principles maintained (if applicable)
- [x] Input validation added for user-provided data
- [ ] Dependencies checked for vulnerabilities
- [ ] No new high/critical security warnings
- [x] No production secrets or credentials committed

## Performance Impact
- [x] Performance improved

**Details:** Core path stays lean; Pro loads only when `tiltcheck_pro_monolith_enabled` is true. Observers ignore TiltCheck safety overlay DOM to avoid thrashing.

## Breaking Changes
Pro monolith no longer auto-starts from `content.ts`; enable via `chrome.storage.local.tiltcheck_pro_monolith_enabled`. Core Touch Grass runs by default when opt-in is unset/true.

## Documentation
- [x] Code comments added/updated
- [ ] README updated
- [x] Architecture docs updated
- [ ] API documentation updated
- [ ] No documentation needed

## Deployment Notes
- [x] Requires configuration updates
- [ ] Requires environment variable changes
- [ ] Requires database migration
- [ ] No special deployment steps

**Details:** Manual extension reload from `apps/chrome-extension/dist`. Users arm guards via popup or storage keys documented in `apps/chrome-extension/docs/development.md`.

## Screenshots/Videos
N/A

## Additional Context
Rollback: set `tiltcheck_pro_monolith_enabled` false and reload tab; `deactivateProMonolith()` clears Pro surfaces while Core shield remains.

---

## Reviewer Checklist
- [ ] Code follows TiltCheck architecture principles
- [ ] Changes are minimal and focused
- [ ] Security implications reviewed
- [ ] Tests are adequate
- [ ] Documentation is complete
- [ ] No unnecessary dependencies added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it refactors the main content script into a new Core/Pro loading model and introduces an undismissable full-screen lockout flow that can block page interaction based on new risk-scoring logic and storage-driven settings.
> 
> **Overview**
> Refactors the extension into an always-on **Core circuit breaker** (`content.ts`) that records click pacing and polls tilt risk every 2s to trigger a new undismissable `Touch Grass Timeout` overlay, while the legacy full feature set is moved into a lazy-loaded **Pro monolith** (`pro-monolith-bootstrap.ts`) gated by `chrome.storage.local['tiltcheck_pro_monolith_enabled']` with explicit teardown on disable.
> 
> Adds new storage-backed Core settings (`core-options.ts`) and a redesigned popup **Guards** UI (new `popup-settings.ts` + `popup.html`/`popup.ts` updates) to opt in/out and tune risk threshold/duration, plus Pro-only “strategic filters” managed via a local blocked-game slug list and enforced by a new `LocalGameBlocker` with safety-root DOM containment.
> 
> Updates tilt scoring in `tilt-detector.ts` to a composite model (indicator weights + micro-pacing velocity + loss-streak compounding) scaled by a `tiltcheck_risk_profile`, and updates build/manifest to emit and expose `dist/pro-monolith-bootstrap.js` as a web-accessible ESM bundle; includes unit tests for new Pro storage/containment helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a27f3bf2891029d2c7f7c750c87c20ccf6f2d77c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->