### PR TITLE
feat(bonuses): unified US daily bonus feed from all intel sources

### DIFF
--- a/apps/api/src/lib/daily-bonus-feed.ts
+++ b/apps/api/src/lib/daily-bonus-feed.ts
@@ -1,0 +1,378 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-06-16
+/**
+ * Daily Bonus Feed Aggregator
+ *
+ * Merges CollectClock, email inbox intel, and local fallback bonus data
+ * into a single deduplicated feed for US casino discovery surfaces.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getActiveEmailBonusEntries, type EmailBonusFeedEntry } from './email-bonus-feed.js';
+
+export type BonusFeedSourceKey = 'collectclock' | 'email-inbox' | 'local-fallback';
+
+export interface DailyBonusFeedEntry {
+  id: string;
+  brand: string;
+  bonus: string;
+  url: string;
+  verified: string;
+  code: string | null;
+  sources: BonusFeedSourceKey[];
+  bonusType: string | null;
+  bonusValue: string | null;
+  expiresAt: string | null;
+  expiryMessage: string | null;
+  imageUrl: string | null;
+  isUsCasino: boolean;
+  casinoCategory: string | null;
+  trustScore: number | null;
+}
+
+export interface BonusSourceStatus {
+  key: BonusFeedSourceKey;
+  label: string;
+  available: boolean;
+  count: number;
+  updatedAt: string | null;
+  detail: string;
+}
+
+export interface DailyBonusFeedResult {
+  updatedAt: string;
+  total: number;
+  usTotal: number;
+  data: DailyBonusFeedEntry[];
+  sources: BonusSourceStatus[];
+}
+
+interface RawBonusEntry {
+  brand: string;
+  bonus: string;
+  url: string;
+  verified: string;
+  code?: string | null;
+}
+
+interface CasinoCatalogEntry {
+  name: string;
+  category?: string;
+}
+
+const COLLECTCLOCK_BONUS_URL =
+  'https://raw.githubusercontent.com/TiltCheck-ME/CollectClock/main/bonus-data.json';
+
+const SOURCE_LABELS: Record<BonusFeedSourceKey, string> = {
+  collectclock: 'CollectClock',
+  'email-inbox': 'Email inbox',
+  'local-fallback': 'Local cache',
+};
+
+const API_LIB_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+let usCasinoIndex: Map<string, CasinoCatalogEntry> | null = null;
+
+function normalizeKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function normalizeBonusKey(entry: Pick<RawBonusEntry, 'brand' | 'bonus' | 'url'>): string {
+  return `${entry.brand.trim().toLowerCase()}::${entry.bonus.trim().toLowerCase()}::${entry.url.trim().toLowerCase()}`;
+}
+
+function isRawBonusEntry(value: unknown): value is RawBonusEntry {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<RawBonusEntry>;
+  return (
+    typeof candidate.brand === 'string'
+    && typeof candidate.bonus === 'string'
+    && typeof candidate.url === 'string'
+    && typeof candidate.verified === 'string'
+  );
+}
+
+function readJsonArray(filePath: string): unknown[] {
+  if (!existsSync(filePath)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function resolveDataDir(): string {
+  const candidates = [
+    process.env.STATS_DATA_DIR?.trim(),
+    path.resolve(process.cwd(), 'data'),
+    path.resolve(API_LIB_DIR, '../../../../data'),
+    path.resolve(API_LIB_DIR, '../../data'),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  for (const candidate of candidates) {
+    if (existsSync(path.join(candidate, 'sweepstakes-casinos.json'))) {
+      return candidate;
+    }
+  }
+
+  return path.resolve(process.cwd(), 'data');
+}
+
+function loadUsCasinoIndex(): Map<string, CasinoCatalogEntry> {
+  if (usCasinoIndex) return usCasinoIndex;
+
+  const index = new Map<string, CasinoCatalogEntry>();
+  const dataDir = resolveDataDir();
+
+  for (const entry of readJsonArray(path.join(dataDir, 'sweepstakes-casinos.json'))) {
+    if (!entry || typeof entry !== 'object') continue;
+    const name = (entry as CasinoCatalogEntry).name;
+    if (!name) continue;
+    index.set(normalizeKey(name), {
+      name,
+      category: (entry as CasinoCatalogEntry).category ?? 'Sweeps',
+    });
+  }
+
+  for (const entry of readJsonArray(path.join(dataDir, 'online-casinos.json'))) {
+    if (!entry || typeof entry !== 'object') continue;
+    const candidate = entry as CasinoCatalogEntry & { category?: string };
+    if (!candidate.name) continue;
+    if (candidate.category === 'Regulated' || candidate.category === 'Sweeps Hybrid') {
+      index.set(normalizeKey(candidate.name), {
+        name: candidate.name,
+        category: candidate.category,
+      });
+    }
+  }
+
+  if (index.size > 0) {
+    usCasinoIndex = index;
+  }
+
+  return index;
+}
+
+function resolveUsCasino(brand: string, url: string): { isUsCasino: boolean; casinoCategory: string | null } {
+  const index = loadUsCasinoIndex();
+  const normalizedBrand = normalizeKey(brand);
+
+  for (const [key, entry] of index.entries()) {
+    if (normalizedBrand.includes(key) || key.includes(normalizedBrand)) {
+      return { isUsCasino: true, casinoCategory: entry.category ?? null };
+    }
+  }
+
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    if (hostname.endsWith('.us') || hostname.includes('stake.us')) {
+      return { isUsCasino: true, casinoCategory: 'US Domain' };
+    }
+  } catch {
+    // ignore invalid URLs
+  }
+
+  return { isUsCasino: false, casinoCategory: null };
+}
+
+function readLocalFallbackBonuses(): RawBonusEntry[] {
+  const localPath = path.join(resolveDataDir(), 'bonus-data.json');
+  return readJsonArray(localPath)
+    .filter(isRawBonusEntry)
+    .map((entry) => ({
+      brand: entry.brand.trim(),
+      bonus: entry.bonus.trim(),
+      url: entry.url.trim(),
+      verified: entry.verified,
+      code: entry.code ?? null,
+    }));
+}
+
+async function fetchCollectClockBonuses(): Promise<{
+  entries: RawBonusEntry[];
+  updatedAt: string | null;
+}> {
+  try {
+    const response = await fetch(COLLECTCLOCK_BONUS_URL, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) {
+      return { entries: [], updatedAt: null };
+    }
+
+    const data = await response.json();
+    const entries = Array.isArray(data)
+      ? data.filter(isRawBonusEntry).map((entry) => ({
+          brand: entry.brand.trim(),
+          bonus: entry.bonus.trim(),
+          url: entry.url.trim(),
+          verified: entry.verified,
+          code: entry.code ?? null,
+        }))
+      : [];
+
+    return {
+      entries,
+      updatedAt: entries[0]?.verified ?? null,
+    };
+  } catch {
+    return { entries: [], updatedAt: null };
+  }
+}
+
+function toDailyEntry(
+  base: RawBonusEntry,
+  source: BonusFeedSourceKey,
+  inboxMeta?: EmailBonusFeedEntry,
+): DailyBonusFeedEntry {
+  const usMeta = resolveUsCasino(base.brand, base.url);
+  return {
+    id: normalizeBonusKey(base),
+    brand: base.brand,
+    bonus: base.bonus,
+    url: base.url,
+    verified: base.verified,
+    code: base.code ?? null,
+    sources: [source],
+    bonusType: inboxMeta?.bonusType ?? null,
+    bonusValue: inboxMeta?.bonusValue ?? null,
+    expiresAt: inboxMeta?.expiresAt ?? null,
+    expiryMessage: inboxMeta?.expiryMessage ?? null,
+    imageUrl: inboxMeta?.imageUrl ?? null,
+    isUsCasino: usMeta.isUsCasino,
+    casinoCategory: usMeta.casinoCategory,
+    trustScore: null,
+  };
+}
+
+function mergeEntry(
+  existing: DailyBonusFeedEntry,
+  incoming: DailyBonusFeedEntry,
+): DailyBonusFeedEntry {
+  const preferIncoming = Date.parse(incoming.verified) >= Date.parse(existing.verified);
+  const primary = preferIncoming ? incoming : existing;
+  const secondary = preferIncoming ? existing : incoming;
+
+  return {
+    ...primary,
+    sources: [...new Set([...existing.sources, ...incoming.sources])],
+    code: primary.code ?? secondary.code,
+    bonusType: primary.bonusType ?? secondary.bonusType,
+    bonusValue: primary.bonusValue ?? secondary.bonusValue,
+    expiresAt: primary.expiresAt ?? secondary.expiresAt,
+    expiryMessage: primary.expiryMessage ?? secondary.expiryMessage,
+    imageUrl: primary.imageUrl ?? secondary.imageUrl,
+    isUsCasino: existing.isUsCasino || incoming.isUsCasino,
+    casinoCategory: primary.casinoCategory ?? secondary.casinoCategory,
+    trustScore: primary.trustScore ?? secondary.trustScore,
+  };
+}
+
+function buildSourceStatus(
+  key: BonusFeedSourceKey,
+  entries: readonly DailyBonusFeedEntry[],
+  available: boolean,
+  updatedAt: string | null,
+  detail: string,
+): BonusSourceStatus {
+  const count = entries.filter((entry) => entry.sources.includes(key)).length;
+  return {
+    key,
+    label: SOURCE_LABELS[key],
+    available: available && count > 0,
+    count,
+    updatedAt,
+    detail,
+  };
+}
+
+export async function buildDailyBonusFeed(options?: {
+  usOnly?: boolean;
+}): Promise<DailyBonusFeedResult> {
+  const usOnly = options?.usOnly ?? false;
+  const [collectClock, inboxEntries] = await Promise.all([
+    fetchCollectClockBonuses(),
+    Promise.resolve(getActiveEmailBonusEntries()),
+  ]);
+  const localFallback = readLocalFallbackBonuses();
+
+  const merged = new Map<string, DailyBonusFeedEntry>();
+
+  const ingest = (entry: RawBonusEntry, source: BonusFeedSourceKey, inboxMeta?: EmailBonusFeedEntry) => {
+    const daily = toDailyEntry(entry, source, inboxMeta);
+    const existing = merged.get(daily.id);
+    merged.set(daily.id, existing ? mergeEntry(existing, daily) : daily);
+  };
+
+  for (const entry of localFallback) {
+    ingest(entry, 'local-fallback');
+  }
+
+  for (const entry of collectClock.entries) {
+    ingest(entry, 'collectclock');
+  }
+
+  for (const entry of inboxEntries) {
+    ingest(
+      {
+        brand: entry.brand,
+        bonus: entry.bonus,
+        url: entry.url,
+        verified: entry.verified,
+        code: entry.code,
+      },
+      'email-inbox',
+      entry,
+    );
+  }
+
+  let data = [...merged.values()].sort(
+    (left, right) => Date.parse(right.verified) - Date.parse(left.verified),
+  );
+
+  if (usOnly) {
+    data = data.filter((entry) => entry.isUsCasino);
+  }
+
+  const allEntries = [...merged.values()];
+  const sources: BonusSourceStatus[] = [
+    buildSourceStatus(
+      'email-inbox',
+      allEntries,
+      inboxEntries.length > 0,
+      inboxEntries[0]?.verified ?? null,
+      inboxEntries.length > 0
+        ? `${inboxEntries.length} inbox promos parsed`
+        : 'No active inbox promos',
+    ),
+    buildSourceStatus(
+      'collectclock',
+      allEntries,
+      collectClock.entries.length > 0,
+      collectClock.updatedAt,
+      collectClock.entries.length > 0
+        ? `${collectClock.entries.length} CollectClock entries`
+        : 'CollectClock unreachable',
+    ),
+    buildSourceStatus(
+      'local-fallback',
+      allEntries,
+      localFallback.length > 0,
+      localFallback[0]?.verified ?? null,
+      localFallback.length > 0
+        ? `${localFallback.length} cached entries`
+        : 'No local cache',
+    ),
+  ];
+
+  return {
+    updatedAt: new Date().toISOString(),
+    total: data.length,
+    usTotal: allEntries.filter((entry) => entry.isUsCasino).length,
+    data,
+    sources,
+  };
+}

--- a/apps/api/src/lib/daily-bonus-feed.ts
+++ b/apps/api/src/lib/daily-bonus-feed.ts
@@ -159,9 +159,11 @@ function resolveUsCasino(brand: string, url: string): { isUsCasino: boolean; cas
   const index = loadUsCasinoIndex();
   const normalizedBrand = normalizeKey(brand);
 
-  for (const [key, entry] of index.entries()) {
-    if (normalizedBrand.includes(key) || key.includes(normalizedBrand)) {
-      return { isUsCasino: true, casinoCategory: entry.category ?? null };
+  if (normalizedBrand) {
+    for (const [key, entry] of index.entries()) {
+      if (normalizedBrand.includes(key) || key.includes(normalizedBrand)) {
+        return { isUsCasino: true, casinoCategory: entry.category ?? null };
+      }
     }
   }
 
@@ -177,9 +179,13 @@ function resolveUsCasino(brand: string, url: string): { isUsCasino: boolean; cas
   return { isUsCasino: false, casinoCategory: null };
 }
 
+let cachedLocalFallback: RawBonusEntry[] | null = null;
+
 function readLocalFallbackBonuses(): RawBonusEntry[] {
+  if (cachedLocalFallback) return cachedLocalFallback;
+
   const localPath = path.join(resolveDataDir(), 'bonus-data.json');
-  return readJsonArray(localPath)
+  const entries = readJsonArray(localPath)
     .filter(isRawBonusEntry)
     .map((entry) => ({
       brand: entry.brand.trim(),
@@ -188,6 +194,12 @@ function readLocalFallbackBonuses(): RawBonusEntry[] {
       verified: entry.verified,
       code: entry.code ?? null,
     }));
+
+  if (entries.length > 0) {
+    cachedLocalFallback = entries;
+  }
+
+  return entries;
 }
 
 async function fetchCollectClockBonuses(): Promise<{
@@ -218,7 +230,8 @@ async function fetchCollectClockBonuses(): Promise<{
       entries,
       updatedAt: entries[0]?.verified ?? null,
     };
-  } catch {
+  } catch (error) {
+    console.error('[CollectClock] Failed to fetch or parse bonuses:', error);
     return { entries: [], updatedAt: null };
   }
 }

--- a/apps/api/src/routes/bonuses.ts
+++ b/apps/api/src/routes/bonuses.ts
@@ -1,12 +1,15 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-06-16
 /**
  * @tiltcheck/api - CollectClock Bonuses Proxy Routes
  *
- * Route: GET /bonuses         - Proxy CollectClock bonus data with trust score enrichment
+ * Route: GET /bonuses              - Proxy CollectClock bonus data with trust score enrichment
+ * Route: GET /bonuses/inbox          - Email inbox bonus feed
+ * Route: GET /bonuses/daily-feed     - Unified daily bonus feed (all sources)
  * Route: GET /bonuses/trust/:casinoName - Get trust score for a casino by name
  */
 
 import { Router, Request, Response } from 'express';
