### PR TITLE
feat(docs): restore GitHub Pages spec mirror for current tiltcheck specs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17
+name: Deploy GitHub Pages Specs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/tiltcheck/**'
+      - 'scripts/convert-markdown.js'
+      - 'scripts/pages-assets/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build spec HTML
+        run: node scripts/convert-markdown.js docs/tiltcheck out/docs
+
+      - name: Add shared assets
+        run: |
+          mkdir -p out/styles
+          cp scripts/pages-assets/styles/base.css out/styles/base.css
+          mkdir -p out/docs-md
+          rsync -av docs/tiltcheck/ out/docs-md/
+
+      - name: Publish to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: out
+          force_orphan: true

--- a/docs/GITHUB-PAGES-TROUBLESHOOTING.md
+++ b/docs/GITHUB-PAGES-TROUBLESHOOTING.md
@@ -1,15 +1,35 @@
 # GitHub Pages Troubleshooting Guide
 
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17 -->
+
+## What GitHub Pages hosts now
+
+Production marketing and docs live on **Railway** at `https://tiltcheck.me` (Next.js `apps/web`, including `/docs`).
+
+GitHub Pages (`gh-pages` branch) is a **static mirror** of `docs/tiltcheck/` specs:
+
+| Path on Pages | Source |
+|---------------|--------|
+| `/` | Redirect to `/docs/index.html` |
+| `/docs/*.html` | `node scripts/convert-markdown.js` output |
+| `/docs-md/*.md` | Raw markdown from `docs/tiltcheck/` |
+
+Default URL: `https://tiltcheck-me.github.io/tiltcheck-monorepo/` (no custom domain on `gh-pages`).
+
+Workflow: `.github/workflows/pages.yml` — triggers on `docs/tiltcheck/**` changes.
+
+Local build: `pnpm docs:pages`
+
 ## Quick Diagnostics
 
-If tiltcheck.me is showing 404 errors, run through this checklist:
+If the GitHub Pages specs site is stale or 404:
 
 ### 1. Check GitHub Actions Status
 
 ```bash
 # In GitHub UI:
 # 1. Go to Actions tab
-# 2. Look for "Deploy GitHub Pages" workflow
+# 2. Look for "Deploy GitHub Pages Specs" workflow
 # 3. Check if latest run succeeded (green checkmark)
 ```
 
@@ -18,46 +38,25 @@ If tiltcheck.me is showing 404 errors, run through this checklist:
 ### 2. Verify gh-pages Branch
 
 ```bash
-git fetch origin gh-pages:gh-pages
-git log gh-pages -1 --oneline
-git show gh-pages:index.html | head -10
+git fetch origin gh-pages
+git log origin/gh-pages -1 --oneline
+git show origin/gh-pages:docs/index.html | head -10
 ```
 
-**Expected**: Recent commit with index.html content visible
+**Expected**: Recent commit with specs index HTML visible
 
-### 3. Check CNAME Configuration
-
-```bash
-git show gh-pages:CNAME
-```
-
-**Expected output**: `tiltcheck.me`
-
-### 4. Verify Repository Settings
+### 3. Verify Repository Settings
 
 1. Go to Repository Settings
 2. Navigate to Pages section
 3. Check:
    - **Source**: Deploy from branch → gh-pages
    - **Branch**: gh-pages, / (root)
-   - **Custom domain**: tiltcheck.me
-   - **Enforce HTTPS**: ✓ Enabled
+   - **Custom domain**: empty (production is Railway, not Pages)
 
-### 5. DNS Status
+### 4. Production site (tiltcheck.me) issues
 
-Check if DNS is properly configured:
-```bash
-dig tiltcheck.me +short
-nslookup tiltcheck.me
-```
-
-**Expected**: Should return GitHub Pages IP addresses:
-- 185.199.108.153
-- 185.199.109.153
-- 185.199.110.153
-- 185.199.111.153
-
-Or CNAME pointing to: `jmenichole.github.io`
+If `tiltcheck.me` is down, check **Railway** deploy (`.github/workflows/deploy-railway.yml`), not GitHub Pages.
 
 ## Common Issues and Fixes
 
@@ -67,200 +66,47 @@ Or CNAME pointing to: `jmenichole.github.io`
 
 **Diagnosis**:
 ```bash
-# Check if workflow file exists
 cat .github/workflows/pages.yml
-
-# Check if workflow is enabled
-# Go to Actions tab → Select "Deploy GitHub Pages" → Check if disabled
 ```
 
 **Fixes**:
 1. Enable the workflow in GitHub UI if disabled
-2. Push a small change to main branch to trigger it
+2. Push a change under `docs/tiltcheck/`
 3. Manually trigger via workflow_dispatch
 
 ### Issue 2: Workflow Fails
 
 **Symptoms**: Red X in Actions tab
 
-**Diagnosis**: Click on failed workflow run to see error logs
-
 **Common errors**:
-- **Permission denied**: Check workflow has `contents: write` permission
-- **Missing files**: Verify `services/landing/public/` exists and has content
-- **rsync error**: Check rsync command syntax in workflow
+- **Permission denied**: Workflow needs `contents: write`
+- **Missing source**: Verify `docs/tiltcheck/` exists
 
-**Fixes**:
-1. Update workflow permissions in `.github/workflows/pages.yml`
-2. Verify source directory exists
-3. Check workflow syntax
+**Fix**: Re-run after fixing the workflow log error.
 
-### Issue 3: DNS Not Resolving
+### Issue 3: Specs out of date on Pages but correct on tiltcheck.me
 
-**Symptoms**: Domain doesn't resolve or points to wrong IP
+**Cause**: `tiltcheck.me/docs` reads live markdown via Next.js; Pages mirrors only update when `pages.yml` runs.
 
-**Diagnosis**:
-```bash
-dig tiltcheck.me
-whois tiltcheck.me
-```
+**Fix**: Merge spec changes to `main` or manually trigger the Pages workflow.
 
-**Fixes**:
-1. Update DNS records at your domain registrar
-2. Add A records pointing to GitHub Pages IPs
-3. Wait for DNS propagation (up to 24-48 hours)
-4. Clear local DNS cache:
-   - Mac: `sudo dscacheutil -flushcache`
-   - Windows: `ipconfig /flushdns`
-   - Linux: `sudo systemd-resolve --flush-caches`
-
-### Issue 4: CNAME Missing or Wrong
-
-**Symptoms**: Site works at jmenichole.github.io but not tiltcheck.me
-
-**Diagnosis**:
-```bash
-git show gh-pages:CNAME
-```
-
-**Fixes**:
-1. Ensure CNAME file exists in `services/landing/public/`
-2. Verify it contains exactly: `tiltcheck.me` (no http://, no trailing slash)
-3. Re-run deployment workflow
-
-### Issue 5: Jekyll Processing Issues
-
-**Symptoms**: Some files or directories not appearing
-
-**Diagnosis**:
-```bash
-git show gh-pages:.nojekyll
-```
-
-**Fixes**:
-1. Ensure `.nojekyll` file exists in `services/landing/public/`
-2. File should be empty or contain a single newline
-3. Re-run deployment workflow
-
-### Issue 6: Stale Deployment
-
-**Symptoms**: Old content showing, changes not visible
-
-**Diagnosis**:
-```bash
-# Check last deployment time
-git log gh-pages -1 --format="%ai %s"
-
-# Compare with main branch
-git log main -1 --format="%ai %s"
-```
-
-**Fixes**:
-1. Trigger new deployment:
-   ```bash
-   # Option 1: Push to main
-   git commit --allow-empty -m "Trigger pages deployment"
-   git push origin main
-   
-   # Option 2: Manual trigger in GitHub UI
-   # Actions → Deploy GitHub Pages → Run workflow
-   ```
-
-2. Clear browser cache:
-   - Hard refresh: Ctrl+Shift+R (Windows/Linux) or Cmd+Shift+R (Mac)
-   - Clear cache in browser settings
-
-## Manual Deployment
-
-If automatic deployment fails, you can manually deploy:
+## Manual local verification
 
 ```bash
-# 1. Checkout main branch
-git checkout main
-
-# 2. Create out directory
-mkdir -p out
-
-# 3. Copy landing page files
-rsync -av --delete services/landing/public/ out/
-
-# 4. Copy documentation
-mkdir -p out/docs-md
-rsync -av docs/tiltcheck/ out/docs-md/
-
-# 5. Ensure CNAME is present
-if [ -f services/landing/public/CNAME ]; then 
-  cp services/landing/public/CNAME out/CNAME
-fi
-
-# 6. Deploy to gh-pages
-git checkout --orphan gh-pages-new
-git rm -rf .
-mv out/* .
-rmdir out
-git add .
-git commit -m "Manual deployment $(date -u +%Y-%m-%d)"
-git push -f origin gh-pages-new:gh-pages
-git checkout main
-git branch -D gh-pages-new
+pnpm docs:pages
+npx http-server out -p 4173
+# Open http://127.0.0.1:4173/docs/index.html
 ```
 
-## Verification Checklist
+## Checklist before escalating
 
-After applying fixes:
+- [ ] `Deploy GitHub Pages Specs` workflow succeeded on latest `main`
+- [ ] `origin/gh-pages` has recent commit
+- [ ] `/docs/index.html` exists on `gh-pages`
+- [ ] `.nojekyll` present on `gh-pages`
+- [ ] No `CNAME` on `gh-pages` pointing at `tiltcheck.me` (conflicts with Railway)
 
-- [ ] Workflow runs and completes successfully
-- [ ] gh-pages branch updated with recent commit
-- [ ] CNAME file present in gh-pages
-- [ ] .nojekyll file present in gh-pages
-- [ ] index.html loads at https://tiltcheck.me
-- [ ] Other pages accessible (about, contact, etc.)
-- [ ] DNS resolves correctly
-- [ ] No mixed content warnings
-- [ ] HTTPS works properly
-
-## When to Escalate
-
-Contact GitHub Support if:
-- DNS is correct but site still shows 404 after 48 hours
-- Workflow succeeds but deployment doesn't update
-- Custom domain verification fails
-- HTTPS certificate issues persist
-- Multiple deployments fail with unclear errors
-
-## Additional Resources
+## References
 
 - [GitHub Pages Documentation](https://docs.github.com/en/pages)
-- [Custom Domain Configuration](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site)
-- [Troubleshooting GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/troubleshooting-404-errors-for-github-pages-sites)
-- [GitHub Pages Status](https://www.githubstatus.com/)
-
-## Support Contacts
-
-- **Repository Owner**: jmenichole
-- **GitHub Support**: https://support.github.com/
-- **Domain Registrar**: Check with your DNS provider
-
-## Log Collection
-
-When reporting issues, include:
-
-```bash
-# Workflow logs
-# Download from Actions tab in GitHub
-
-# DNS information
-dig tiltcheck.me +trace > dns-trace.txt
-
-# Repository status
-git --no-pager log gh-pages -5 --oneline > gh-pages-log.txt
-git --no-pager show gh-pages:CNAME > cname-content.txt
-ls -la services/landing/public/ > public-files.txt
-
-# Include these files when seeking help
-```
-
----
-
-**Last Updated**: December 14, 2025  
-**Document Version**: 1.0
+- [Troubleshooting GitHub Pages 404s](https://docs.github.com/en/pages/getting-started-with-github-pages/troubleshooting-404-errors-for-github-pages-sites)

--- a/docs/tiltcheck/index.md
+++ b/docs/tiltcheck/index.md
@@ -3,7 +3,7 @@ title: TiltCheck Documentation Hub
 layout: default
 ---
 
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-07 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17 -->
 
 # TiltCheck Ecosystem Docs
 
@@ -26,6 +26,7 @@ Built by a degen, for degens. Fast reference to every internal spec, prompt, and
 - [8A Instagram Stake.us Code Timing (Observed)](8a-instagram-stake-us-code-timing.md)
 - [9 Architecture](9-architecture.md)
 - [10 Data Models](10-data-models.md)
+- [TRUST-POLICY](TRUST-POLICY.md)
 
 ## System Intelligence & APIs
 - [11 System Prompts](11-system-prompts.md)
@@ -34,12 +35,15 @@ Built by a degen, for degens. Fast reference to every internal spec, prompt, and
 
 ## Modules & Features
 - [14 Poker Module](14-poker-module.md)
+- [16 RGaaS Pivot](16-rgaas-pivot.md)
 - [17 LockVault](17-lockvault.md)
 - [17 LinkGuard Integration](17-linkguard-integration.md)
 - [17 Branch Protection](17-branch-protection.md)
+- [17 Components & A11y Audits](17-components-audits.md)
 - [17 Migration Checklist](17-migration-checklist.md)
 - [17 Trust Migration](17-trust-migration.md)
-- [21 Surgical Self-Exclusion](../surgical-self-exclusion.md)
+- [20 Casino Trust Score Page](20-casino-trust-score-page.md)
+- [21 Provably Fair Limitations](21-provably-fair-limitations.md)
 - [22 Auto-Vault Rule Engine](22-autovault.md)
 
 ## Roadmap & Diagrams
@@ -59,8 +63,7 @@ Built by a degen, for degens. Fast reference to every internal spec, prompt, and
 - [Design Prompts Replies](DESIGN_PROMPTS_REPLIES.md)
 - [Dashboard Enhancements](DASHBOARD_ENHANCEMENTS.md)
 
-## Deployment & Infra Notes
-- [Render Deployment Notes](RENDER_DEPLOYMENT.md)
-
 ---
 Generated index for GitHub Pages fast navigation. Update when adding new spec files.
+
+Made for Degens. By Degens.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "crawl:emails:schedule": "powershell -ExecutionPolicy Bypass -File scripts/register-email-crawler-task.ps1",
     "crawl:casinos": "tsx scripts/scrape-casinos.ts",
     "test:e2e": "playwright test",
-    "test:e2e:degens-trivia": "PLAYWRIGHT_DEGENS_LOCAL=1 playwright test tests/e2e/degens-activity-trivia.spec.ts"
+    "test:e2e:degens-trivia": "PLAYWRIGHT_DEGENS_LOCAL=1 playwright test tests/e2e/degens-activity-trivia.spec.ts",
+    "docs:pages": "node scripts/convert-markdown.js docs/tiltcheck out/docs && mkdir -p out/styles && cp scripts/pages-assets/styles/base.css out/styles/base.css"
   },
   "devDependencies": {
     "@google-cloud/secret-manager": "^6.1.1",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,7 +35,7 @@ This folder has many one-off and historical utilities. If you are working solo, 
 
 ## Use With Caution (Specialized / One-off)
 
-- Docs/content conversion: `convert-markdown.js`, `generate-regulations-draft.mjs`, `sync-regulations-us.mjs`
+- Docs/content conversion: `convert-markdown.js` (`pnpm docs:pages`), `sync-docs.sh`, `generate-regulations-draft.mjs`, `sync-regulations-us.mjs`
 - Repo/admin helpers: `migrate-repo.sh`, `build-gitlab-wiki.js`, `add-copyright-headers.sh`
 - Setup/deploy diagnostics: `validate-production-env.sh`, `validate-docker-credentials.sh`, `check-health.sh`
 - Experimental automation: `devx-duo-agent.mjs`

--- a/scripts/convert-markdown.js
+++ b/scripts/convert-markdown.js
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 /**
+ * © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17
+ *
  * Lightweight Markdown → HTML converter for TiltCheck docs.
  * No external deps; supports:
+ *  - YAML frontmatter (skipped in body)
  *  - Headings (# .. ######)
  *  - Paragraphs / blank line separation
  *  - Unordered lists (-, *)
@@ -14,99 +17,168 @@
  *   node scripts/convert-markdown.js [sourceDir] [outDir]
  * Defaults:
  *   sourceDir = docs/tiltcheck
- *   outDir = services/landing/public/docs
+ *   outDir = out/docs
  */
 import fs from 'fs';
 import path from 'path';
 
 const sourceRoot = path.resolve(process.argv[2] || 'docs/tiltcheck');
