### PR TITLE
feat(infra): full-stack Railway exit — VPS compose + tunnel cutover

### DIFF
--- a/.github/workflows/configure-tunnel.yml
+++ b/.github/workflows/configure-tunnel.yml
@@ -1,6 +1,6 @@
-# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17
 # Optional one-shot workflow: if a Cloudflare Tunnel exists, set public hostname
-# ingress rules pointing to Railway internal services.
+# ingress rules pointing to Railway internal services OR Docker Compose service names.
 # Trigger manually from Actions tab only when tunnel-based routing is the chosen
 # delivery path. Direct custom-domain routing does not require this workflow.
 
@@ -13,6 +13,14 @@ on:
         description: "Cloudflare Tunnel UUID (find it at: zero-trust dash -> Networks -> Tunnels). Leave empty to recover from existing DNS records or auto-discover as a last resort."
         required: false
         type: string
+      ingress_target:
+        description: "Upstream target for tunnel ingress rules"
+        required: true
+        type: choice
+        default: railway
+        options:
+          - railway
+          - compose
 
 permissions:
   contents: read
@@ -23,6 +31,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Find tunnel ID
         id: tunnel
         env:
@@ -107,26 +118,15 @@ jobs:
           CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           TUNNEL_ID: ${{ steps.tunnel.outputs.id }}
+          INGRESS_TARGET: ${{ github.event.inputs.ingress_target }}
         run: |