+import { buildDailyBonusFeed } from '../lib/daily-bonus-feed.js';
 import { getActiveEmailBonusEntries, readEmailBonusFeed } from '../lib/email-bonus-feed.js';
 import { optionalAuthMiddleware } from '../middleware/auth.js';
 import { resolveExclusionProfileForRequest, suppressBonusEntries } from '../services/bonus-suppression.js';
@@ -128,6 +131,36 @@ router.get('/inbox', optionalAuthMiddleware, async (req: Request, res: Response)
       total: 0,
       data: [],
       error: 'INBOX_FEED_LOAD_FAILED',
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /bonuses/daily-feed
+// Unified aggregator: CollectClock + email inbox + local fallback.
+// ---------------------------------------------------------------------------
+router.get('/daily-feed', optionalAuthMiddleware, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const usOnly = req.query.usOnly !== 'false';
+    const profile = await resolveExclusionProfileForRequest(req);
+    const feed = await buildDailyBonusFeed({ usOnly });
+    const suppression = suppressBonusEntries(feed.data, profile);
+
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.json({
+      ...feed,
+      total: suppression.entries.length,
+      data: suppression.entries,
+      suppression: {
+        active: suppression.active,
+        hiddenCount: suppression.hiddenCount,
+      },
+    });
+  } catch (error) {
+    console.error('[Bonuses] Failed to build daily bonus feed:', error);
+    res.status(500).json({
+      error: 'DAILY_FEED_BUILD_FAILED',
+      message: 'Could not build unified daily bonus feed.',
     });
   }
 });