-const outRoot = path.resolve(process.argv[3] || 'services/landing/public/docs');
+const outRoot = path.resolve(process.argv[3] || 'out/docs');
+const FOOTER = 'Made for Degens. By Degens.';
+const COPYRIGHT = '© 2024–2026 TiltCheck Ecosystem. All Rights Reserved.';
 
-function slugify(name){
+function slugify(name) {
   return name
-    .replace(/^\d+-/, '') // drop numeric prefixes like 1-, 10-
-    .replace(/\.md$/i,'')
+    .replace(/^\d+[a-z]?-/, '')
+    .replace(/\.md$/i, '')
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g,'-')
-    .replace(/^-+|-+$/g,'');
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
-function escapeHtml(str){
-  return str.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+function escapeHtml(str) {
+  return str.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
 
-function renderMarkdown(md){
-  const lines = md.split(/\r?\n/);
+function stripFrontmatter(md) {
+  if (!md.startsWith('---')) return md;
+  const end = md.indexOf('\n---', 3);
+  if (end === -1) return md;
+  return md.slice(end + 4).replace(/^\s*\n/, '');
+}
+
+function renderMarkdown(md) {
+  const lines = stripFrontmatter(md).split(/\r?\n/);
   const out = [];
-  let inCode = false; let codeLang = '';
+  let inCode = false;
+  let codeLang = '';
   let listOpen = false;
-  for(const raw of lines){
-    const line = raw.replace(/\t/g,'    ');
+
+  for (const raw of lines) {
+    const line = raw.replace(/\t/g, '    ');
     const fenceMatch = line.match(/^```(.*)$/);
-    if(fenceMatch){
-      if(!inCode){ inCode = true; codeLang = fenceMatch[1].trim(); out.push(`<pre class="code-block" data-lang="${escapeHtml(codeLang)}"><code>`); }
-      else { inCode = false; codeLang=''; out.push('</code></pre>'); }
+    if (fenceMatch) {
+      if (!inCode) {
+        inCode = true;
+        codeLang = fenceMatch[1].trim();
+        out.push(`<pre class="code-block" data-lang="${escapeHtml(codeLang)}"><code>`);
+      } else {
+        inCode = false;
+        codeLang = '';
+        out.push('</code></pre>');
+      }
       continue;
     }
-    if(inCode){ out.push(escapeHtml(line)); continue; }
-    if(/^\s*$/.test(line)){ if(listOpen){ out.push('</ul>'); listOpen=false; } out.push(''); continue; }
+    if (inCode) {
+      out.push(escapeHtml(line));
+      continue;
+    }
+    if (/^\s*$/.test(line)) {
+      if (listOpen) {
+        out.push('</ul>');
+        listOpen = false;
+      }
+      out.push('');
+      continue;
+    }
     const heading = line.match(/^(#{1,6})\s+(.*)$/);
-    if(heading){ const level = heading[1].length; out.push(`<h${level}>${inline(heading[2].trim())}</h${level}>`); continue; }
+    if (heading) {
+      const level = heading[1].length;
+      out.push(`<h${level}>${inline(heading[2].trim())}</h${level}>`);
+      continue;
+    }
     const list = line.match(/^[-*]\s+(.*)$/);
-    if(list){ if(!listOpen){ out.push('<ul>'); listOpen=true; } out.push(`<li>${inline(list[1].trim())}</li>`); continue; }
-    // Paragraph
+    if (list) {
+      if (!listOpen) {
+        out.push('<ul>');
+        listOpen = true;
+      }
+      out.push(`<li>${inline(list[1].trim())}</li>`);
+      continue;
+    }
     out.push(`<p>${inline(line.trim())}</p>`);
   }
-  if(listOpen) out.push('</ul>');
-  if(inCode) out.push('</code></pre>');
+  if (listOpen) out.push('</ul>');
+  if (inCode) out.push('</code></pre>');
   return out.join('\n');
 }
 
-function inline(str){
-  // links
-  str = str.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_,text,url)=>`<a href="${escapeHtml(url)}">${escapeHtml(text)}</a>`);
-  // bold ** **
-  str = str.replace(/\*\*([^*]+)\*\*/g, (_,t)=>`<strong>${escapeHtml(t)}</strong>`);
-  // emphasis * * (avoid bold already)
-  str = str.replace(/(^|[^*])\*([^*]+)\*(?!\*)/g, (_,pre,t)=>`${pre}<em>${escapeHtml(t)}</em>`);
-  // inline code
-  str = str.replace(/`([^`]+)`/g, (_,t)=>`<code>${escapeHtml(t)}</code>`);
+function inline(str) {
+  str = str.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) => `<a href="${escapeHtml(url)}">${escapeHtml(text)}</a>`);
+  str = str.replace(/\*\*([^*]+)\*\*/g, (_, t) => `<strong>${escapeHtml(t)}</strong>`);
+  str = str.replace(/(^|[^*])\*([^*]+)\*(?!\*)/g, (_, pre, t) => `${pre}<em>${escapeHtml(t)}</em>`);
+  str = str.replace(/`([^`]+)`/g, (_, t) => `<code>${escapeHtml(t)}</code>`);
   return str;
 }
 
-function extractMeta(md){
-  // first heading as title; first paragraph as description
-  let title=''; let description='';
-  const heading = md.match(/^#\s+(.+)$/m); if(heading) title=heading[1].trim();
-  const para = md.replace(/```[\s\S]*?```/g,'').match(/(^|\n)([^#\n][^\n]+)\n/); if(para) description=para[2].trim();
-  return { title: title || 'Untitled', description: description.slice(0,180) };
+function extractMeta(md) {
+  let title = '';
+  let description = '';
+  const body = stripFrontmatter(md);
+  const heading = body.match(/^#\s+(.+)$/m);
+  if (heading) title = heading[1].trim();
+  const para = body.replace(/```[\s\S]*?```/g, '').match(/(^|\n)([^#\n][^\n]+)\n/);
+  if (para) description = para[2].trim();
+  return { title: title || 'Untitled', description: description.slice(0, 180) };
 }
 
-function buildPage({ slug, title, description, body }){
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>${escapeHtml(title)} - TiltCheck</title><meta name="description" content="${escapeHtml(description)}"/><link rel="stylesheet" href="/styles/base.css"/><style>body{background:#0a0a0a;color:#e0e0e0;font-family:Inter,system-ui,sans-serif;margin:0;padding:0}main{max-width:900px;margin:0 auto;padding:40px 18px;line-height:1.7}a{color:#00d4aa;text-decoration:none}a:hover{text-decoration:underline}.page-hero{padding:54px 24px 32px;background:linear-gradient(135deg,#121212,#181818);border-bottom:1px solid #222}.page-hero h1{margin:0 0 10px;font-size:2.4rem;background:linear-gradient(135deg,#00d4aa,#00a8ff);-webkit-background-clip:text;color:transparent}.lede{color:#aaa;font-size:1.05rem;max-width:760px}pre{background:#181818;padding:14px 16px;border:1px solid #222;border-radius:8px;overflow:auto;font-size:.85rem}code{font-family:ui-monospace,Monaco,Consolas,monospace;color:#00a8ff}.breadcrumb{font-size:.7rem;letter-spacing:.12em;text-transform:uppercase;color:#888;margin:0 0 12px}.nav-inline{display:flex;gap:20px;align-items:center;font-size:.8rem;padding:10px 20px;background:#111;border-bottom:1px solid #222}nav a{color:#aaa}nav a[aria-current="page"]{color:#00d4aa;font-weight:600}</style></head><body><nav class="nav-inline"><a href="/" >Home</a><a href="/docs/index.html" aria-current="page">Docs</a><a href="/dashboard">Dashboard</a><a href="/about.html">About</a></nav><header class="page-hero"><div class="breadcrumb">Docs / ${escapeHtml(title)}</div><h1>${escapeHtml(title)}</h1><p class="lede">${escapeHtml(description)}</p></header><main id="content">${body}</main><footer style="padding:40px 24px;text-align:center;font-size:.75rem;color:#666;border-top:1px solid #222">TiltCheck Docs • Non-custodial • Signals only.</footer></body></html>`;
-}
-
-function run(){
-  if(!fs.existsSync(sourceRoot)){
-    console.error('Source directory missing:', sourceRoot); process.exit(1);
+function sortKey(file) {
+  const base = path.basename(file, '.md');
+  const match = base.match(/^(\d+)([a-z]?)/i);
+  if (match) {
+    return `${match[1].padStart(4, '0')}${match[2] || ' '}-${base}`;
   }
+  return `9999-${base.toLowerCase()}`;
+}
+
+function buildPage({ title, description, body }) {
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>${escapeHtml(title)} - TiltCheck</title><meta name="description" content="${escapeHtml(description)}"/><meta name="viewport" content="width=device-width, initial-scale=1"/><link rel="stylesheet" href="/styles/base.css"/><style>body{background:#0a0a0a;color:#e0e0e0;font-family:Inter,system-ui,sans-serif;margin:0;padding:0}main{max-width:900px;margin:0 auto;padding:40px 18px;line-height:1.7}a{color:#00d4aa;text-decoration:none}a:hover{text-decoration:underline}.page-hero{padding:54px 24px 32px;background:linear-gradient(135deg,#121212,#181818);border-bottom:1px solid #222}.page-hero h1{margin:0 0 10px;font-size:2.4rem;background:linear-gradient(135deg,#00d4aa,#00a8ff);-webkit-background-clip:text;color:transparent}.lede{color:#aaa;font-size:1.05rem;max-width:760px}pre{background:#181818;padding:14px 16px;border:1px solid #222;border-radius:8px;overflow:auto;font-size:.85rem}code{font-family:ui-monospace,Monaco,Consolas,monospace;color:#00a8ff}.breadcrumb{font-size:.7rem;letter-spacing:.12em;text-transform:uppercase;color:#888;margin:0 0 12px}.nav-inline{display:flex;gap:20px;align-items:center;font-size:.8rem;padding:10px 20px;background:#111;border-bottom:1px solid #222}nav a{color:#aaa}nav a[aria-current="page"]{color:#00d4aa;font-weight:600}</style></head><body><nav class="nav-inline"><a href="https://tiltcheck.me">tiltcheck.me</a><a href="/docs/index.html" aria-current="page">Specs</a><a href="https://tiltcheck.me/docs">Live Docs</a></nav><header class="page-hero"><div class="breadcrumb">Specs / ${escapeHtml(title)}</div><h1>${escapeHtml(title)}</h1><p class="lede">${escapeHtml(description)}</p></header><main id="content">${body}</main><footer style="padding:40px 24px;text-align:center;font-size:.75rem;color:#666;border-top:1px solid #222">${FOOTER} // ${COPYRIGHT}</footer></body></html>`;
+}
+
+function buildIndexPage(entries) {
+  const listHtml = entries
+    .map((e) => `<li><a href="${e.slug}.html"><strong>${escapeHtml(e.title)}</strong></a><br/><span style="color:#888;font-size:.75rem">${escapeHtml(e.description)}</span></li>`)
+    .join('\n');
+
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>TiltCheck Specs - GitHub Pages</title><meta name="description" content="TiltCheck ecosystem specifications and architecture docs"/><meta name="viewport" content="width=device-width, initial-scale=1"/><link rel="stylesheet" href="/styles/base.css"/><style>body{background:#0a0a0a;color:#e0e0e0;font-family:Inter,system-ui,sans-serif;margin:0}main{max-width:900px;margin:0 auto;padding:44px 20px;line-height:1.6}a{color:#00d4aa;text-decoration:none}a:hover{text-decoration:underline}h1{font-size:2.4rem;margin:0 0 22px;background:linear-gradient(135deg,#00d4aa,#00a8ff);-webkit-background-clip:text;color:transparent}ul{list-style:disc;padding-left:22px}nav{display:flex;gap:20px;align-items:center;font-size:.8rem;padding:10px 20px;background:#111;border-bottom:1px solid #222}nav a{color:#aaa}nav a[aria-current='page']{color:#00d4aa;font-weight:600}</style></head><body><nav><a href="https://tiltcheck.me">tiltcheck.me</a><a href="/docs/index.html" aria-current="page">Specs</a><a href="https://tiltcheck.me/docs">Live Docs</a></nav><main><h1>TiltCheck Specs</h1><p style="color:#aaa;font-size:1.05rem;max-width:760px">Ecosystem specifications mirrored from <code>docs/tiltcheck/</code>. Production docs live at <a href="https://tiltcheck.me/docs">tiltcheck.me/docs</a>.</p><ul>${listHtml}</ul></main><footer style="padding:40px 24px;text-align:center;font-size:.75rem;color:#666;border-top:1px solid #222">${FOOTER} // ${COPYRIGHT}</footer></body></html>`;
+}
+
+function buildRootRedirect() {
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><meta http-equiv="refresh" content="0;url=/docs/index.html"/><title>TiltCheck Specs</title><meta name="viewport" content="width=device-width, initial-scale=1"/></head><body style="background:#0a0a0a;color:#e0e0e0;font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh"><p>Redirecting to <a href="/docs/index.html" style="color:#00d4aa">TiltCheck specs</a>...</p></body></html>`;
+}
+
+function run() {
+  if (!fs.existsSync(sourceRoot)) {
+    console.error('Source directory missing:', sourceRoot);
+    process.exit(1);
+  }
+
+  const siteRoot = path.dirname(outRoot);
   fs.mkdirSync(outRoot, { recursive: true });
-  const files = fs.readdirSync(sourceRoot).filter(f=>f.endsWith('.md'));
+  fs.mkdirSync(siteRoot, { recursive: true });
+
+  const files = fs
+    .readdirSync(sourceRoot)
+    .filter((f) => f.endsWith('.md') && f !== 'index.md')
+    .sort((a, b) => sortKey(a).localeCompare(sortKey(b)));
+
   const indexEntries = [];
-  for(const file of files){
-    const full = path.join(sourceRoot,file);
-    const raw = fs.readFileSync(full,'utf-8');
+
+  for (const file of files) {
+    const full = path.join(sourceRoot, file);
+    const raw = fs.readFileSync(full, 'utf-8');
     const slug = slugify(file);
     const meta = extractMeta(raw);
     const body = renderMarkdown(raw);
-    const html = buildPage({ slug, title: meta.title, description: meta.description, body });
+    const html = buildPage({ title: meta.title, description: meta.description, body });
     fs.writeFileSync(path.join(outRoot, `${slug}.html`), html);
     indexEntries.push({ slug, title: meta.title, description: meta.description });
   }
-  // Build index
-  const listHtml = indexEntries.map(e=>`<li><a href="${e.slug}.html"><strong>${escapeHtml(e.title)}</strong></a><br/><span style=\"color:#888;font-size:.75rem\">${escapeHtml(e.description)}</span></li>`).join('\n');
-  const indexPage = `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>Docs Index - TiltCheck</title><meta name="description" content="TiltCheck Documentation Index"/><link rel="stylesheet" href="/styles/base.css"/><style>body{background:#0a0a0a;color:#e0e0e0;font-family:Inter,system-ui,sans-serif;margin:0}main{max-width:900px;margin:0 auto;padding:44px 20px;line-height:1.6}a{color:#00d4aa;text-decoration:none}a:hover{text-decoration:underline}h1{font-size:2.4rem;margin:0 0 22px;background:linear-gradient(135deg,#00d4aa,#00a8ff);-webkit-background-clip:text;color:transparent}ul{list-style:disc;padding-left:22px}nav{display:flex;gap:20px;align-items:center;font-size:.8rem;padding:10px 20px;background:#111;border-bottom:1px solid #222}nav a{color:#aaa}nav a[aria-current='page']{color:#00d4aa;font-weight:600}</style></head><body><nav><a href="/">Home</a><a href="/docs/index.html" aria-current="page">Docs</a><a href="/dashboard">Dashboard</a><a href="/about.html">About</a></nav><main><h1>TiltCheck Docs</h1><p style="color:#aaa;font-size:1.05rem;max-width:760px">Developer and ecosystem documentation. Non-custodial trust & transparency modules, tool specs, prompts, architecture, and standards.</p><ul>${listHtml}</ul></main><footer style="padding:40px 24px;text-align:center;font-size:.75rem;color:#666;border-top:1px solid #222">TiltCheck Docs • Signals only • © 2024–2025</footer></body></html>`;
-  fs.writeFileSync(path.join(outRoot,'index.html'), indexPage);
+
+  fs.writeFileSync(path.join(outRoot, 'index.html'), buildIndexPage(indexEntries));
+  fs.writeFileSync(path.join(siteRoot, 'index.html'), buildRootRedirect());
+  fs.writeFileSync(path.join(siteRoot, '.nojekyll'), '');
+
   console.log(`Converted ${files.length} markdown files to HTML in ${outRoot}`);
 }
 

--- a/scripts/pages-assets/styles/base.css
+++ b/scripts/pages-assets/styles/base.css
@@ -1,0 +1,36 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17 */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+}
+
+th,
+td {
+  border: 1px solid #222;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+th {
+  background: #111;
+}

--- a/scripts/sync-docs.sh
+++ b/scripts/sync-docs.sh
@@ -1,21 +1,12 @@
 #!/usr/bin/env bash
-# ================================================================
-# © 2024–2025 TiltCheck Ecosystem. All Rights Reserved.
-# Created by jmenichole (https://github.com/jmenichole)
-# 
-# This file is part of the TiltCheck project.
-# For licensing information, see LICENSE file in the project root.
-# ================================================================
-
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17
 set -euo pipefail
-
-# Sync markdown docs into landing public docs-md folder for Pages deploy preview.
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SRC_DIR="$ROOT_DIR/docs/tiltcheck"
-DEST_DIR="$ROOT_DIR/services/landing/public/docs-md"
+DEST_DIR="$ROOT_DIR/out/docs-md"
 
 mkdir -p "$DEST_DIR"
 rsync -av --delete "$SRC_DIR/" "$DEST_DIR/"
 
-echo "Docs synced to services/landing/public/docs-md"
+echo "Docs synced to out/docs-md"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

GitHub Pages deployment was removed in February 2026 (`pages.yml` deleted). The `gh-pages` branch still serves stale static HTML from the pre-Next.js era and is missing newer specs (RGaaS pivot, AutoVault, trust policy, provably-fair limitations, casino trust score page, LockVault, components audits, Instagram timing log, etc.).

Production docs already live at `tiltcheck.me/docs` via Railway, but there is no automated public mirror of `docs/tiltcheck/` on GitHub Pages.

## Approach

- Restore `.github/workflows/pages.yml` as a **specs-only** deploy (not the old static landing site)
- Convert all `docs/tiltcheck/*.md` to HTML via `scripts/convert-markdown.js`
- Publish to `gh-pages` with:
  - `/` redirect → `/docs/index.html`
  - `/docs/*.html` converted specs
  - `/docs-md/*.md` raw markdown mirror
- **No `CNAME`** on deploy — avoids conflicting with Railway-hosted `tiltcheck.me`

## Scope

- Updated `docs/tiltcheck/index.md` navigation hub with all current spec files
- Modernized `convert-markdown.js` (frontmatter stripping, sorted index, 2026 footer)
- Added `pnpm docs:pages` local build script
- Refreshed `docs/GITHUB-PAGES-TROUBLESHOOTING.md` for the new model

## Risks

| Risk | Mitigation |
|------|------------|
| `force_orphan: true` replaces entire `gh-pages` branch | Intentional — removes stale static site and `tiltcheck.me` CNAME conflict |
| Markdown converter is lightweight (no tables/GFM) | Acceptable for spec mirror; production `/docs` uses full ReactMarkdown + GFM |
| Pages URL changes from custom domain to `github.io` | Documented; production remains `tiltcheck.me/docs` |

## Validation

- [x] `pnpm docs:pages` — 35 spec files converted to HTML
- [x] New pages present: `autovault`, `rgaas-pivot`, `trust-policy`, `provably-fair-limitations`, `casino-trust-score-page`, `lockvault`, `components-audits`, `instagram-stake-us-code-timing`
- [ ] Merge → confirm `Deploy GitHub Pages Specs` workflow succeeds
- [ ] Verify `https://tiltcheck-me.github.io/tiltcheck-monorepo/docs/index.html` after deploy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7216-c040-7f6e-999c-175909090c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7216-c040-7f6e-999c-175909090c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