-          # Railway internal hostnames — cloudflared and all services share the same project network
-          CONFIG=$(cat <<'EOF'
-          {
-            "config": {
-              "ingress": [
-                { "hostname": "api.tiltcheck.me",      "service": "http://api.railway.internal:3000" },
-                { "hostname": "hub.tiltcheck.me",      "service": "http://user-dashboard.railway.internal:6001" },
-                { "hostname": "dashboard.tiltcheck.me","service": "http://user-dashboard.railway.internal:6001" },
-                { "hostname": "activity.tiltcheck.me", "service": "http://activity.railway.internal:3000" },
-                { "hostname": "arena.tiltcheck.me",    "service": "http://game-arena.railway.internal:3000" },
-                { "hostname": "admin.tiltcheck.me",    "service": "http://control-room.railway.internal:3000" },
-                { "hostname": "tiltcheck.me",          "service": "http://web.railway.internal:3000" },
-                { "hostname": "www.tiltcheck.me",      "service": "http://web.railway.internal:3000" },
-                { "service": "http_status:404" }
-              ]
-            }
-          }
-          EOF
-          )
+          CONFIG_FILE="infra/compose/tunnel-ingress.${INGRESS_TARGET}.json"
+          if [ ! -f "$CONFIG_FILE" ]; then
+            echo "Missing ingress config: $CONFIG_FILE"
+            exit 1
+          fi
+          echo "Applying ingress from $CONFIG_FILE"
+          CONFIG=$(cat "$CONFIG_FILE")
 
           RESULT=$(curl -sf -X PUT \
             "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT}/cfd_tunnel/${TUNNEL_ID}/configurations" \
@@ -141,7 +141,7 @@ jobs:
             exit 1
           fi
 
-          echo "Tunnel routes configured successfully."
+          echo "Tunnel routes configured for target: ${INGRESS_TARGET}"
 
       - name: Verify DNS records exist
         env:

--- a/.github/workflows/deploy-stack.yml
+++ b/.github/workflows/deploy-stack.yml
@@ -1,0 +1,55 @@
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17
+# Deploy GHCR images to VPS Docker Compose stack (Railway exit path).
+# Requires GitHub secrets: VPS_HOST, VPS_USER, VPS_SSH_KEY
+# Optional: VPS_DEPLOY_PATH (default /opt/tiltcheck)
+
+name: Deploy Stack to VPS
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "GHCR image tag to deploy (e.g. latest or sha-<commit>)"
+        required: true
+        default: latest
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-vps:
+    name: Pull and restart on VPS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_DEPLOY_PATH: ${{ secrets.VPS_DEPLOY_PATH }}
+          IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+        run: |
+          if [ -z "$VPS_HOST" ] || [ -z "$VPS_USER" ] || [ -z "$VPS_SSH_KEY" ]; then
+            echo "Missing VPS_HOST, VPS_USER, or VPS_SSH_KEY secrets."
+            exit 1
+          fi
+
+          DEPLOY_PATH="${VPS_DEPLOY_PATH:-/opt/tiltcheck}"
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+
+          mkdir -p ~/.ssh
+          echo "$VPS_SSH_KEY" > ~/.ssh/vps_key
+          chmod 600 ~/.ssh/vps_key
+
+          ssh -o StrictHostKeyChecking=no -i ~/.ssh/vps_key "${VPS_USER}@${VPS_HOST}" bash -s <<EOF
+          set -euo pipefail
+          cd "${DEPLOY_PATH}"
+          git fetch origin main
+          git checkout main
+          git pull origin main
+          export GHCR_OWNER="${OWNER}"
+          export IMAGE_TAG="${IMAGE_TAG}"
+          bash scripts/ops/deploy-ghcr-stack.sh
+          VERIFY_PUBLIC=1 bash scripts/ops/verify-stack-health.sh || true
+          EOF

--- a/apps/activity/Dockerfile
+++ b/apps/activity/Dockerfile
@@ -1,4 +1,4 @@
-# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-20
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17
 # TiltCheck Activity - Production HUD Host
 # Multi-stage build: Node.js builds the Vite app, nginx serves the static output.
 
@@ -10,72 +10,26 @@ ENV CI=true
 RUN corepack enable && corepack prepare pnpm@10.29.1 --activate
 WORKDIR /app
 
-# Copy workspace manifests and lockfile first for better layer caching
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/activity/package.json ./apps/activity/package.json
 RUN pnpm fetch
-# Copy full source so pnpm workspace can resolve all package manifests
 COPY . .
 RUN pnpm install --frozen-lockfile --filter @tiltcheck/activity...
 
-# Build the Vite app — outputs to apps/activity/dist
 RUN pnpm --filter @tiltcheck/activity build
 
 # ── Stage 2: Serve ────────────────────────────────────────────────────────────
 FROM nginx:alpine
 
-# Copy the compiled static assets from the build stage
-COPY --from=build /app/apps/activity/dist /usr/share/nginx/html
+RUN apk add --no-cache gettext
 
-# Custom nginx config: SPA routing + Discord Activity required headers
-RUN printf 'server {\n\
-    listen 8080;\n\
-    server_name localhost;\n\
-    root /usr/share/nginx/html;\n\
-    index index.html;\n\
-\n\
-    # Discord SDK proxies API calls through /.proxy — must forward to discord.com\n\
-    location /.proxy/ {\n\
-        resolver 1.1.1.1 valid=30s;\n\
-        proxy_pass https://discord.com/;\n\
-        proxy_set_header Host discord.com;\n\
-        proxy_set_header X-Real-IP $remote_addr;\n\
-        proxy_ssl_server_name on;\n\
-    }\n\
-\n\
-    location /api/ {\n\
-        proxy_pass http://api.railway.internal:3000/;\n\
-        proxy_http_version 1.1;\n\
-        proxy_set_header Host api.railway.internal;\n\
-        proxy_set_header X-Real-IP $remote_addr;\n\
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n\
-        proxy_set_header X-Forwarded-Proto $scheme;\n\
-    }\n\
-\n\
-    location /socket.io/ {\n\
-        proxy_pass http://game-arena.railway.internal:3000/socket.io/;\n\
-        proxy_http_version 1.1;\n\
-        proxy_set_header Upgrade $http_upgrade;\n\
-        proxy_set_header Connection \"upgrade\";\n\
-        proxy_set_header Host game-arena.railway.internal;\n\
-        proxy_set_header X-Real-IP $remote_addr;\n\
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n\
-        proxy_set_header X-Forwarded-Proto $scheme;\n\
-    }\n\
-\n\
-    location / {\n\
-        try_files $uri $uri/ /index.html;\n\
-        # Allow Discord to iframe this page\n\
-        add_header Content-Security-Policy "frame-ancestors https://discord.com https://*.discord.com https://*.discordsays.com https://*.discordapp.com" always;\n\
-        add_header Access-Control-Allow-Origin "*" always;\n\
-    }\n\
-\n\
-    location /assets/ {\n\
-        try_files $uri =404;\n\
-        add_header Cache-Control "public, max-age=31536000, immutable";\n\
-    }\n\
-}' > /etc/nginx/conf.d/default.conf
+COPY --from=build /app/apps/activity/dist /usr/share/nginx/html
+COPY apps/activity/nginx.default.conf.template /etc/nginx/templates/default.conf.template
+COPY apps/activity/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV API_UPSTREAM=http://api:3001
+ENV ARENA_UPSTREAM=http://game-arena:8080
 
 EXPOSE 8080
-
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/apps/activity/docker-entrypoint.sh
+++ b/apps/activity/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17
+set -eu
+
+export API_UPSTREAM="${API_UPSTREAM:-http://api:3001}"
+export ARENA_UPSTREAM="${ARENA_UPSTREAM:-http://game-arena:8080}"
+
+envsubst '${API_UPSTREAM} ${ARENA_UPSTREAM}' \
+  < /etc/nginx/templates/default.conf.template \
+  > /etc/nginx/conf.d/default.conf
+
+exec nginx -g 'daemon off;'

--- a/apps/activity/nginx.default.conf.template
+++ b/apps/activity/nginx.default.conf.template
@@ -1,0 +1,45 @@
+server {
+    listen 8080;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /.proxy/ {
+        resolver 1.1.1.1 valid=30s;
+        proxy_pass https://discord.com/;
+        proxy_set_header Host discord.com;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_ssl_server_name on;
+    }
+
+    location /api/ {
+        proxy_pass ${API_UPSTREAM}/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /socket.io/ {
+        proxy_pass ${ARENA_UPSTREAM}/socket.io/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+        add_header Content-Security-Policy "frame-ancestors https://discord.com https://*.discord.com https://*.discordsays.com https://*.discordapp.com" always;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
+    location /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+}

--- a/apps/cloudflared/Dockerfile
+++ b/apps/cloudflared/Dockerfile
@@ -1,6 +1,7 @@
 # © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-08
-# Cloudflare Tunnel daemon — routes public *.tiltcheck.me traffic to Railway internal services
-# Token is injected via TUNNEL_TOKEN environment variable in Railway — never hardcode it.
+# Cloudflare Tunnel daemon — routes public *.tiltcheck.me traffic to backend services.
+# Token is injected via TUNNEL_TOKEN environment variable — never hardcode it.
+# Backend may be Railway (*.railway.internal) or Docker Compose (service names).
 
 FROM cloudflare/cloudflared:latest
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,4 +1,4 @@
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-06 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17 -->
 
 # TiltCheck Deployment Inventory
 
@@ -6,10 +6,11 @@ This file is the canonical deploy map for the current repo. If a workflow, image
 
 ## Current Reality
 
-- Containerized services ship through `.github/workflows/deploy-railway.yml`.
+- Containerized services ship through `.github/workflows/deploy-railway.yml` (legacy) or `.github/workflows/deploy-stack.yml` (VPS compose target).
 - Images are built in GitHub Actions and pushed to GHCR as `ghcr.io/tiltcheck-me/tiltcheck-<service>`.
-- Railway pulls the SHA-tagged image for each wired service.
-- Public hostnames may be routed either through direct custom-domain mappings or, when explicitly enabled, through `.github/workflows/configure-tunnel.yml`.
+- **Production today:** Railway pulls GHCR images; Cloudflare Tunnel routes public hostnames.
+- **Migration target:** VPS running `infra/compose/docker-compose.ghcr.yml` — see `docs/migration/exit-railway-plan.md`.
+- Public hostnames may be routed either through direct custom-domain mappings or, when explicitly enabled, through `.github/workflows/configure-tunnel.yml` (`ingress_target`: `railway` | `compose`).
 - `.github/workflows/deploy-web.yml` is a manual Vercel fallback, not the primary production path.
 - There is no active in-repo GCP deploy workflow.
 
@@ -17,7 +18,8 @@ This file is the canonical deploy map for the current repo. If a workflow, image
 
 | Workflow | Required secrets | Notes |
 | :--- | :--- | :--- |
-| `.github/workflows/deploy-railway.yml` | `RAILWAY_TOKEN` | `PACKAGES_TOKEN` is optional but needed if GHCR package visibility updates should succeed without warnings. |
+| `.github/workflows/deploy-railway.yml` | `RAILWAY_TOKEN` | Legacy production redeploy to Railway. Disable after VPS cutover. |
+| `.github/workflows/deploy-stack.yml` | `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY`, optional `VPS_DEPLOY_PATH` | Manual VPS compose deploy (Railway exit). |
 | `.github/workflows/deploy-hub.yml` | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` | Deploys `apps/hub` with Wrangler to Cloudflare Workers. D1 and KV bindings remain configured in `apps/hub/wrangler.toml`. |
 | `.github/workflows/configure-tunnel.yml` | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_ZONE_ID` | Optional: reconciles tunnel ingress rules and DNS when Cloudflare Tunnel is the chosen public ingress path. |
 | `.github/workflows/deploy-web.yml` | `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `VERCEL_TOKEN` | Manual fallback only. |
@@ -52,15 +54,27 @@ Packages such as **`@tiltcheck/event-router`** point `exports` at **`dist/*.js`*
 
 ## Public Routing
 
-Public hostnames do not automatically come from the deploy workflow itself. This repo includes an optional Cloudflare Tunnel reconciler at `.github/workflows/configure-tunnel.yml`, but teams may also map Railway custom domains directly. The tunnel workflow mappings currently described in-repo are:
+Public hostnames do not automatically come from the deploy workflow itself. This repo includes an optional Cloudflare Tunnel reconciler at `.github/workflows/configure-tunnel.yml` with `ingress_target`:
 
-- `api.tiltcheck.me` -> `api.railway.internal:3000`
-- `tiltcheck.me` and `www.tiltcheck.me` -> `web.railway.internal:3000`
-- `dashboard.tiltcheck.me` and `hub.tiltcheck.me` -> `user-dashboard.railway.internal:6001`
-- activity.tiltcheck.me -> activity.railway.internal:8080 (matches the container listen port in the Dockerfile)
-- `arena.tiltcheck.me` -> `game-arena.railway.internal:3000` (historic / alternate DNS; Socket.IO and web may also use **`game-arena.tiltcheck.me`** per your edge mapping)
-- Degens second Activity (example): **`degens.activity.tiltcheck.me`** -> `degens-activity.railway.internal:<port>` once the Railway service and custom domain exist
-- `admin.tiltcheck.me` -> `control-room.railway.internal:3000`
+| Target | Config file | Upstream style |
+|--------|-------------|----------------|
+| `railway` (legacy) | `infra/compose/tunnel-ingress.railway.json` | `*.railway.internal` |
+| `compose` (VPS exit) | `infra/compose/tunnel-ingress.compose.json` | Docker service names (`api:3001`, `web:3000`, …) |
+
+Teams may also map custom domains directly in Railway or on the VPS host without the tunnel workflow.
+
+### Compose ingress (VPS target)
+
+- `api.tiltcheck.me` -> `api:3001`
+- `tiltcheck.me` and `www.tiltcheck.me` -> `web:3000`
+- `dashboard.tiltcheck.me` and `hub.tiltcheck.me` -> `user-dashboard:6001`
+- `activity.tiltcheck.me` -> `activity:8080`
+- `arena.tiltcheck.me` / `game-arena.tiltcheck.me` -> `game-arena:8080`
+- `admin.tiltcheck.me` -> `control-room:3001`
+
+### Railway ingress (legacy)
+
+- Same hostnames via `*.railway.internal` — see `infra/compose/tunnel-ingress.railway.json`
 
 ## Discord Activity (`apps/activity`) — production checklist
 
@@ -151,9 +165,9 @@ If you copy the `apps/activity` Dockerfile pattern, proxy **`/socket.io/`** to `
 
 ## Rollback Notes
 
-- Container services: rollback from the Railway dashboard to the prior image or release.
+- Container services: rollback from the Railway dashboard to the prior image, **or** on VPS `export IMAGE_TAG=<previous-sha> && bash scripts/ops/deploy-ghcr-stack.sh`
 - `hub` Worker: rollback from the Cloudflare dashboard or redeploy the previous Worker bundle with Wrangler.
-- Tunnel drift: rerun `.github/workflows/configure-tunnel.yml` only if tunnel-based ingress is intentionally enabled; otherwise verify direct custom-domain mapping in Railway/Cloudflare.
+- Tunnel drift: rerun `.github/workflows/configure-tunnel.yml` with the correct `ingress_target` (`railway` or `compose`).
 - Browser assets: republish the previous extension or SPA artifact manually.
 
 ## Manual Publish Notes

--- a/docs/infra/railway-setup.md
+++ b/docs/infra/railway-setup.md
@@ -2,6 +2,8 @@
 
 # Railway Setup Guide
 
+> **Migration:** Full-stack exit plan lives at [`docs/migration/exit-railway-plan.md`](../migration/exit-railway-plan.md). Keep this guide until Railway is decommissioned.
+
 One-time steps required in Railway and GitHub before the `deploy-railway.yml` workflow can run.
 
 ---

--- a/docs/migration/exit-railway-plan.md
+++ b/docs/migration/exit-railway-plan.md
@@ -1,0 +1,143 @@
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17 -->
+
+# Exit Railway — Full Stack Migration Plan
+
+Move every containerized TiltCheck service off Railway while keeping **Cloudflare DNS + Tunnel** as the public edge. Domains stay on `tiltcheck.me`; only the compute backend changes.
+
+## Target architecture
+
+```
+Internet
+   │
+   ▼
+Cloudflare DNS (proxied CNAME → tunnel)
+   │
+   ▼
+cloudflared (on VPS Docker network)
+   │
+   ├── api:3001              → api.tiltcheck.me
+   ├── web:3000              → tiltcheck.me / www
+   ├── user-dashboard:6001   → dashboard.tiltcheck.me / hub
+   ├── activity:8080         → activity.tiltcheck.me
+   ├── game-arena:8080       → arena.tiltcheck.me
+   ├── control-room:3001     → admin.tiltcheck.me
+   └── (bots: no public hostname — outbound only)
+
+GHCR images (unchanged CI build) ← GitHub Actions
+VPS runs `infra/compose/docker-compose.ghcr.yml`
+```
+
+**Stays off this stack**
+
+| Surface | Host | Reason |
+|---------|------|--------|
+| Hub Worker | `hub.tiltcheck.me` (optional) | Already Cloudflare Workers via `deploy-hub.yml` |
+| GitHub Pages | `github.io/.../docs` | Static spec mirror only |
+| Chrome extension | Browser asset | Manual / store publish |
+
+## Why VPS + Docker Compose (not another PaaS)
+
+| Requirement | VPS + Compose | Fly.io (11 apps) | GCP Cloud Run |
+|-------------|---------------|------------------|---------------|
+| Reuse GHCR images | Yes | Yes | Yes |
+| Discord bots 24/7 | Yes | Yes (min instances) | Awkward / costly |
+| Socket.IO (`game-arena`) | Same Docker network | Needs config | Extra LB work |
+| Single `.env` for secrets | Yes | Per-app secrets | Secret Manager sprawl |
+| Repo already has compose | `docker-compose.prod.yml` | New fly.toml × 11 | GCP scripts pruned |
+
+Fly.io remains a valid alternative if you prefer managed ops over a single VPS bill. This plan optimizes for **one box, one compose file, tunnel ingress unchanged**.
+
+## Service inventory (11 containers)
+
+| Service | Image | Container port | Public host |
+|---------|-------|----------------|-------------|
+| `api` | `tiltcheck-api` | 3001 | `api.tiltcheck.me` |
+| `web` | `tiltcheck-web` | 3000 | `tiltcheck.me`, `www` |
+| `discord-bot` | `tiltcheck-discord-bot` | 8080 | none |
+| `justthetip-bot` | `tiltcheck-justthetip-bot` | 8080 | none |
+| `dad-bot` | `tiltcheck-dad-bot` | 8080 | none |
+| `trust-rollup` | `tiltcheck-trust-rollup` | 8082 | none |
+| `control-room` | `tiltcheck-control-room` | 3001 | `admin.tiltcheck.me` |
+| `game-arena` | `tiltcheck-game-arena` | 8080 | `arena.tiltcheck.me` |
+| `user-dashboard` | `tiltcheck-user-dashboard` | 6001 | `dashboard.tiltcheck.me` |
+| `activity` | `tiltcheck-activity` | 8080 | `activity.tiltcheck.me` |
+| `cloudflared` | `tiltcheck-cloudflared` | n/a | tunnel daemon |
+
+## Migration phases
+
+### Phase 0 — Prep (no DNS change)
+
+- [ ] Provision VPS (4 vCPU / 8 GB RAM minimum for full stack; Ubuntu 22.04+)
+- [ ] Install Docker + Docker Compose plugin
+- [ ] Copy production `.env` to VPS (`/opt/tiltcheck/.env`) — never commit
+- [ ] Set GitHub secrets: `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY`, `VPS_DEPLOY_PATH` (optional, default `/opt/tiltcheck`)
+- [ ] Confirm `TUNNEL_TOKEN` works on VPS (same token as Railway cloudflared or rotate)
+
+### Phase 1 — Staging on VPS
+
+1. `pnpm docs:pages` not required here — focus on containers.
+2. On VPS:
+   ```bash
+   git clone https://github.com/TiltCheck-ME/tiltcheck-monorepo.git /opt/tiltcheck
+   cd /opt/tiltcheck
+   cp /path/to/production.env .env
+   export IMAGE_TAG=latest GHCR_OWNER=tiltcheck-me
+   bash scripts/ops/deploy-ghcr-stack.sh
+   bash scripts/ops/verify-stack-health.sh
+   ```
+3. Run tunnel workflow with **`ingress_target: compose`** (manual `workflow_dispatch`) against a **staging tunnel** or temporary hostnames — do not cut prod DNS yet.
+
+### Phase 2 — Production cutover
+
+1. Stop Railway `cloudflared` service (avoid dual tunnel fights).
+2. Start `cloudflared` on VPS compose stack.
+3. Re-run `Configure Cloudflare Tunnel Routes` with `ingress_target: compose`.
+4. Verify:
+   - `curl -sf https://api.tiltcheck.me/health`
+   - `https://tiltcheck.me/` loads
+   - `https://dashboard.tiltcheck.me/health`
+   - `https://activity.tiltcheck.me/` (browser — CF may challenge bots)
+   - Discord bots online in guild
+5. Disable Railway deploy job in `.github/workflows/deploy-railway.yml` (or delete workflow after bake-in).
+6. Enable `.github/workflows/deploy-stack.yml` VPS SSH redeploy on `main`.
+
+### Phase 3 — Decommission Railway
+
+- [ ] Export env vars from Railway dashboard (backup)
+- [ ] Scale all Railway services to 0 / delete project
+- [ ] Remove `RAILWAY_TOKEN` from GitHub secrets
+- [ ] Update `docs/DEPLOY.md` canonical path to VPS compose
+
+## Rollback
+
+1. Re-enable Railway services and `cloudflared` on Railway.
+2. Run tunnel workflow with `ingress_target: railway`.
+3. Redeploy last known-good GHCR SHA on Railway via `deploy-railway.yml` manual dispatch.
+
+Rollback window: keep Railway project alive **7 days** after cutover before deletion.
+
+## Risk notes
+
+| Risk | Mitigation |
+|------|------------|
+| `activity` nginx upstreams were Railway-hardcoded | Fixed: env `API_UPSTREAM` / `ARENA_UPSTREAM` (defaults to Docker service names) |
+| Tunnel port drift (Railway used `:3000` for some services) | Compose ingress uses **actual container ports** from Dockerfiles |
+| Single VPS = single point of failure | Accept for solo phase; add standby VPS + DNS failover later |
+| Secret leakage on VPS | `.env` permissions `600`, no secrets in compose file |
+| Downtime during cutover | Run VPS stack healthy first; swap tunnel in one workflow run |
+
+## Validation checklist (post-cutover)
+
+```bash
+bash scripts/ops/verify-stack-health.sh
+curl -sf https://api.tiltcheck.me/health
+curl -sfI https://tiltcheck.me/ | head -1
+```
+
+Discord manual checks:
+
+- `/vault status` (discord-bot)
+- JustTheTip tip flow in test guild
+- Launch Embedded Activity at `activity.tiltcheck.me`
+
+Made for Degens. By Degens.

--- a/infra/compose/README.md
+++ b/infra/compose/README.md
@@ -1,0 +1,21 @@
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17 -->
+
+# Compose production stack
+
+Files for the **Railway exit** path (VPS + GHCR + Cloudflare Tunnel).
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.ghcr.yml` | Pull all `ghcr.io/tiltcheck-me/tiltcheck-*` images and run the full stack |
+| `tunnel-ingress.compose.json` | Tunnel ingress when `cloudflared` runs on the same Docker network |
+| `tunnel-ingress.railway.json` | Legacy Railway `*.railway.internal` ingress (rollback) |
+
+Deploy:
+
+```bash
+export GHCR_OWNER=tiltcheck-me IMAGE_TAG=latest
+bash scripts/ops/deploy-ghcr-stack.sh
+VERIFY_PUBLIC=1 bash scripts/ops/verify-stack-health.sh
+```
+
+Full cutover checklist: `docs/migration/exit-railway-plan.md`

--- a/infra/compose/docker-compose.ghcr.yml
+++ b/infra/compose/docker-compose.ghcr.yml
@@ -1,0 +1,141 @@
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17
+# Production stack — pull pre-built images from GHCR (built by deploy-railway.yml / deploy-stack.yml).
+#
+# Usage on VPS:
+#   export GHCR_OWNER=tiltcheck-me IMAGE_TAG=latest   # or sha-<git-sha>
+#   docker compose -f infra/compose/docker-compose.ghcr.yml pull
+#   docker compose -f infra/compose/docker-compose.ghcr.yml up -d
+#
+# Requires .env at repo root (or path via --env-file).
+
+name: tiltcheck-production
+
+x-common: &common
+  env_file:
+    - ../../.env
+  environment:
+    NODE_ENV: production
+    SKIP_ENV_VALIDATION: "1"
+  restart: unless-stopped
+  networks:
+    - tiltcheck-network
+
+services:
+  api:
+    <<: *common
+    image: ghcr.io/${GHCR_OWNER:-tiltcheck-me}/tiltcheck-api:${IMAGE_TAG:-latest}
+    container_name: api
+    environment:
+      PORT: "3001"
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3001/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+  web:
+    <<: *common
+    image: ghcr.io/${GHCR_OWNER:-tiltcheck-me}/tiltcheck-web:${IMAGE_TAG:-latest}
+    container_name: web
+    environment:
+      PORT: "3000"
+      HOSTNAME: "0.0.0.0"
+    depends_on:
+      api:
+        condition: service_healthy
+
+  discord-bot:
+    <<: *common
+    image: ghcr.io/${GHCR_OWNER:-tiltcheck-me}/tiltcheck-discord-bot:${IMAGE_TAG:-latest}
+    container_name: discord-bot
+    depends_on:
+      api:
+        condition: service_healthy
+
+  justthetip-bot:
+    <<: *common
+    image: ghcr.io/${GHCR_OWNER:-tiltcheck-me}/tiltcheck-justthetip-bot:${IMAGE_TAG:-latest}
+    container_name: justthetip-bot
+    depends_on:
+      api:
+        condition: service_healthy
+
+  dad-bot:
+    <<: *common
+    image: ghcr.io/${GHCR_OWNER:-tiltcheck-me}/tiltcheck-dad-bot:${IMAGE_TAG:-latest}
+    container_name: dad-bot
+    depends_on:
+      api:
+        condition: service_healthy
+
+  trust-rollup:
+    <<: *common
+    image: ghcr.io/${GHCR_OWNER:-tiltcheck-me}/tiltcheck-trust-rollup:${IMAGE_TAG:-latest}
+    container_name: trust-rollup
+    environment:
+      PORT: "8082"
+    depends_on:
+      api:
+        condition: service_healthy
+
+  control-room:
+    <<: *common
+    image: ghcr.io/${GHCR_OWNER:-tiltcheck-me}/tiltcheck-control-room:${IMAGE_TAG:-latest}
+    container_name: control-room
+    environment:
+      PORT: "3001"
+    depends_on:
+      api:
+        condition: service_healthy
+
+  game-arena:
+    <<: *common
+    image: ghcr.io/${GHCR_OWNER:-tiltcheck-me}/tiltcheck-game-arena:${IMAGE_TAG:-latest}
+    container_name: game-arena
+    environment:
+      PORT: "8080"
+    depends_on:
+      api:
+        condition: service_healthy
+
+  user-dashboard:
+    <<: *common
+    image: ghcr.io/${GHCR_OWNER:-tiltcheck-me}/tiltcheck-user-dashboard:${IMAGE_TAG:-latest}
+    container_name: user-dashboard
+    environment:
+      PORT: "6001"
+    depends_on:
+      api:
+        condition: service_healthy
+
+  activity:
+    <<: *common
+    image: ghcr.io/${GHCR_OWNER:-tiltcheck-me}/tiltcheck-activity:${IMAGE_TAG:-latest}
+    container_name: activity
+    environment:
+      API_UPSTREAM: http://api:3001
+      ARENA_UPSTREAM: http://game-arena:8080
+    depends_on:
+      - api
+      - game-arena
+
+  cloudflared:
+    image: ghcr.io/${GHCR_OWNER:-tiltcheck-me}/tiltcheck-cloudflared:${IMAGE_TAG:-latest}
+    container_name: cloudflared
+    restart: unless-stopped
+    environment:
+      TUNNEL_TOKEN: ${TUNNEL_TOKEN}
+    depends_on:
+      - api
+      - web
+      - user-dashboard
+      - activity
+      - game-arena
+      - control-room
+    networks:
+      - tiltcheck-network
+
+networks:
+  tiltcheck-network:
+    driver: bridge

--- a/infra/compose/tunnel-ingress.compose.json
+++ b/infra/compose/tunnel-ingress.compose.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "ingress": [
+      { "hostname": "api.tiltcheck.me", "service": "http://api:3001" },
+      { "hostname": "hub.tiltcheck.me", "service": "http://user-dashboard:6001" },
+      { "hostname": "dashboard.tiltcheck.me", "service": "http://user-dashboard:6001" },
+      { "hostname": "activity.tiltcheck.me", "service": "http://activity:8080" },
+      { "hostname": "arena.tiltcheck.me", "service": "http://game-arena:8080" },
+      { "hostname": "game-arena.tiltcheck.me", "service": "http://game-arena:8080" },
+      { "hostname": "admin.tiltcheck.me", "service": "http://control-room:3001" },
+      { "hostname": "tiltcheck.me", "service": "http://web:3000" },
+      { "hostname": "www.tiltcheck.me", "service": "http://web:3000" },
+      { "service": "http_status:404" }
+    ]
+  }
+}

--- a/infra/compose/tunnel-ingress.railway.json
+++ b/infra/compose/tunnel-ingress.railway.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "ingress": [
+      { "hostname": "api.tiltcheck.me", "service": "http://api.railway.internal:3000" },
+      { "hostname": "hub.tiltcheck.me", "service": "http://user-dashboard.railway.internal:6001" },
+      { "hostname": "dashboard.tiltcheck.me", "service": "http://user-dashboard.railway.internal:6001" },
+      { "hostname": "activity.tiltcheck.me", "service": "http://activity.railway.internal:3000" },
+      { "hostname": "arena.tiltcheck.me", "service": "http://game-arena.railway.internal:3000" },
+      { "hostname": "admin.tiltcheck.me", "service": "http://control-room.railway.internal:3000" },
+      { "hostname": "tiltcheck.me", "service": "http://web.railway.internal:3000" },
+      { "hostname": "www.tiltcheck.me", "service": "http://web.railway.internal:3000" },
+      { "service": "http_status:404" }
+    ]
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,8 +13,8 @@ This folder has many one-off and historical utilities. If you are working solo, 
   - Inserts a new migration milestone template into `docs/migration/logs/milestone-log.md`.
 - `docs/DEPLOY.md`
   - Canonical source of truth for the current GHCR -> Railway production path.
-- `scripts/mvp-beta-tools-smoke.sh`
-  - Quick smoke checks for beta/tools pages.
+- `scripts/ops/deploy-ghcr-stack.sh` / `scripts/ops/verify-stack-health.sh`
+  - VPS compose deploy and health checks (Railway exit). See `docs/migration/exit-railway-plan.md`.
 - `scripts/linear-sync.mjs`
   - Syncs `docs/ops/linear-tasks.json` into Linear issues.
 - `scripts/daily-ops.ps1`

--- a/scripts/ops/deploy-ghcr-stack.sh
+++ b/scripts/ops/deploy-ghcr-stack.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+COMPOSE_FILE="${COMPOSE_FILE:-$ROOT_DIR/infra/compose/docker-compose.ghcr.yml}"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
+
+export GHCR_OWNER="${GHCR_OWNER:-tiltcheck-me}"
+export IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing env file: $ENV_FILE"
+  echo "Copy .env.example and fill production values before deploying."
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+echo "Pulling GHCR images (owner=$GHCR_OWNER tag=$IMAGE_TAG)..."
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull
+
+echo "Starting stack..."
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans
+
+echo "Stack status:"
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" ps

--- a/scripts/ops/verify-stack-health.sh
+++ b/scripts/ops/verify-stack-health.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+COMPOSE_FILE="${COMPOSE_FILE:-$ROOT_DIR/infra/compose/docker-compose.ghcr.yml}"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
+
+export GHCR_OWNER="${GHCR_OWNER:-tiltcheck-me}"
+export IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+failures=0
+
+check_http() {
+  local name="$1"
+  local url="$2"
+  if curl -sf --max-time 15 "$url" > /dev/null; then
+    echo "OK  $name ($url)"
+  else
+    echo "FAIL $name ($url)"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "=== Docker container status ==="
+if ! docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" ps; then
+  echo "docker compose ps failed"
+  exit 1
+fi
+
+not_running=$(docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" ps --status exited --status dead -q | wc -l)
+if [[ "$not_running" -gt 0 ]]; then
+  echo "WARN: $not_running container(s) not running"
+  failures=$((failures + 1))
+fi
+
+if [[ "${VERIFY_PUBLIC:-0}" == "1" ]]; then
+  echo ""
+  echo "=== Public edge checks (Cloudflare) ==="
+  check_http "api" "https://api.tiltcheck.me/health"
+  check_http "web" "https://tiltcheck.me/"
+  check_http "dashboard" "https://dashboard.tiltcheck.me/health"
+  check_http "activity" "https://activity.tiltcheck.me/"
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  echo ""
+  echo "$failures check(s) failed."
+  exit 1
+fi
+
+echo ""
+echo "Stack health checks passed."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production runs entirely on Railway (11 container services + tunnel). We need a documented, reversible path to move **all** services off Railway while keeping `tiltcheck.me` hostnames on Cloudflare.

## Approach

**VPS + Docker Compose + existing GHCR images + Cloudflare Tunnel** (domains stay; compute moves).

- `infra/compose/docker-compose.ghcr.yml` — pulls pre-built `ghcr.io/tiltcheck-me/tiltcheck-*` images
- `scripts/ops/deploy-ghcr-stack.sh` + `verify-stack-health.sh` — VPS deploy and smoke
- `.github/workflows/deploy-stack.yml` — manual SSH deploy when `VPS_*` secrets are set
- `.github/workflows/configure-tunnel.yml` — new `ingress_target` input: `railway` | `compose`
- `apps/activity` — nginx upstreams no longer hardcoded to `*.railway.internal` (env `API_UPSTREAM` / `ARENA_UPSTREAM`)

Full checklist: `docs/migration/exit-railway-plan.md`

## What you need before cutover

1. VPS (4 vCPU / 8 GB+ RAM), Docker installed
2. Production `.env` on VPS at `/opt/tiltcheck/.env`
3. GitHub secrets: `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY`
4. `TUNNEL_TOKEN` on VPS compose stack

## Cutover (summary)

1. Deploy stack on VPS (`deploy-ghcr-stack.sh`)
2. Stop Railway `cloudflared`
3. Run tunnel workflow with **`ingress_target: compose`**
4. Verify public health + Discord bots
5. Disable `deploy-railway.yml` after bake-in

## Risks

| Risk | Mitigation |
|------|------------|
| Single VPS SPOF | Accept for solo phase; Railway kept 7 days for rollback |
| Activity image change | Defaults target Docker service names; Railway can override env during transition |
| Railway workflow still active | Intentional — no prod DNS change until manual cutover |

## Validation

- [x] Compose file covers all 11 Railway services
- [x] Tunnel JSON uses correct container ports (api:3001, activity:8080, etc.)
- [ ] VPS provisioned and stack deployed (manual, post-merge)
- [ ] Tunnel switched to `compose` on staging then prod
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7216-c040-7f6e-999c-175909090c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7216-c040-7f6e-999c-175909090c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