--- a/apps/api/tests/lib/daily-bonus-feed.test.ts
+++ b/apps/api/tests/lib/daily-bonus-feed.test.ts
@@ -62,4 +62,45 @@ describe('buildDailyBonusFeed', () => {
     expect(mcluck).toBeDefined();
     expect(feed.sources.some((source) => source.key === 'email-inbox' && source.count > 0)).toBe(true);
   });
+
+  it('does not treat non-alphanumeric brands as US casinos', async () => {
+    vi.resetModules();
+    writeFileSync(
+      TEST_EMAIL_BONUS_FEED_PATH,
+      JSON.stringify({
+        updatedAt: '2026-06-16T12:00:00.000Z',
+        bonuses: [
+          {
+            id: 'symbol-brand',
+            brand: '!!!',
+            bonus: 'Fake promo',
+            url: 'https://example.com/promo',
+            verified: '2026-06-16T12:00:00.000Z',
+            code: null,
+            source: 'email-inbox',
+            senderDomain: 'example.com',
+            senderEmail: 'promo@example.com',
+            subject: 'Bonus',
+            bonusType: 'Unknown',
+            bonusValue: '0',
+            terms: 'None',
+            expiryMessage: 'Valid through end of year',
+            expiresAt: '2026-12-31T23:59:59.999Z',
+            isExpired: false,
+            discoveredAt: '2026-06-16T12:00:00.000Z',
+            updatedAt: '2026-06-16T12:00:00.000Z',
+            lastPublishedAt: null,
+            imageUrl: null,
+          },
+        ],
+      }),
+    );
+
+    const { buildDailyBonusFeed } = await import('../../src/lib/daily-bonus-feed.js');
+    const feed = await buildDailyBonusFeed({ usOnly: false });
+    const symbolBrand = feed.data.find((entry) => entry.brand === '!!!');
+
+    expect(symbolBrand).toBeDefined();
+    expect(symbolBrand?.isUsCasino).toBe(false);
+  });
 });

--- a/apps/api/tests/lib/daily-bonus-feed.test.ts
+++ b/apps/api/tests/lib/daily-bonus-feed.test.ts
@@ -1,0 +1,65 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-06-16 */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import path from 'node:path';
+import { existsSync, rmSync, writeFileSync } from 'node:fs';
+
+const TEST_EMAIL_BONUS_FEED_PATH = path.join(process.cwd(), 'data', 'test-daily-bonus-feed-lib.json');
+
+describe('buildDailyBonusFeed', () => {
+  beforeEach(() => {
+    process.env.EMAIL_BONUS_FEED_PATH = TEST_EMAIL_BONUS_FEED_PATH;
+    if (existsSync(TEST_EMAIL_BONUS_FEED_PATH)) rmSync(TEST_EMAIL_BONUS_FEED_PATH);
+  });
+
+  afterEach(() => {
+    delete process.env.EMAIL_BONUS_FEED_PATH;
+    if (existsSync(TEST_EMAIL_BONUS_FEED_PATH)) rmSync(TEST_EMAIL_BONUS_FEED_PATH);
+  });
+
+  it('merges inbox and local fallback entries with source tags', async () => {
+    vi.resetModules();
+    writeFileSync(
+      TEST_EMAIL_BONUS_FEED_PATH,
+      JSON.stringify({
+        updatedAt: '2026-06-16T12:00:00.000Z',
+        bonuses: [
+          {
+            id: 'mcluck-inbox',
+            brand: 'McLuck',
+            bonus: '100% match up to $500',
+            url: 'https://mcluck.com/promos/claim',
+            verified: '2026-06-16T12:00:00.000Z',
+            code: 'DROP500',
+            source: 'email-inbox',
+            senderDomain: 'mcluck.com',
+            senderEmail: 'promo@mcluck.com',
+            subject: 'Bonus drop',
+            bonusType: 'Match',
+            bonusValue: '$500',
+            terms: 'Wagering applies',
+            expiryMessage: 'Valid through end of year',
+            expiresAt: '2026-12-31T23:59:59.999Z',
+            isExpired: false,
+            discoveredAt: '2026-06-16T12:00:00.000Z',
+            updatedAt: '2026-06-16T12:00:00.000Z',
+            lastPublishedAt: null,
+            imageUrl: null,
+          },
+        ],
+      }),
+    );
+
+    const { buildDailyBonusFeed } = await import('../../src/lib/daily-bonus-feed.js');
+    const feedAll = await buildDailyBonusFeed({ usOnly: false });
+    const feed = await buildDailyBonusFeed({ usOnly: true });
+
+    const mcluckAny = feedAll.data.find((entry) => entry.brand === 'McLuck');
+    expect(mcluckAny).toBeDefined();
+    expect(mcluckAny?.sources).toContain('email-inbox');
+    expect(mcluckAny?.isUsCasino).toBe(true);
+
+    const mcluck = feed.data.find((entry) => entry.brand === 'McLuck');
+    expect(mcluck).toBeDefined();
+    expect(feed.sources.some((source) => source.key === 'email-inbox' && source.count > 0)).toBe(true);
+  });
+});

--- a/apps/api/tests/routes/daily-bonus-feed.test.ts
+++ b/apps/api/tests/routes/daily-bonus-feed.test.ts
@@ -1,0 +1,109 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-06-16 */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import path from 'node:path';
+import { existsSync, rmSync, writeFileSync } from 'node:fs';
+
+const mockedAuth = vi.hoisted(() => ({
+  optionalAuthMiddleware: vi.fn((_req: unknown, _res: unknown, next: () => void) => next()),
+}));
+
+const mockedExclusionCache = vi.hoisted(() => ({
+  getForbiddenGamesProfile: vi.fn(),
+  profileBlocksTarget: vi.fn(),
+}));
+
+const mockedDb = vi.hoisted(() => ({
+  findUserByDiscordId: vi.fn(),
+}));
+
+vi.mock('../../src/middleware/auth.js', () => mockedAuth);
+vi.mock('../../src/services/exclusion-cache.js', () => mockedExclusionCache);
+vi.mock('@tiltcheck/db', () => mockedDb);
+
+import { bonusesRouter } from '../../src/routes/bonuses.js';
+
+const app = express();
+app.use('/bonuses', bonusesRouter);
+
+const TEST_EMAIL_BONUS_FEED_PATH = path.join(process.cwd(), 'data', 'test-daily-bonus-feed.json');
+
+describe('GET /bonuses/daily-feed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.EMAIL_BONUS_FEED_PATH = TEST_EMAIL_BONUS_FEED_PATH;
+    if (existsSync(TEST_EMAIL_BONUS_FEED_PATH)) rmSync(TEST_EMAIL_BONUS_FEED_PATH);
+  });
+
+  afterEach(() => {
+    delete process.env.EMAIL_BONUS_FEED_PATH;
+    if (existsSync(TEST_EMAIL_BONUS_FEED_PATH)) rmSync(TEST_EMAIL_BONUS_FEED_PATH);
+  });
+
+  it('returns a unified feed with source metadata', async () => {
+    writeFileSync(
+      TEST_EMAIL_BONUS_FEED_PATH,
+      JSON.stringify({
+        updatedAt: '2026-06-16T12:00:00.000Z',
+        bonuses: [
+          {
+            id: 'stake-us-inbox',
+            brand: 'Stake.us',
+            bonus: '25 SC daily drop from inbox',
+            url: 'https://stake.us/promo',
+            verified: '2026-06-16T12:00:00.000Z',
+            code: 'DROP25',
+            source: 'email-inbox',
+            senderDomain: 'stake.us',
+            senderEmail: 'promo@stake.us',
+            subject: 'Daily bonus',
+            bonusType: 'Daily',
+            bonusValue: '25 SC',
+            terms: 'Daily login',
+            expiryMessage: 'today only',
+            expiresAt: '2026-06-16T23:59:59.999Z',
+            isExpired: false,
+            discoveredAt: '2026-06-16T12:00:00.000Z',
+            updatedAt: '2026-06-16T12:00:00.000Z',
+            lastPublishedAt: null,
+            imageUrl: null,
+          },
+        ],
+      }),
+    );
+
+    const response = await request(app).get('/bonuses/daily-feed');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      total: expect.any(Number),
+      usTotal: expect.any(Number),
+      updatedAt: expect.any(String),
+    });
+    expect(Array.isArray(response.body.data)).toBe(true);
+    expect(Array.isArray(response.body.sources)).toBe(true);
+    expect(response.body.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'email-inbox' }),
+        expect.objectContaining({ key: 'collectclock' }),
+        expect.objectContaining({ key: 'local-fallback' }),
+      ]),
+    );
+
+    const stakeEntry = response.body.data.find((entry: { brand: string }) => entry.brand === 'Stake.us');
+    expect(stakeEntry).toMatchObject({
+      brand: 'Stake.us',
+      sources: expect.arrayContaining(['email-inbox']),
+      isUsCasino: true,
+      code: 'DROP25',
+    });
+  });
+
+  it('honors usOnly=false to include non-US entries when present', async () => {
+    const response = await request(app).get('/bonuses/daily-feed?usOnly=false');
+
+    expect(response.status).toBe(200);
+    expect(response.body.total).toBeGreaterThanOrEqual(response.body.data.length);
+  });
+});

--- a/apps/web/src/app/bonuses/page.tsx
+++ b/apps/web/src/app/bonuses/page.tsx
@@ -59,9 +59,6 @@ const EMPTY_FEED: DailyBonusFeedResponse = {
 
 async function fetchDailyBonusFeed(): Promise<DailyBonusFeedResponse> {
   const apiUrl = getDailyFeedApiUrl(true);
-  if (!apiUrl) {
-    return EMPTY_FEED;
-  }
 
   try {
     const response = await fetch(apiUrl, { next: { revalidate: 300 } });

--- a/apps/web/src/app/bonuses/page.tsx
+++ b/apps/web/src/app/bonuses/page.tsx
@@ -1,138 +1,95 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-06-16 */
 import React from 'react';
 import type { Metadata } from 'next';
-import BonusGrid, { BonusEntry } from '@/components/BonusGrid';
+import DailyBonusFeed from '@/components/DailyBonusFeed';
 import PublicPageHero from '@/components/PublicPageHero';
+import {
+  getDailyFeedApiUrl,
+  type DailyBonusFeedResponse,
+} from '@/lib/daily-bonus-feed';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Daily Bonus Tracker | TiltCheck',
+  title: 'US Daily Bonus Feed | TiltCheck',
   description:
-    'Sweepstakes and social casino bonuses sourced from CollectClock and TiltCheck inbox intel.',
+    'Daily bonus intel for US sweepstakes and social casinos — merged from CollectClock, email inbox parsing, and local cache.',
   openGraph: {
-    title: 'Daily Bonus Tracker | TiltCheck',
+    title: 'US Daily Bonus Feed | TiltCheck',
     description:
-      'Sweepstakes and social casino bonuses sourced from CollectClock and TiltCheck inbox intel.',
+      'Daily bonus intel for US sweepstakes and social casinos — merged from CollectClock, email inbox parsing, and local cache.',
     url: 'https://tiltcheck.me/bonuses',
   },
 };
 
-const COLLECTCLOCK_RAW_URL =
-  'https://raw.githubusercontent.com/TiltCheck-ME/CollectClock/main/bonus-data.json';
-
 const COLLECTCLOCK_SITE_URL = 'https://tiltcheck-me.github.io/CollectClock/';
-const EMAIL_FEED_API_URL = (() => {
-  const apiBase = process.env.NEXT_PUBLIC_API_URL || process.env.API_URL;
-  if (!apiBase) return null;
-  return `${apiBase.replace(/\/$/, '')}/bonuses/inbox`;
-})();
 
-type BonusFeedResponse = {
-  data?: BonusEntry[];
-  available?: boolean;
-  updatedAt?: string | null;
+const EMPTY_FEED: DailyBonusFeedResponse = {
+  updatedAt: new Date().toISOString(),
+  total: 0,
+  usTotal: 0,
+  data: [],
+  sources: [
+    {
+      key: 'email-inbox',
+      label: 'Email inbox',
+      available: false,
+      count: 0,
+      updatedAt: null,
+      detail: 'No active inbox promos',
+    },
+    {
+      key: 'collectclock',
+      label: 'CollectClock',
+      available: false,
+      count: 0,
+      updatedAt: null,
+      detail: 'CollectClock unreachable',
+    },
+    {
+      key: 'local-fallback',
+      label: 'Local cache',
+      available: false,
+      count: 0,
+      updatedAt: null,
+      detail: 'No local cache',
+    },
+  ],
 };
 
-function normalizeBonusKey(entry: BonusEntry): string {
-  return `${entry.brand.trim().toLowerCase()}::${entry.bonus.trim().toLowerCase()}::${entry.url.trim().toLowerCase()}`;
-}
-
-function mergeBonuses(...sources: BonusEntry[][]): BonusEntry[] {
-  const byKey = new Map<string, BonusEntry>();
-
-  for (const source of sources) {
-    for (const entry of source) {
-      const key = normalizeBonusKey(entry);
-      const existing = byKey.get(key);
-
-      if (!existing || Date.parse(entry.verified) > Date.parse(existing.verified)) {
-        byKey.set(key, entry);
-      }
-    }
-  }
-
-  return [...byKey.values()].sort(
-    (left, right) => Date.parse(right.verified) - Date.parse(left.verified)
-  );
-}
-
-type BonusFeedResult = {
-  bonuses: BonusEntry[];
-  available: boolean;
-  updatedAt: string | null;
-};
-
-async function fetchCollectClockBonuses(): Promise<BonusFeedResult> {
-  try {
-    const res = await fetch(COLLECTCLOCK_RAW_URL, {
-      next: { revalidate: 3600 },
-    });
-    if (!res.ok) {
-      console.error(
-        `[BonusTracker] CollectClock fetch failed: ${res.status} ${res.statusText}`
-      );
-      return { bonuses: [], available: false, updatedAt: null };
-    }
-    const data: BonusEntry[] = await res.json();
-    const bonuses = Array.isArray(data) ? data : [];
-    return {
-      bonuses,
-      available: bonuses.length > 0,
-      updatedAt: bonuses[0]?.verified ?? null,
-    };
-  } catch (err) {
-    console.error('[BonusTracker] Failed to load bonus data:', err);
-    return { bonuses: [], available: false, updatedAt: null };
-  }
-}
-
-async function fetchInboxBonuses(): Promise<BonusFeedResult> {
-  if (!EMAIL_FEED_API_URL) {
-    return { bonuses: [], available: false, updatedAt: null };
+async function fetchDailyBonusFeed(): Promise<DailyBonusFeedResponse> {
+  const apiUrl = getDailyFeedApiUrl(true);
+  if (!apiUrl) {
+    return EMPTY_FEED;
   }
 
   try {
-    const res = await fetch(EMAIL_FEED_API_URL, {
-      next: { revalidate: 300 },
-    });
-    if (!res.ok) {
-      console.error(
-        `[BonusTracker] Inbox bonus feed fetch failed: ${res.status} ${res.statusText}`
-      );
-      return { bonuses: [], available: false, updatedAt: null };
+    const response = await fetch(apiUrl, { next: { revalidate: 300 } });
+    if (!response.ok) {
+      console.error(`[BonusFeed] daily-feed fetch failed: ${response.status} ${response.statusText}`);
+      return EMPTY_FEED;
     }
-    const data: BonusFeedResponse = await res.json();
-    const bonuses = Array.isArray(data.data) ? data.data : [];
-    return {
-      bonuses,
-      available: Boolean(data.available) && bonuses.length > 0,
-      updatedAt: data.updatedAt ?? bonuses[0]?.verified ?? null,
-    };
-  } catch (err) {
-    console.error('[BonusTracker] Failed to load inbox bonus feed:', err);
-    return { bonuses: [], available: false, updatedAt: null };
+    return await response.json() as DailyBonusFeedResponse;
+  } catch (error) {
+    console.error('[BonusFeed] Failed to load daily bonus feed:', error);
+    return EMPTY_FEED;
   }
 }
 
 export default async function BonusesPage() {
-  const [collectClockFeed, inboxFeed] = await Promise.all([
-    fetchCollectClockBonuses(),
-    fetchInboxBonuses(),
-  ]);
-  const bonuses = mergeBonuses(inboxFeed.bonuses, collectClockFeed.bonuses);
-  const hasAnyFeed = bonuses.length > 0;
-  const sourceLabel = inboxFeed.available ? 'COLLECTCLOCK + EMAIL INBOX' : 'COLLECTCLOCK';
+  const feed = await fetchDailyBonusFeed();
+  const hasAnyFeed = feed.data.length > 0;
+  const liveSources = feed.sources.filter((source) => source.available).map((source) => source.label);
 
   return (
     <main className="public-page public-page--tight text-white">
       <PublicPageHero
         compact
         eyebrow="Bonus intel"
-        title="Claim first. Deposit later."
+        title="US daily bonus feed"
         description={
           <p>
-            CollectClock plus inbox email drops — free value before real-money deposits.
+            One lane for US casino promos — CollectClock daily trackers, parsed email drops, and cached intel merged into a single feed.
           </p>
         }
         actions={
@@ -150,38 +107,23 @@ export default async function BonusesPage() {
 
       <section className="public-page-section px-4">
         <div className="landing-shell">
-          <p className="mb-4 text-[11px] font-mono uppercase tracking-[0.16em] text-gray-500">
-            {bonuses.length} offers · {sourceLabel.toLowerCase()} · verify terms before claiming
-          </p>
-          {!collectClockFeed.available && inboxFeed.available && (
+          {!hasAnyFeed && (
             <div className="mb-6 public-page-card public-page-card--accent">
               <p className="text-xs font-mono uppercase tracking-widest text-[#17c3b2]">
-                [COLLECTCLOCK OFFLINE] Showing inbox-discovered bonuses only.
+                [FEED OFFLINE] All sources are empty or unreachable. Inbox crawler and CollectClock sync run on schedule — check back shortly.
               </p>
             </div>
           )}
 
-          {!hasAnyFeed ? (
-            <div className="public-page-card py-20 text-center">
-              <p className="font-mono text-xs uppercase tracking-widest text-[#17c3b2] mb-2">
-                [DATA UNAVAILABLE]
-              </p>
-              <p className="font-mono text-[#8a97a8] text-sm">
-                CollectClock and inbox feeds are empty or unreachable. Check back shortly or visit{' '}
-                <a
-                  href={COLLECTCLOCK_SITE_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-[#17c3b2] hover:underline"
-                >
-                  CollectClock directly
-                </a>
-                .
+          {hasAnyFeed && liveSources.length > 0 && (
+            <div className="mb-6 public-page-card">
+              <p className="text-xs font-mono uppercase tracking-widest text-[#8a97a8]">
+                Live sources: {liveSources.join(' · ')} · {feed.usTotal} US casino offers indexed
               </p>
             </div>
-          ) : (
-            <BonusGrid bonuses={bonuses} />
           )}
+
+          <DailyBonusFeed initialFeed={feed} usOnlyDefault />
         </div>
       </section>
     </main>

--- a/apps/web/src/components/DailyBonusFeed.tsx
+++ b/apps/web/src/components/DailyBonusFeed.tsx
@@ -81,7 +81,7 @@ function BonusCard({
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
       }).catch((err) => {
-        console.error('Failed to copy text: ', err);
+        console.error('Failed to copy text:', err);
       });
     }
   }, [entry.code]);
@@ -211,12 +211,16 @@ export default function DailyBonusFeed({ initialFeed, usOnlyDefault = true }: Da
 
   useEffect(() => {
     const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://api.tiltcheck.me').replace(/\/$/, '');
-    fetch(`${apiUrl}/rgaas/casino-scores`, { cache: 'no-store' })
+    const controller = new AbortController();
+
+    fetch(`${apiUrl}/rgaas/casino-scores`, { cache: 'no-store', signal: controller.signal })
       .then((response) => (response.ok ? response.json() : null))
       .then((payload: { casinos?: LiveTrustScore[] } | null) => {
         setLiveScores(Array.isArray(payload?.casinos) ? payload.casinos : []);
       })
-      .catch(() => setLiveScores([]));
+      .catch(() => {});
+
+    return () => controller.abort();
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/components/DailyBonusFeed.tsx
+++ b/apps/web/src/components/DailyBonusFeed.tsx
@@ -76,10 +76,14 @@ function BonusCard({
 
   const handleCopy = useCallback(() => {
     if (!entry.code) return;
-    navigator.clipboard.writeText(entry.code).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      navigator.clipboard.writeText(entry.code).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }).catch((err) => {
+        console.error('Failed to copy text: ', err);
+      });
+    }
   }, [entry.code]);
 
   const trustLabel = trustScore

--- a/apps/web/src/components/DailyBonusFeed.tsx
+++ b/apps/web/src/components/DailyBonusFeed.tsx
@@ -1,0 +1,373 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-06-16
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import {
+  SOURCE_BADGE_LABELS,
+  type BonusFeedSourceKey,
+  type BonusSourceStatus,
+  type DailyBonusFeedEntry,
+  type DailyBonusFeedResponse,
+} from '@/lib/daily-bonus-feed';
+import { findLiveTrustScore, type LiveTrustScore } from '@/lib/casino-trust';
+
+interface DailyBonusFeedProps {
+  initialFeed: DailyBonusFeedResponse;
+  usOnlyDefault?: boolean;
+}
+
+type SourceFilter = 'all' | BonusFeedSourceKey;
+
+function formatShortDate(value: string | null | undefined): string {
+  if (!value) return 'Unknown';
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return 'Unknown';
+  return new Date(timestamp).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function SourceBadge({ source }: { source: BonusFeedSourceKey }) {
+  const tone = source === 'email-inbox'
+    ? 'text-[#ffd700] border-[#ffd700]/40'
+    : source === 'collectclock'
+      ? 'text-[#17c3b2] border-[#17c3b2]/40'
+      : 'text-[#8a97a8] border-[#8a97a8]/40';
+
+  return (
+    <span className={`text-[10px] font-mono font-bold uppercase tracking-widest border px-2 py-0.5 ${tone}`}>
+      [{SOURCE_BADGE_LABELS[source]}]
+    </span>
+  );
+}
+
+function SourceStatusBar({ sources }: { sources: readonly BonusSourceStatus[] }) {
+  return (
+    <div className="mb-8 grid gap-3 sm:grid-cols-3">
+      {sources.map((source) => (
+        <div
+          key={source.key}
+          className={`public-page-card px-4 py-3 ${source.available ? 'public-page-card--accent' : ''}`}
+        >
+          <p className="text-[10px] font-mono uppercase tracking-[0.16em] text-gray-500">
+            {source.label}
+          </p>
+          <p className="mt-1 text-sm font-mono text-white">
+            {source.available ? `${source.count} live` : 'offline'}
+          </p>
+          <p className="mt-1 text-[11px] font-mono text-[#8a97a8]">{source.detail}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function BonusCard({
+  entry,
+  trustScore,
+}: {
+  entry: DailyBonusFeedEntry;
+  trustScore: LiveTrustScore | null;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    if (!entry.code) return;
+    navigator.clipboard.writeText(entry.code).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [entry.code]);
+
+  const trustLabel = trustScore
+    ? `TRUST ${Math.round(trustScore.currentScore)}`
+    : 'TRUST PENDING';
+
+  const expiryLabel = entry.expiresAt
+    ? `EXPIRES ${formatShortDate(entry.expiresAt)}`
+    : entry.expiryMessage && entry.expiryMessage !== 'Expiry not stated in email'
+      ? entry.expiryMessage.toUpperCase()
+      : null;
+
+  return (
+    <div
+      className="group relative flex flex-col justify-between p-6 border border-[#283347] bg-gradient-to-br from-[#0E0E0F] to-[#0a0c10] transition-all duration-300 hover:border-[#17c3b2] hover:shadow-[0_0_20px_rgba(23,195,178,0.15)]"
+      style={{ minHeight: '280px' }}
+    >
+      <div className="absolute top-4 right-4 text-[10px] font-mono uppercase tracking-widest text-[#17c3b2]/70 border border-[#17c3b2]/20 px-2 py-1">
+        [{trustLabel}]
+      </div>
+
+      <div className="flex-1 mt-2">
+        <div className="flex gap-2 mb-3 flex-wrap pr-24">
+          {entry.sources.map((source) => (
+            <SourceBadge key={source} source={source} />
+          ))}
+          {entry.code && (
+            <span className="text-[10px] font-mono font-bold uppercase tracking-widest text-[#ffd700] border border-[#ffd700]/40 px-2 py-0.5">
+              [HAS CODE]
+            </span>
+          )}
+          {entry.isUsCasino && (
+            <span className="text-[10px] font-mono font-bold uppercase tracking-widest text-[#17c3b2] border border-[#17c3b2]/30 px-2 py-0.5">
+              [US]
+            </span>
+          )}
+        </div>
+
+        {entry.imageUrl && (
+          <div className="mb-4 overflow-hidden border border-[#283347] bg-[#080a0d]">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={entry.imageUrl}
+              alt={`${entry.brand} promo`}
+              className="h-28 w-full object-cover"
+              loading="lazy"
+            />
+          </div>
+        )}
+
+        <h3 className="text-2xl font-black uppercase tracking-tight text-white mb-2 leading-tight">
+          {entry.brand}
+        </h3>
+
+        {entry.bonusType && (
+          <p className="text-[10px] font-mono uppercase tracking-widest text-[#8a97a8] mb-2">
+            {entry.bonusType}
+            {entry.bonusValue ? ` · ${entry.bonusValue}` : ''}
+          </p>
+        )}
+
+        <p className="text-[#c4ced8] text-sm font-mono leading-relaxed mb-4">
+          {entry.bonus}
+        </p>
+
+        {entry.code && (
+          <div className="flex items-center gap-2 mb-4 p-2 border border-[#ffd700]/20 bg-[#ffd700]/5">
+            <span className="text-xs font-mono uppercase tracking-widest text-[#8a97a8]">CODE:</span>
+            <span className="text-[#ffd700] font-mono font-bold tracking-widest flex-1">
+              {entry.code}
+            </span>
+            <button
+              onClick={handleCopy}
+              className="text-[10px] font-mono font-bold uppercase tracking-widest border px-2 py-1 transition-all duration-200"
+              style={{
+                borderColor: copied ? 'var(--color-positive)' : 'rgba(255,215,0,0.4)',
+                color: copied ? 'var(--color-positive)' : '#ffd700',
+              }}
+              aria-label={`Copy promo code for ${entry.brand}`}
+            >
+              {copied ? '[COPIED]' : '[COPY]'}
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2 pt-4 border-t border-[#283347]">
+        <a
+          href={entry.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn btn-primary text-center text-xs font-black tracking-widest"
+          aria-label={`Claim bonus at ${entry.brand}`}
+        >
+          CLAIM BONUS
+        </a>
+        <div className="flex justify-between items-center pt-1 gap-2">
+          <span className="text-[10px] font-mono uppercase tracking-widest text-[#4B5563]">
+            LAST VERIFIED:
+          </span>
+          <span className="text-[10px] font-mono text-[#8a97a8]">{formatShortDate(entry.verified)}</span>
+        </div>
+        {expiryLabel && (
+          <div className="flex justify-between items-center gap-2">
+            <span className="text-[10px] font-mono uppercase tracking-widest text-[#4B5563]">
+              EXPIRY:
+            </span>
+            <span className="text-[10px] font-mono text-[#ffd700]">{expiryLabel}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function DailyBonusFeed({ initialFeed, usOnlyDefault = true }: DailyBonusFeedProps) {
+  const { user, loading } = useAuth();
+  const [feed, setFeed] = useState(initialFeed);
+  const [usOnly, setUsOnly] = useState(usOnlyDefault);
+  const [query, setQuery] = useState('');
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>('all');
+  const [liveScores, setLiveScores] = useState<LiveTrustScore[]>([]);
+  const [hiddenCount, setHiddenCount] = useState(initialFeed.suppression?.hiddenCount ?? 0);
+  const [suppressionActive, setSuppressionActive] = useState(initialFeed.suppression?.active ?? false);
+
+  useEffect(() => {
+    const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://api.tiltcheck.me').replace(/\/$/, '');
+    fetch(`${apiUrl}/rgaas/casino-scores`, { cache: 'no-store' })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((payload: { casinos?: LiveTrustScore[] } | null) => {
+        setLiveScores(Array.isArray(payload?.casinos) ? payload.casinos : []);
+      })
+      .catch(() => setLiveScores([]));
+  }, []);
+
+  useEffect(() => {
+    if (loading) return;
+
+    const token = typeof window !== 'undefined'
+      ? window.localStorage.getItem('tc_token')?.trim() || null
+      : null;
+    if (!user && !token) {
+      setFeed(initialFeed);
+      setHiddenCount(initialFeed.suppression?.hiddenCount ?? 0);
+      setSuppressionActive(initialFeed.suppression?.active ?? false);
+      return;
+    }
+
+    const apiBase = (process.env.NEXT_PUBLIC_API_URL || 'https://api.tiltcheck.me').replace(/\/$/, '');
+    const controller = new AbortController();
+    const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+
+    fetch(`${apiBase}/bonuses/daily-feed?usOnly=${usOnly ? 'true' : 'false'}`, {
+      credentials: 'include',
+      headers,
+      signal: controller.signal,
+      cache: 'no-store',
+    })
+      .then(async (response) => {
+        if (!response.ok) return;
+        const body = await response.json() as DailyBonusFeedResponse;
+        setFeed(body);
+        setHiddenCount(body.suppression?.hiddenCount ?? 0);
+        setSuppressionActive(Boolean(body.suppression?.active));
+      })
+      .catch(() => {});
+
+    return () => controller.abort();
+  }, [loading, user, usOnly, initialFeed]);
+
+  const filtered = useMemo(() => {
+    let entries = feed.data;
+
+    if (sourceFilter !== 'all') {
+      entries = entries.filter((entry) => entry.sources.includes(sourceFilter));
+    }
+
+    const trimmed = query.trim().toLowerCase();
+    if (trimmed) {
+      entries = entries.filter((entry) =>
+        entry.brand.toLowerCase().includes(trimmed)
+        || entry.bonus.toLowerCase().includes(trimmed),
+      );
+    }
+
+    return entries;
+  }, [feed.data, query, sourceFilter]);
+
+  return (
+    <div>
+      <SourceStatusBar sources={feed.sources} />
+
+      <div className="mb-6 flex flex-wrap items-center gap-3">
+        <p className="text-[11px] font-mono uppercase tracking-[0.16em] text-gray-500">
+          {filtered.length} offers · updated {formatShortDate(feed.updatedAt)} · verify terms before claiming
+        </p>
+        <button
+          type="button"
+          onClick={() => setUsOnly((current) => !current)}
+          className={`text-[10px] font-mono uppercase tracking-widest border px-3 py-1 transition-colors ${
+            usOnly
+              ? 'border-[#17c3b2] text-[#17c3b2]'
+              : 'border-[#283347] text-[#8a97a8] hover:border-[#17c3b2]/50'
+          }`}
+        >
+          {usOnly ? '[US CASINOS ONLY]' : '[ALL SOURCES]'}
+        </button>
+      </div>
+
+      {suppressionActive && hiddenCount > 0 && (
+        <div className="mb-6 border border-[#17c3b2]/30 bg-[#0d1117] px-4 py-3">
+          <p className="text-xs font-mono uppercase tracking-widest text-[#17c3b2]">
+            [{hiddenCount} HIDDEN] Your active casino filters are suppressing matching bonus promos.
+          </p>
+        </div>
+      )}
+
+      <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="relative max-w-lg flex-1">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#17c3b2] font-mono text-sm select-none pointer-events-none">
+            $
+          </span>
+          <input
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="FILTER BY BRAND OR BONUS..."
+            className="w-full pl-8 pr-4 py-3 bg-[#080a0d] border border-[#283347] text-white font-mono text-sm uppercase tracking-widest placeholder:text-[#4B5563] focus:outline-none focus:border-[#17c3b2] focus:shadow-[0_0_10px_rgba(23,195,178,0.2)] transition-all duration-200"
+            aria-label="Filter bonuses by brand or bonus text"
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {(['all', 'email-inbox', 'collectclock', 'local-fallback'] as const).map((filter) => (
+            <button
+              key={filter}
+              type="button"
+              onClick={() => setSourceFilter(filter)}
+              className={`text-[10px] font-mono uppercase tracking-widest border px-3 py-2 transition-colors ${
+                sourceFilter === filter
+                  ? 'border-[#17c3b2] text-[#17c3b2]'
+                  : 'border-[#283347] text-[#8a97a8] hover:border-[#17c3b2]/50'
+              }`}
+            >
+              {filter === 'all' ? '[ALL SOURCES]' : `[${SOURCE_BADGE_LABELS[filter]}]`}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {query && (
+        <p className="mb-4 text-xs font-mono text-[#8a97a8] uppercase tracking-widest">
+          {filtered.length} RESULT{filtered.length !== 1 ? 'S' : ''} FOR &quot;{query.toUpperCase()}&quot;
+        </p>
+      )}
+
+      {filtered.length === 0 ? (
+        <div className="public-page-card py-20 text-center">
+          <p className="font-mono text-xs uppercase tracking-widest text-[#17c3b2] mb-2">
+            [NO BONUSES FOUND]
+          </p>
+          <p className="font-mono text-[#8a97a8] text-sm">
+            No cap — the feed is dry right now. Toggle filters or check back after the next inbox crawl.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filtered.map((entry) => {
+            let domainCandidates: string[] = [];
+            try {
+              domainCandidates = [new URL(entry.url).hostname.replace(/^www\./i, '')];
+            } catch {
+              domainCandidates = [];
+            }
+
+            return (
+            <BonusCard
+              key={entry.id}
+              entry={entry}
+              trustScore={findLiveTrustScore(
+                { name: entry.brand, slug: entry.brand, domainCandidates },
+                liveScores,
+              )}
+            />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/daily-bonus-feed.ts
+++ b/apps/web/src/lib/daily-bonus-feed.ts
@@ -1,0 +1,55 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-06-16
+
+export type BonusFeedSourceKey = 'collectclock' | 'email-inbox' | 'local-fallback';
+
+export interface DailyBonusFeedEntry {
+  id: string;
+  brand: string;
+  bonus: string;
+  url: string;
+  verified: string;
+  code: string | null;
+  sources: BonusFeedSourceKey[];
+  bonusType: string | null;
+  bonusValue: string | null;
+  expiresAt: string | null;
+  expiryMessage: string | null;
+  imageUrl: string | null;
+  isUsCasino: boolean;
+  casinoCategory: string | null;
+  trustScore: number | null;
+}
+
+export interface BonusSourceStatus {
+  key: BonusFeedSourceKey;
+  label: string;
+  available: boolean;
+  count: number;
+  updatedAt: string | null;
+  detail: string;
+}
+
+export interface DailyBonusFeedResponse {
+  updatedAt: string;
+  total: number;
+  usTotal: number;
+  data: DailyBonusFeedEntry[];
+  sources: BonusSourceStatus[];
+  suppression?: {
+    active?: boolean;
+    hiddenCount?: number;
+  };
+}
+
+export const SOURCE_BADGE_LABELS: Record<BonusFeedSourceKey, string> = {
+  collectclock: 'CollectClock',
+  'email-inbox': 'Inbox',
+  'local-fallback': 'Cache',
+};
+
+export function getDailyFeedApiUrl(usOnly = true): string | null {
+  const apiBase = process.env.NEXT_PUBLIC_API_URL || process.env.API_URL;
+  if (!apiBase) return null;
+  const suffix = usOnly ? '?usOnly=true' : '?usOnly=false';
+  return `${apiBase.replace(/\/$/, '')}/bonuses/daily-feed${suffix}`;
+}

--- a/apps/web/src/lib/daily-bonus-feed.ts
+++ b/apps/web/src/lib/daily-bonus-feed.ts
@@ -47,9 +47,8 @@ export const SOURCE_BADGE_LABELS: Record<BonusFeedSourceKey, string> = {
   'local-fallback': 'Cache',
 };
 
-export function getDailyFeedApiUrl(usOnly = true): string | null {
-  const apiBase = process.env.NEXT_PUBLIC_API_URL || process.env.API_URL;
-  if (!apiBase) return null;
+export function getDailyFeedApiUrl(usOnly = true): string {
+  const apiBase = process.env.NEXT_PUBLIC_API_URL || process.env.API_URL || 'https://api.tiltcheck.me';
   const suffix = usOnly ? '?usOnly=true' : '?usOnly=false';
   return `${apiBase.replace(/\/$/, '')}/bonuses/daily-feed${suffix}`;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `/bonuses` page only merged CollectClock and inbox feeds client-side with a minimal card model. There was no single backend contract for a US-focused daily bonus feed, no source visibility, and inbox enrichment (expiry, images, bonus type) was dropped in the UI.

## Approach

- Add `GET /bonuses/daily-feed` that aggregates:
  - **CollectClock** (live GitHub JSON)
  - **Email inbox** (parsed promos from `email-bonus-feed.json`)
  - **Local cache** (`data/bonus-data.json` fallback)
- Deduplicate by brand/bonus/url, tag each entry with its source(s), and index US casinos from `sweepstakes-casinos.json` + regulated entries in `online-casinos.json`.
- Rebuild `/bonuses` as a **US Daily Bonus Feed** using a new `DailyBonusFeed` component with source status pills, per-source filters, US-only toggle, trust score overlay, and enriched inbox metadata.

## Scope

| Area | Change |
|------|--------|
| API | `apps/api/src/lib/daily-bonus-feed.ts`, route on `/bonuses/daily-feed` |
| Web | `DailyBonusFeed.tsx`, updated `/bonuses` page |
| Tests | API unit + route tests for feed aggregation |

## Risks

- **External dependency**: CollectClock upstream outage falls back to local cache; source bar shows offline state.
- **US matching**: Heuristic brand/domain match against catalog; `.us` domains auto-qualify.
- **Trust scores**: Still loaded client-side from `/rgaas/casino-scores` (unchanged pattern from `/casinos`).
- **Rollback**: Revert PR; existing `/bonuses` and `/bonuses/inbox` endpoints remain intact.

## Validation

- [x] `pnpm exec vitest run tests/lib/daily-bonus-feed.test.ts tests/routes/daily-bonus-feed.test.ts` (apps/api)
- [ ] Manual: visit `/bonuses`, confirm source pills, US filter, and bonus cards render
- [ ] Manual: `GET /bonuses/daily-feed?usOnly=true` returns merged feed with `sources` metadata

## Not in scope

- Live web search scraping (no in-repo search ingest pipeline today)
- Discord channel watcher promos (still routed via bot/events; can be wired later)
- DB-backed promotions table
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2709c3c-696f-4cfd-95a1-4d91238aec58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2709c3c-696f-4cfd-95a1-4d91238aec58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

