### PR TITLE
feat(pages): static tiltcheck.me twin on GitHub Pages

### DIFF
--- a/docs/GITHUB-PAGES-TROUBLESHOOTING.md
+++ b/docs/GITHUB-PAGES-TROUBLESHOOTING.md
@@ -1,22 +1,25 @@
 # GitHub Pages Troubleshooting Guide
 
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18 -->
 
 ## What GitHub Pages hosts now
 
 Production marketing and docs live on **Railway** at `https://tiltcheck.me` (Next.js `apps/web`, including `/docs`).
 
-GitHub Pages (`gh-pages` branch) is a **static mirror** of `docs/tiltcheck/` specs:
+GitHub Pages (`gh-pages` branch) is a **branded static mirror** — same obsidian/teal chrome as tiltcheck.me, no app runtime:
 
 | Path on Pages | Source |
 |---------------|--------|
-| `/` | Redirect to `/docs/index.html` |
+| `/` | Mini landing (brand, one-liner, CTAs to site / Discord / Ko-fi) + specs preview |
 | `/docs/*.html` | `node scripts/convert-markdown.js` output |
+| `/styles/base.css` | `scripts/pages-assets/styles/base.css` |
 | `/docs-md/*.md` | Raw markdown from `docs/tiltcheck/` |
+
+Asset and nav links are **relative** so project Pages at `https://tiltcheck-me.github.io/tiltcheck-monorepo/` resolve correctly (absolute `/styles/...` breaks under the repo base path).
 
 Default URL: `https://tiltcheck-me.github.io/tiltcheck-monorepo/` (no custom domain on `gh-pages`).
 
-Workflow: `.github/workflows/pages.yml` — triggers on `docs/tiltcheck/**` changes.
+Workflow: `.github/workflows/pages.yml` — triggers on `docs/tiltcheck/**`, `scripts/convert-markdown.js`, `scripts/pages-assets/**`.
 
 Local build: `pnpm docs:pages`
 

--- a/docs/GITHUB-PAGES-TROUBLESHOOTING.md
+++ b/docs/GITHUB-PAGES-TROUBLESHOOTING.md
@@ -6,16 +6,16 @@
 
 Production marketing and docs live on **Railway** at `https://tiltcheck.me` (Next.js `apps/web`, including `/docs`).
 
-GitHub Pages (`gh-pages` branch) is a **branded static mirror** — same obsidian/teal chrome as tiltcheck.me, no app runtime:
+GitHub Pages (`gh-pages` branch) is a **static product twin** of tiltcheck.me — same obsidian/teal landing composition, no app runtime:
 
 | Path on Pages | Source |
 |---------------|--------|
-| `/` | Mini landing (brand, one-liner, CTAs to site / Discord / Ko-fi) + specs preview |
-| `/docs/*.html` | `node scripts/convert-markdown.js` output |
+| `/` | Product landing clone (hero: `House always wins? FUCK THAT.`; CTAs → live `tiltcheck.me/extension` + `/casinos`) |
+| `/docs/*.html` | Specs secondary surface from `node scripts/convert-markdown.js` |
 | `/styles/base.css` | `scripts/pages-assets/styles/base.css` |
 | `/docs-md/*.md` | Raw markdown from `docs/tiltcheck/` |
 
-Asset and nav links are **relative** so project Pages at `https://tiltcheck-me.github.io/tiltcheck-monorepo/` resolve correctly (absolute `/styles/...` breaks under the repo base path).
+Asset and nav links are **relative** so project Pages at `https://tiltcheck-me.github.io/tiltcheck-monorepo/` resolve correctly (absolute `/styles/...` breaks under the repo base path). Specs are not in the first viewport — product home only.
 
 Default URL: `https://tiltcheck-me.github.io/tiltcheck-monorepo/` (no custom domain on `gh-pages`).
 

--- a/docs/superpowers/plans/2026-07-18-pages-site-clone.md
+++ b/docs/superpowers/plans/2026-07-18-pages-site-clone.md
@@ -1,0 +1,210 @@
+# GitHub Pages Site Clone Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make GitHub Pages `/` a static visual twin of the tiltcheck.me homepage with locked hero line `House always wins? FUCK THAT.`, product CTAs to live URLs, and specs only under `/docs`.
+
+**Architecture:** Keep the existing `convert-markdown.js` + `pages-assets` pipeline. Replace `buildRootLanding` with product-landing HTML mirroring `apps/web/src/app/page.tsx`. Expand `base.css` with landing-critical web tokens/classes. Docs pages keep shared product nav + footer but stay doc-layout under `/docs`.
+
+**Tech Stack:** Node ESM script (no deps), static HTML/CSS, GitHub Pages via `.github/workflows/pages.yml`, Google Fonts (Inter + JetBrains Mono).
+
+**Spec:** [docs/superpowers/specs/2026-07-18-pages-site-clone-design.md](../specs/2026-07-18-pages-site-clone-design.md)
+
+## Global Constraints
+
+- Copyright header on every new/modified file: `© 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18`
+- No emojis in code, comments, or docs
+- User-facing footer must include: `Made for Degens. By Degens.`
+- Hero headline verbatim: `House always wins? FUCK THAT.`
+- Relative asset paths only (project Pages base path `/tiltcheck-monorepo/`)
+- Atomic docs: update `docs/GITHUB-PAGES-TROUBLESHOOTING.md` with landing changes
+- CTAs leave to live `https://tiltcheck.me/*` — no fake app routes on Pages
+- Specs must not appear in the first viewport
+
+## File map
+
+| Path | Responsibility |
+|------|----------------|
+| `scripts/pages-assets/styles/base.css` | Brand tokens + landing + shared nav/footer + doc chrome |
+| `scripts/convert-markdown.js` | Generate root product landing + `/docs/*` HTML |
+| `docs/GITHUB-PAGES-TROUBLESHOOTING.md` | Path table / verification notes for the clone |
+| `docs/superpowers/plans/2026-07-18-pages-site-clone.md` | This plan |
+
+---
+
+### Task 1: Product landing CSS (web twin)
+
+**Files:**
+- Modify: `scripts/pages-assets/styles/base.css`
+
+**Interfaces:**
+- Produces CSS classes used by Task 2 HTML:
+  - `.landing-page`, `.hero-surface`, `.landing-shell`, `.landing-hero-centered`
+  - `.brand-wordmark`, `.brand-eyebrow`, `.landing-hero-title`, `.landing-hero-subtitle`
+  - `.hero-actions`, `.btn`, `.btn-primary`, `.hero-actions__secondary-link`
+  - `.public-page-section`, `.public-page-section-heading`, `.public-page-grid--3`
+  - `.public-page-card`, `.public-page-card__eyebrow`, `.public-page-card__title`, `.public-page-card__copy`
+  - `.site-nav`, `.site-footer` (product nav, not docs-first)
+
+- [ ] **Step 1: Rewrite `base.css` for product landing**
+
+Replace the current docs-mini-landing styles with web-aligned tokens and landing structure. Keep doc page styles (`.doc-hero`, `.doc-main`, `.spec-list`) for `/docs` only.
+
+Required token values:
+
+```css
+--color-primary: #17c3b2;
+--bg-primary: #06080b;
+--text-secondary: #c4ced8;
+--border-default: #283347;
+--font-sans: "Inter", ...;
+--font-mono: "JetBrains Mono", ...;
+```
+
+Hero title must be large display type (clamp ~3rem–5.5rem), uppercase stroke/shadow treatment matching web. First viewport: full-bleed atmosphere, no cards in hero. Include 2–3 motions (rise-in, grain drift, CTA hover) with `prefers-reduced-motion` kill switch.
+
+- [ ] **Step 2: Smoke-check CSS file**
+
+Run: `rg -n "House|landing-hero-title|17c3b2|Made for Degens|doc-hero" scripts/pages-assets/styles/base.css | head`
+Expected: tokens + landing + doc chrome selectors present; no `#00d4aa`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/pages-assets/styles/base.css
+git commit -m "feat(pages): product landing CSS twin for tiltcheck.me"
+```
+
+---
+
+### Task 2: Root HTML generator = product home
+
+**Files:**
+- Modify: `scripts/convert-markdown.js`
+
+**Interfaces:**
+- Consumes CSS classes from Task 1
+- Produces:
+  - `buildRootLanding()` → product home HTML written to site root `index.html`
+  - Shared `navHtml(depth, current)` with product links (Extension, Casinos, Discord)
+  - Docs builders unchanged in purpose (`buildPage`, `buildIndexPage`) but share product nav
+
+Locked copy constants:
+
+```js
+const SITE_HERO_HEADLINE = 'House always wins? FUCK THAT.';
+const SITE_ONE_LINER =
+  'Read-only browser guardrail. Watches pacing and tilt in real time — pulls you out before you rug yourself.';
+const SITE_URL = 'https://tiltcheck.me';
+const EXTENSION_URL = `${SITE_URL}/extension`;
+const CASINOS_URL = `${SITE_URL}/casinos`;
+const OPERATORS_URL = `${SITE_URL}/operators`;
+const DISCORD_URL = 'https://discord.gg/gdBsEJfCar';
+```
+
+`coreJobs` must match `apps/web/src/app/page.tsx`:
+
+```js
+const CORE_JOBS = [
+  { step: '01', title: 'Kill the Auto-Pilot', description: 'Tracks click-speed and bet pacing. Wakes you up when you play like a bot.' },
+  { step: '02', title: 'Read the Room', description: 'Flags sus pacing and pressure loops while you are still in the session.' },
+  { step: '03', title: 'Enforce the Exit', description: 'Set your line. We enforce it — not passive warnings.' },
+];
+```
+
+- [ ] **Step 1: Rewrite `buildRootLanding` (no specs in hero)**
+
+Root body structure:
+
+1. `site-nav` — brand → `index.html`; links: Extension, Casinos, Discord; optional Support
+2. `main.landing-page`
+   - `section.hero-surface` — brand wordmark/eyebrow, locked H1, one-liner, two CTAs
+   - `section` three jobs grid
+   - `section` operator block (static bullets + GET SANDBOX ACCESS → operators URL)
+   - RG disclaimer section
+3. `site-footer` — Made for Degens. By Degens. + copyright + quiet Specs link to `docs/index.html`
+
+Remove from root: “Docs mirror”, “Specs without Railway”, top-of-page specs list.
+
+- [ ] **Step 2: Align shared nav for docs depth**
+
+For `depth === 'docs'`, Extension/Casinos still go to absolute tiltcheck.me URLs; Specs → `index.html` with `aria-current` when on docs; brand → `../index.html`.
+
+- [ ] **Step 3: Build and assert**
+
+Run:
+
+```bash
+pnpm docs:pages
+rg -n "House always wins\? FUCK THAT\.|INSTALL THE EXTENSION|CHECK CASINO TRUST|Docs mirror|STOP GIVING" out/index.html
+```
+
+Expected:
+- Headline present
+- Both product CTAs present
+- `Docs mirror` / `STOP GIVING` absent from root
+- Footer tag present
+
+Also:
+
+```bash
+rg -n 'href="/|src="/' out/index.html out/docs/index.html || true
+```
+
+Expected: no absolute root asset hrefs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/convert-markdown.js
+git commit -m "feat(pages): static twin home with locked FUCK THAT hero"
+```
+
+---
+
+### Task 3: Docs + verify + PR
+
+**Files:**
+- Modify: `docs/GITHUB-PAGES-TROUBLESHOOTING.md`
+
+- [ ] **Step 1: Update troubleshooting path table**
+
+Document:
+- `/` = product landing clone (not redirect, not specs-first)
+- Hero line locked
+- CTAs to live tiltcheck.me
+- `/docs` = specs secondary
+- Relative paths note retained
+
+- [ ] **Step 2: Local visual check**
+
+```bash
+python3 -m http.server 8765 --directory out
+# browser: http://127.0.0.1:8765/ — product first viewport
+# browser: http://127.0.0.1:8765/docs/index.html — specs still work
+```
+
+- [ ] **Step 3: Commit, push, update PR #628**
+
+```bash
+git add docs/GITHUB-PAGES-TROUBLESHOOTING.md docs/superpowers/plans/2026-07-18-pages-site-clone.md
+git commit -m "docs(pages): Pages product-clone troubleshooting + plan"
+git push -u origin cursor/pages-tiltcheck-brand-0c5a
+```
+
+---
+
+## Spec coverage check
+
+| Spec requirement | Task |
+|------------------|------|
+| Static twin of home | 1, 2 |
+| Locked hero line | 2 |
+| SITE_ONE_LINER support | 2 |
+| Extension + Casinos CTAs | 2 |
+| Three jobs + operator + RG | 2 |
+| Specs only under `/docs` | 2, 3 |
+| Relative paths | 2 |
+| Footer degen line | 2 |
+| Troubleshooting atomic docs | 3 |
+| No Next export / no fake apps | constrained by design; enforced in Task 2 CTAs |

--- a/docs/superpowers/specs/2026-07-18-pages-site-clone-design.md
+++ b/docs/superpowers/specs/2026-07-18-pages-site-clone-design.md
@@ -1,0 +1,119 @@
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18 -->
+
+# GitHub Pages Site Clone — Design Spec
+
+Status: Approved (design)  
+Owner: founder (solo)  
+Surface: GitHub Pages (`gh-pages` via `.github/workflows/pages.yml`)  
+Share URL: `https://tiltcheck-me.github.io/tiltcheck-monorepo/`  
+Related: [docs/GITHUB-PAGES-TROUBLESHOOTING.md](../../GITHUB-PAGES-TROUBLESHOOTING.md), `apps/web` landing (`src/app/page.tsx`)
+
+## Problem
+
+The Railway-free share link on GitHub Pages currently reads as a docs/spec shell (nav + spec list + doc chrome). Founder needs a link that **looks like tiltcheck.me** — product landing first — when the app host is down or for quick sharing. Specs can remain available, but they must not define the home experience.
+
+## Goals
+
+- Pages `/` is a static visual twin of the tiltcheck.me homepage composition
+- Locked hero headline: **House always wins? FUCK THAT.**
+- Brand is hero-level (TILTCHECK), not only nav text
+- Primary CTAs point at live product URLs on `tiltcheck.me` (extension, casinos)
+- Obsidian + teal brand tokens match web (`#17c3b2`, `#06080b` / `#0a0c10`)
+- Footer includes **Made for Degens. By Degens.**
+- Specs remain at `/docs/*` as a secondary surface, not the home story
+- Relative asset paths so project Pages under `/tiltcheck-monorepo/` resolve
+
+## Non-goals (v1)
+
+- Full Next.js static export of `apps/web`
+- Fake dashboard / vault / auth / API routes on Pages
+- Hosting interactive Intel/Ask without the API
+- Custom domain on `gh-pages` (production hostname stays Railway / future VPS)
+- Changing copy on live `tiltcheck.me` in this PR (Pages-only hero line unless founder later ports it)
+
+## Decisions (locked)
+
+| Topic | Choice |
+|-------|--------|
+| Approach | **A** — hand-built static HTML/CSS twin of home |
+| Hero headline | `House always wins? FUCK THAT.` (verbatim; supporting one-liner allowed) |
+| Supporting lede | Site one-liner from `SITE_ONE_LINER` (read-only guardrail / pacing / tilt) |
+| Primary CTA | Install the Extension → `https://tiltcheck.me/extension` |
+| Secondary CTA | Check Casino Trust → `https://tiltcheck.me/casinos` |
+| Below-fold | Three jobs (“Protect the bankroll”) + static operator block + RG disclaimer |
+| Specs | `/docs/*` only; footer link optional; no specs list in first viewport |
+| Nav | Product-style: brand, Extension, Casinos, Discord (Support/Ko-fi optional) |
+| Fonts | Inter + JetBrains Mono (match web) |
+| Deploy | Existing `pages.yml` + `pnpm docs:pages` / converter pipeline |
+
+## Information architecture
+
+```
+/                     → product landing clone (this spec)
+/styles/base.css      → brand + landing + doc chrome
+/docs/index.html      → specs index (secondary)
+/docs/*.html          → converted markdown specs
+/docs-md/*.md         → raw markdown mirror (unchanged)
+```
+
+## Landing composition
+
+### First viewport (hero budget)
+
+Exactly:
+
+1. Brand signal — **TILTCHECK** (wordmark or eyebrow + brand weight matching web)
+2. Headline — **House always wins? FUCK THAT.**
+3. One short supporting sentence — `SITE_ONE_LINER`
+4. CTA group — Install Extension (primary), Check Casino Trust (secondary)
+5. Dominant atmosphere — full-bleed obsidian plane with subtle teal/grain (no inset hero cards, no floating badges)
+
+Not in first viewport: specs list, “docs mirror” framing, schedules, stats strips, operator deep-dives.
+
+Eyebrow may use “Built for Degens. By Degens.” to match web `brand-eyebrow` without crowding the brand.
+
+### Below fold
+
+1. **Three jobs** — same copy as `apps/web/src/app/page.tsx` `coreJobs`
+2. **Operator block** — static twin of `OperatorBlock` bullets; CTA → `https://tiltcheck.me/operators`
+3. **RG disclaimer** — NCPG / 1-800-GAMBLER line (match web)
+4. **Footer** — Made for Degens. By Degens. + copyright; optional quiet Specs link
+
+### Motion (2–3 intentional)
+
+- Hero rise/fade-in on load
+- Subtle grain or gradient drift in hero atmosphere
+- CTA hover lift (match web btn feel)
+- Respect `prefers-reduced-motion`
+
+## Technical approach
+
+1. Rewrite root generator in `scripts/convert-markdown.js` from “docs mini-landing” to product landing HTML matching the structure above
+2. Expand `scripts/pages-assets/styles/base.css` to mirror web landing tokens/classes closely enough that a side-by-side glance reads as the same site (not a new design system)
+3. Keep `buildPage` / `buildIndexPage` for `/docs/*` with shared nav/footer chrome, but doc-first layout only under `/docs`
+4. Continue relative hrefs (`styles/base.css`, `docs/...`) — never absolute `/styles/...` on project Pages
+5. Update `docs/GITHUB-PAGES-TROUBLESHOOTING.md` atomically
+
+## Success criteria
+
+- [ ] First viewport cannot be mistaken for a docs index after removing the nav
+- [ ] Headline string present exactly: `House always wins? FUCK THAT.`
+- [ ] CTAs hit live tiltcheck.me product paths
+- [ ] Specs not in hero; discoverable via `/docs` or footer
+- [ ] `pnpm docs:pages` builds; relative CSS loads under repo base path
+- [ ] Footer: Made for Degens. By Degens.
+- [ ] No emojis; copyright headers on touched files
+
+## Risks / rollback
+
+| Risk | Mitigation |
+|------|------------|
+| Visual drift from live Next.js CSS | Port the landing-critical rules; do not try to copy all of `globals.css` |
+| Founder expects interactive pages to work on Pages | CTAs leave to tiltcheck.me; no fake apps |
+| Pages deploy lag after merge | `pages.yml` path triggers + `workflow_dispatch` |
+| Rollback | Revert PR; prior `gh-pages` publish restored by re-run of previous main |
+
+## Out of band (later)
+
+- Port the new hero line onto live `apps/web` if founder wants parity both ways
+- VPS/Cloudflare cutover for the real domain (separate from this Pages clone)

--- a/scripts/convert-markdown.js
+++ b/scripts/convert-markdown.js
@@ -3,23 +3,15 @@
  * © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
  *
  * Lightweight Markdown → HTML converter for TiltCheck docs / GitHub Pages.
- * No external deps; supports:
- *  - YAML frontmatter (skipped in body)
- *  - Headings (# .. ######)
- *  - Paragraphs / blank line separation
- *  - Unordered lists (-, *)
- *  - Inline code (`code`)
- *  - Code fences ```lang ... ``` (lang is optional)
- *  - Bold **text** and emphasis *text*
- *  - Links [text](url)
+ * Root `/` is a static product twin of tiltcheck.me. Specs live under `/docs`.
+ *
+ * Project Pages (github.io/<repo>/) require relative asset paths — never "/styles/...".
  *
  * Usage:
  *   node scripts/convert-markdown.js [sourceDir] [outDir]
  * Defaults:
  *   sourceDir = docs/tiltcheck
  *   outDir = out/docs
- *
- * Project Pages (github.io/<repo>/) require relative asset paths — never "/styles/...".
  */
 import fs from 'fs';
 import path from 'path';
@@ -29,11 +21,38 @@ const outRoot = path.resolve(process.argv[3] || 'out/docs');
 const FOOTER = 'Made for Degens. By Degens.';
 const COPYRIGHT = '© 2024–2026 TiltCheck Ecosystem. All Rights Reserved.';
 const SITE_URL = 'https://tiltcheck.me';
+const EXTENSION_URL = `${SITE_URL}/extension`;
+const CASINOS_URL = `${SITE_URL}/casinos`;
+const OPERATORS_URL = `${SITE_URL}/operators`;
 const DISCORD_URL = 'https://discord.gg/gdBsEJfCar';
 const KOFI_URL = 'https://ko-fi.com/jmenichole0';
-const SITE_HERO_HEADLINE = 'STOP GIVING WINS BACK.';
+const SITE_HERO_HEADLINE = 'House always wins? FUCK THAT.';
 const SITE_ONE_LINER =
   'Read-only browser guardrail. Watches pacing and tilt in real time — pulls you out before you rug yourself.';
+
+const CORE_JOBS = [
+  {
+    step: '01',
+    title: 'Kill the Auto-Pilot',
+    description: 'Tracks click-speed and bet pacing. Wakes you up when you play like a bot.',
+  },
+  {
+    step: '02',
+    title: 'Read the Room',
+    description: 'Flags sus pacing and pressure loops while you are still in the session.',
+  },
+  {
+    step: '03',
+    title: 'Enforce the Exit',
+    description: 'Set your line. We enforce it — not passive warnings.',
+  },
+];
+
+const OPERATOR_BULLETS = [
+  'Trust scoring as a service — non-affiliated, evidence-backed.',
+  'RGaaS API for session guardrails without custodial flows.',
+  'Sandbox access for operators who want tilt signals, not affiliate spam.',
+];
 
 const FONT_LINKS = `<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&family=JetBrains+Mono:wght@500;700;800&display=swap" rel="stylesheet"/>`;
 
@@ -157,7 +176,7 @@ function assetHref(depth, file) {
   return depth === 'root' ? `styles/${file}` : `../styles/${file}`;
 }
 
-/** @param {'root' | 'docs'} depth */
+/** @param {'root' | 'docs'} depth @param {'home' | 'specs'} current */
 function navHtml(depth, current) {
   const home = depth === 'root' ? 'index.html' : '../index.html';
   const specs = depth === 'root' ? 'docs/index.html' : 'index.html';
@@ -166,16 +185,25 @@ function navHtml(depth, current) {
   return `<nav class="site-nav" aria-label="Primary">
   <a class="site-nav__brand" href="${home}"${homeCurrent}><span class="site-nav__mark" aria-hidden="true">TC</span>TiltCheck</a>
   <div class="site-nav__links">
-    <a href="${SITE_URL}">tiltcheck.me</a>
-    <a href="${specs}"${specsCurrent}>Specs</a>
+    <a href="${EXTENSION_URL}">Extension</a>
+    <a href="${CASINOS_URL}">Casinos</a>
     <a href="${DISCORD_URL}" rel="noopener noreferrer">Discord</a>
-    <a href="${KOFI_URL}" rel="noopener noreferrer">Support</a>
+    <a href="${specs}"${specsCurrent}>Specs</a>
   </div>
 </nav>`;
 }
 
-function footerHtml() {
-  return `<footer class="site-footer"><span class="site-footer__tag">${FOOTER}</span>${COPYRIGHT}</footer>`;
+function footerHtml(depth) {
+  const specs = depth === 'root' ? 'docs/index.html' : 'index.html';
+  return `<footer class="site-footer">
+  <span class="site-footer__tag">${FOOTER}</span>
+  <div class="site-footer__links">
+    <a href="${SITE_URL}">tiltcheck.me</a>
+    <a href="${specs}">Specs</a>
+    <a href="${KOFI_URL}" rel="noopener noreferrer">Support</a>
+  </div>
+  ${COPYRIGHT}
+</footer>`;
 }
 
 function shell({ title, description, depth, current, body }) {
@@ -193,7 +221,7 @@ ${FONT_LINKS}
 <body>
 ${navHtml(depth, current)}
 ${body}
-${footerHtml()}
+${footerHtml(depth)}
 </body>
 </html>`;
 }
@@ -226,7 +254,7 @@ function buildIndexPage(entries) {
   const content = `<header class="doc-hero"><div class="doc-hero__inner">
 <p class="doc-hero__crumb">TiltCheck / Specs</p>
 <h1>Ecosystem specs</h1>
-<p class="lede">Static mirror of <code>docs/tiltcheck/</code>. Production product lives at <a href="${SITE_URL}">tiltcheck.me</a>.</p>
+<p class="lede">Static mirror of <code>docs/tiltcheck/</code>. The product lives at <a href="${SITE_URL}">tiltcheck.me</a>.</p>
 </div></header>
 <main class="doc-main">
 <ul class="spec-list">${listHtml}</ul>
@@ -241,44 +269,71 @@ function buildIndexPage(entries) {
   });
 }
 
-function buildRootLanding(entries) {
-  const listHtml = entries
-    .slice(0, 12)
-    .map(
-      (e) =>
-        `<li><a href="docs/${e.slug}.html"><strong>${escapeHtml(e.title)}</strong><span class="spec-list__desc">${escapeHtml(e.description)}</span></a></li>`,
-    )
-    .join('\n');
+function buildRootLanding() {
+  const jobsHtml = CORE_JOBS.map(
+    (job) => `<article class="public-page-card">
+  <p class="public-page-card__eyebrow">Step ${escapeHtml(job.step)}</p>
+  <h3 class="public-page-card__title">${escapeHtml(job.title)}</h3>
+  <p class="public-page-card__copy">${escapeHtml(job.description)}</p>
+</article>`,
+  ).join('\n');
 
-  const moreLink =
-    entries.length > 12
-      ? `<p class="section__lede" style="margin-top:1.25rem"><a href="docs/index.html">See all ${entries.length} specs →</a></p>`
-      : `<p class="section__lede" style="margin-top:1.25rem"><a href="docs/index.html">Browse all specs →</a></p>`;
+  const operatorList = OPERATOR_BULLETS.map((b) => `<li>${escapeHtml(b)}</li>`).join('\n');
 
-  const content = `<section class="landing-hero" aria-label="TiltCheck">
-  <div class="landing-hero__inner">
-    <p class="brand-wordmark">Tilt<span>Check</span></p>
-    <h1 class="landing-hero__headline">${escapeHtml(SITE_HERO_HEADLINE)}</h1>
-    <p class="landing-hero__lede">${escapeHtml(SITE_ONE_LINER)}</p>
-    <div class="hero-actions">
-      <a class="btn btn-primary" href="${SITE_URL}">Open tiltcheck.me</a>
-      <a class="btn btn-ghost" href="${DISCORD_URL}" rel="noopener noreferrer">Join Discord</a>
-      <a class="btn btn-ghost" href="${KOFI_URL}" rel="noopener noreferrer">Support on Ko-fi</a>
+  const content = `<main class="landing-page">
+  <section class="hero-surface" aria-label="TiltCheck">
+    <div class="landing-shell landing-hero-centered">
+      <p class="brand-wordmark">Tilt<span>Check</span></p>
+      <span class="brand-eyebrow">Built for Degens. By Degens.</span>
+      <h1 class="landing-hero-title landing-hero-title--centered">${escapeHtml(SITE_HERO_HEADLINE)}</h1>
+      <p class="landing-hero-subtitle landing-hero-subtitle--centered">${escapeHtml(SITE_ONE_LINER)}</p>
+      <div class="hero-actions">
+        <a class="btn btn-primary" href="${EXTENSION_URL}">Install the Extension</a>
+        <a class="hero-actions__secondary-link" href="${CASINOS_URL}">Check Casino Trust</a>
+      </div>
     </div>
-  </div>
-</section>
-<section class="section section--specs" id="specs" aria-label="Specs">
-  <div class="section__inner">
-    <span class="section__eyebrow">Docs mirror</span>
-    <h2 class="section__title">Specs without Railway</h2>
-    <p class="section__lede">Same brand chrome. Static HTML from the monorepo — share this link when the app host is down or you just need architecture notes.</p>
-    <ul class="spec-list">${listHtml}</ul>
-    ${moreLink}
-  </div>
-</section>`;
+  </section>
+
+  <section class="public-page-section" aria-label="Three jobs">
+    <div class="landing-shell">
+      <div class="public-page-section-heading">
+        <span class="brand-eyebrow">Three jobs</span>
+        <h2 class="public-page-section-heading__title">Protect the bankroll.</h2>
+      </div>
+      <div class="public-page-grid public-page-grid--3">
+        ${jobsHtml}
+      </div>
+    </div>
+  </section>
+
+  <section class="public-page-section" aria-label="Operators">
+    <div class="landing-shell">
+      <article class="public-page-card">
+        <span class="brand-eyebrow">For platforms / operators</span>
+        <h2 class="public-page-section-heading__title">Trust scoring as a service. Non-affiliated. RGaaS API.</h2>
+        <ul class="public-page-card__copy public-page-card__copy--list">
+          ${operatorList}
+        </ul>
+        <div style="margin-top:1.5rem">
+          <a class="btn btn-primary" href="${OPERATORS_URL}">Get Sandbox Access</a>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="public-page-section" aria-label="Responsible gambling">
+    <div class="landing-shell">
+      <p class="rg-disclaimer">
+        Not a casino, not a bank, not financial advice. Problem gambling help:
+        <a href="https://www.ncpg.org" target="_blank" rel="noopener noreferrer">NCPG.org</a>
+        or <strong>1-800-GAMBLER</strong>.
+      </p>
+    </div>
+  </section>
+</main>`;
 
   return shell({
-    title: 'TiltCheck | Specs Mirror',
+    title: 'TiltCheck | The Degen Audit Layer',
     description: SITE_ONE_LINER,
     depth: 'root',
     current: 'home',
@@ -315,7 +370,7 @@ function run() {
   }
 
   fs.writeFileSync(path.join(outRoot, 'index.html'), buildIndexPage(indexEntries));
-  fs.writeFileSync(path.join(siteRoot, 'index.html'), buildRootLanding(indexEntries));
+  fs.writeFileSync(path.join(siteRoot, 'index.html'), buildRootLanding());
   fs.writeFileSync(path.join(siteRoot, '.nojekyll'), '');
 
   console.log(`Converted ${files.length} markdown files to HTML in ${outRoot}`);

--- a/scripts/convert-markdown.js
+++ b/scripts/convert-markdown.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17
+ * © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
  *
- * Lightweight Markdown → HTML converter for TiltCheck docs.
+ * Lightweight Markdown → HTML converter for TiltCheck docs / GitHub Pages.
  * No external deps; supports:
  *  - YAML frontmatter (skipped in body)
  *  - Headings (# .. ######)
@@ -18,6 +18,8 @@
  * Defaults:
  *   sourceDir = docs/tiltcheck
  *   outDir = out/docs
+ *
+ * Project Pages (github.io/<repo>/) require relative asset paths — never "/styles/...".
  */
 import fs from 'fs';
 import path from 'path';
@@ -26,6 +28,14 @@ const sourceRoot = path.resolve(process.argv[2] || 'docs/tiltcheck');
 const outRoot = path.resolve(process.argv[3] || 'out/docs');
 const FOOTER = 'Made for Degens. By Degens.';
 const COPYRIGHT = '© 2024–2026 TiltCheck Ecosystem. All Rights Reserved.';
+const SITE_URL = 'https://tiltcheck.me';
+const DISCORD_URL = 'https://discord.gg/gdBsEJfCar';
+const KOFI_URL = 'https://ko-fi.com/jmenichole0';
+const SITE_HERO_HEADLINE = 'STOP GIVING WINS BACK.';
+const SITE_ONE_LINER =
+  'Read-only browser guardrail. Watches pacing and tilt in real time — pulls you out before you rug yourself.';
+
+const FONT_LINKS = `<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&family=JetBrains+Mono:wght@500;700;800&display=swap" rel="stylesheet"/>`;
 
 function slugify(name) {
   return name
@@ -117,8 +127,15 @@ function extractMeta(md) {
   const body = stripFrontmatter(md);
   const heading = body.match(/^#\s+(.+)$/m);
   if (heading) title = heading[1].trim();
-  const para = body.replace(/```[\s\S]*?```/g, '').match(/(^|\n)([^#\n][^\n]+)\n/);
-  if (para) description = para[2].trim();
+  const plain = body.replace(/```[\s\S]*?```/g, '');
+  for (const line of plain.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('<!--')) continue;
+    if (/^©|^Copyright\b|^All Rights Reserved/i.test(trimmed)) continue;
+    if (/^Last Updated:/i.test(trimmed)) continue;
+    description = trimmed;
+    break;
+  }
   return { title: title || 'Untitled', description: description.slice(0, 180) };
 }
 
@@ -131,20 +148,138 @@ function sortKey(file) {
   return `9999-${base.toLowerCase()}`;
 }
 
+/** @param {'root' | 'docs'} depth */
+function assetHref(depth, file) {
+  return depth === 'root' ? `styles/${file}` : `../styles/${file}`;
+}
+
+/** @param {'root' | 'docs'} depth */
+function navHtml(depth, current) {
+  const home = depth === 'root' ? 'index.html' : '../index.html';
+  const specs = depth === 'root' ? 'docs/index.html' : 'index.html';
+  const homeCurrent = current === 'home' ? ' aria-current="page"' : '';
+  const specsCurrent = current === 'specs' ? ' aria-current="page"' : '';
+  return `<nav class="site-nav" aria-label="Primary">
+  <a class="site-nav__brand" href="${home}"${homeCurrent}><span class="site-nav__mark" aria-hidden="true">TC</span>TiltCheck</a>
+  <div class="site-nav__links">
+    <a href="${SITE_URL}">tiltcheck.me</a>
+    <a href="${specs}"${specsCurrent}>Specs</a>
+    <a href="${DISCORD_URL}" rel="noopener noreferrer">Discord</a>
+    <a href="${KOFI_URL}" rel="noopener noreferrer">Support</a>
+  </div>
+</nav>`;
+}
+
+function footerHtml() {
+  return `<footer class="site-footer"><span class="site-footer__tag">${FOOTER}</span>${COPYRIGHT}</footer>`;
+}
+
+function shell({ title, description, depth, current, body }) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<title>${escapeHtml(title)}</title>
+<meta name="description" content="${escapeHtml(description)}"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="theme-color" content="#06080b"/>
+${FONT_LINKS}
+<link rel="stylesheet" href="${assetHref(depth, 'base.css')}"/>
+</head>
+<body>
+${navHtml(depth, current)}
+${body}
+${footerHtml()}
+</body>
+</html>`;
+}
+
 function buildPage({ title, description, body }) {
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>${escapeHtml(title)} - TiltCheck</title><meta name="description" content="${escapeHtml(description)}"/><meta name="viewport" content="width=device-width, initial-scale=1"/><link rel="stylesheet" href="/styles/base.css"/><style>body{background:#0a0a0a;color:#e0e0e0;font-family:Inter,system-ui,sans-serif;margin:0;padding:0}main{max-width:900px;margin:0 auto;padding:40px 18px;line-height:1.7}a{color:#00d4aa;text-decoration:none}a:hover{text-decoration:underline}.page-hero{padding:54px 24px 32px;background:linear-gradient(135deg,#121212,#181818);border-bottom:1px solid #222}.page-hero h1{margin:0 0 10px;font-size:2.4rem;background:linear-gradient(135deg,#00d4aa,#00a8ff);-webkit-background-clip:text;color:transparent}.lede{color:#aaa;font-size:1.05rem;max-width:760px}pre{background:#181818;padding:14px 16px;border:1px solid #222;border-radius:8px;overflow:auto;font-size:.85rem}code{font-family:ui-monospace,Monaco,Consolas,monospace;color:#00a8ff}.breadcrumb{font-size:.7rem;letter-spacing:.12em;text-transform:uppercase;color:#888;margin:0 0 12px}.nav-inline{display:flex;gap:20px;align-items:center;font-size:.8rem;padding:10px 20px;background:#111;border-bottom:1px solid #222}nav a{color:#aaa}nav a[aria-current="page"]{color:#00d4aa;font-weight:600}</style></head><body><nav class="nav-inline"><a href="https://tiltcheck.me">tiltcheck.me</a><a href="/docs/index.html" aria-current="page">Specs</a><a href="https://tiltcheck.me/docs">Live Docs</a></nav><header class="page-hero"><div class="breadcrumb">Specs / ${escapeHtml(title)}</div><h1>${escapeHtml(title)}</h1><p class="lede">${escapeHtml(description)}</p></header><main id="content">${body}</main><footer style="padding:40px 24px;text-align:center;font-size:.75rem;color:#666;border-top:1px solid #222">${FOOTER} // ${COPYRIGHT}</footer></body></html>`;
+  const content = `<header class="doc-hero"><div class="doc-hero__inner">
+<p class="doc-hero__crumb">Specs / ${escapeHtml(title)}</p>
+<h1>${escapeHtml(title)}</h1>
+<p class="lede">${escapeHtml(description)}</p>
+</div></header>
+<main class="doc-main" id="content">${body}</main>`;
+
+  return shell({
+    title: `${title} - TiltCheck`,
+    description,
+    depth: 'docs',
+    current: 'specs',
+    body: content,
+  });
 }
 
 function buildIndexPage(entries) {
   const listHtml = entries
-    .map((e) => `<li><a href="${e.slug}.html"><strong>${escapeHtml(e.title)}</strong></a><br/><span style="color:#888;font-size:.75rem">${escapeHtml(e.description)}</span></li>`)
+    .map(
+      (e) =>
+        `<li><a href="${e.slug}.html"><strong>${escapeHtml(e.title)}</strong><span class="spec-list__desc">${escapeHtml(e.description)}</span></a></li>`,
+    )
     .join('\n');
 
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>TiltCheck Specs - GitHub Pages</title><meta name="description" content="TiltCheck ecosystem specifications and architecture docs"/><meta name="viewport" content="width=device-width, initial-scale=1"/><link rel="stylesheet" href="/styles/base.css"/><style>body{background:#0a0a0a;color:#e0e0e0;font-family:Inter,system-ui,sans-serif;margin:0}main{max-width:900px;margin:0 auto;padding:44px 20px;line-height:1.6}a{color:#00d4aa;text-decoration:none}a:hover{text-decoration:underline}h1{font-size:2.4rem;margin:0 0 22px;background:linear-gradient(135deg,#00d4aa,#00a8ff);-webkit-background-clip:text;color:transparent}ul{list-style:disc;padding-left:22px}nav{display:flex;gap:20px;align-items:center;font-size:.8rem;padding:10px 20px;background:#111;border-bottom:1px solid #222}nav a{color:#aaa}nav a[aria-current='page']{color:#00d4aa;font-weight:600}</style></head><body><nav><a href="https://tiltcheck.me">tiltcheck.me</a><a href="/docs/index.html" aria-current="page">Specs</a><a href="https://tiltcheck.me/docs">Live Docs</a></nav><main><h1>TiltCheck Specs</h1><p style="color:#aaa;font-size:1.05rem;max-width:760px">Ecosystem specifications mirrored from <code>docs/tiltcheck/</code>. Production docs live at <a href="https://tiltcheck.me/docs">tiltcheck.me/docs</a>.</p><ul>${listHtml}</ul></main><footer style="padding:40px 24px;text-align:center;font-size:.75rem;color:#666;border-top:1px solid #222">${FOOTER} // ${COPYRIGHT}</footer></body></html>`;
+  const content = `<header class="doc-hero"><div class="doc-hero__inner">
+<p class="doc-hero__crumb">TiltCheck / Specs</p>
+<h1>Ecosystem specs</h1>
+<p class="lede">Static mirror of <code>docs/tiltcheck/</code>. Production product lives at <a href="${SITE_URL}">tiltcheck.me</a>.</p>
+</div></header>
+<main class="doc-main">
+<ul class="spec-list">${listHtml}</ul>
+</main>`;
+
+  return shell({
+    title: 'TiltCheck Specs',
+    description: 'TiltCheck ecosystem specifications and architecture docs',
+    depth: 'docs',
+    current: 'specs',
+    body: content,
+  });
 }
 
-function buildRootRedirect() {
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><meta http-equiv="refresh" content="0;url=/docs/index.html"/><title>TiltCheck Specs</title><meta name="viewport" content="width=device-width, initial-scale=1"/></head><body style="background:#0a0a0a;color:#e0e0e0;font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh"><p>Redirecting to <a href="/docs/index.html" style="color:#00d4aa">TiltCheck specs</a>...</p></body></html>`;
+function buildRootLanding(entries) {
+  const listHtml = entries
+    .slice(0, 12)
+    .map(
+      (e) =>
+        `<li><a href="docs/${e.slug}.html"><strong>${escapeHtml(e.title)}</strong><span class="spec-list__desc">${escapeHtml(e.description)}</span></a></li>`,
+    )
+    .join('\n');
+
+  const moreLink =
+    entries.length > 12
+      ? `<p class="section__lede" style="margin-top:1.25rem"><a href="docs/index.html">See all ${entries.length} specs →</a></p>`
+      : `<p class="section__lede" style="margin-top:1.25rem"><a href="docs/index.html">Browse all specs →</a></p>`;
+
+  const content = `<section class="landing-hero" aria-label="TiltCheck">
+  <div class="landing-hero__inner">
+    <p class="brand-wordmark">Tilt<span>Check</span></p>
+    <h1 class="landing-hero__headline">${escapeHtml(SITE_HERO_HEADLINE)}</h1>
+    <p class="landing-hero__lede">${escapeHtml(SITE_ONE_LINER)}</p>
+    <div class="hero-actions">
+      <a class="btn btn-primary" href="${SITE_URL}">Open tiltcheck.me</a>
+      <a class="btn btn-ghost" href="${DISCORD_URL}" rel="noopener noreferrer">Join Discord</a>
+      <a class="btn btn-ghost" href="${KOFI_URL}" rel="noopener noreferrer">Support on Ko-fi</a>
+    </div>
+  </div>
+</section>
+<section class="section section--specs" id="specs" aria-label="Specs">
+  <div class="section__inner">
+    <span class="section__eyebrow">Docs mirror</span>
+    <h2 class="section__title">Specs without Railway</h2>
+    <p class="section__lede">Same brand chrome. Static HTML from the monorepo — share this link when the app host is down or you just need architecture notes.</p>
+    <ul class="spec-list">${listHtml}</ul>
+    ${moreLink}
+  </div>
+</section>`;
+
+  return shell({
+    title: 'TiltCheck | Specs Mirror',
+    description: SITE_ONE_LINER,
+    depth: 'root',
+    current: 'home',
+    body: content,
+  });
 }
 
 function run() {
@@ -176,7 +311,7 @@ function run() {
   }
 
   fs.writeFileSync(path.join(outRoot, 'index.html'), buildIndexPage(indexEntries));
-  fs.writeFileSync(path.join(siteRoot, 'index.html'), buildRootRedirect());
+  fs.writeFileSync(path.join(siteRoot, 'index.html'), buildRootLanding(indexEntries));
   fs.writeFileSync(path.join(siteRoot, '.nojekyll'), '');
 
   console.log(`Converted ${files.length} markdown files to HTML in ${outRoot}`);

--- a/scripts/convert-markdown.js
+++ b/scripts/convert-markdown.js
@@ -133,7 +133,11 @@ function extractMeta(md) {
     if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('<!--')) continue;
     if (/^©|^Copyright\b|^All Rights Reserved/i.test(trimmed)) continue;
     if (/^Last Updated:/i.test(trimmed)) continue;
-    description = trimmed;
+    description = trimmed
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/(^|[^*])\*([^*]+)\*(?!\*)/g, '$1$2')
+      .replace(/`([^`]+)`/g, '$1')
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
     break;
   }
   return { title: title || 'Untitled', description: description.slice(0, 180) };

--- a/scripts/pages-assets/styles/base.css
+++ b/scripts/pages-assets/styles/base.css
@@ -1,8 +1,36 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18 */
+/*
+ * GitHub Pages shell — mirrors tiltcheck.me brand tokens (obsidian + teal).
+ * Absolute /paths break on project Pages; HTML uses relative asset hrefs.
+ */
+
 *,
 *::before,
 *::after {
   box-sizing: border-box;
+}
+
+:root {
+  --color-primary: #17c3b2;
+  --color-primary-dark: #129d8f;
+  --color-primary-light: #48d5c6;
+  --color-gold: #ffd700;
+  --bg-primary: #06080b;
+  --bg-secondary: #08090e;
+  --bg-tertiary: #0d1017;
+  --bg-elevated: #0f1219;
+  --text-primary: #ffffff;
+  --text-secondary: #c4ced8;
+  --text-muted: #8a97a8;
+  --text-disabled: #4b5563;
+  --border-subtle: #1e2533;
+  --border-default: #283347;
+  --border-glow: rgba(23, 195, 178, 0.15);
+  --font-sans: "Inter", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
+  --transition-base: 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  --shell-max: 48rem;
+  --content-max: 56rem;
 }
 
 html {
@@ -11,6 +39,15 @@ html {
 
 body {
   margin: 0;
+  min-height: 100vh;
+  color: var(--text-primary);
+  background:
+    radial-gradient(ellipse 90% 55% at 50% -10%, rgba(23, 195, 178, 0.12), transparent 55%),
+    radial-gradient(ellipse 50% 40% at 100% 0%, rgba(23, 195, 178, 0.05), transparent 45%),
+    linear-gradient(180deg, #06080b 0%, #0a0c10 45%, #08090e 100%);
+  font-family: var(--font-sans);
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
 }
 
 img {
@@ -18,19 +55,477 @@ img {
   height: auto;
 }
 
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: color var(--transition-base);
+}
+
+a:hover {
+  color: var(--color-primary-light);
+}
+
+/* --- Top nav --- */
+.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem 1.25rem;
+  padding: 0.75rem 1.25rem;
+  min-height: 56px;
+  background: rgba(10, 12, 16, 0.88);
+  border-bottom: 1px solid rgba(23, 195, 178, 0.12);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+.site-nav__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.site-nav__brand:hover {
+  color: var(--text-primary);
+  opacity: 0.9;
+}
+
+.site-nav__mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 1px solid rgba(23, 195, 178, 0.35);
+  background: rgba(23, 195, 178, 0.08);
+  color: var(--color-primary);
+  font-size: 0.65rem;
+  font-weight: 900;
+}
+
+.site-nav__links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 1rem;
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.site-nav__links a {
+  color: var(--text-muted);
+}
+
+.site-nav__links a:hover,
+.site-nav__links a[aria-current="page"] {
+  color: var(--color-primary);
+}
+
+/* --- Landing hero --- */
+.landing-hero {
+  position: relative;
+  min-height: calc(100vh - 56px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(3rem, 8vw, 5.5rem) 1.25rem clamp(2.5rem, 6vw, 4rem);
+  text-align: center;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.landing-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(180deg, transparent 60%, rgba(6, 8, 11, 0.85) 100%),
+    repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 2px,
+      rgba(255, 255, 255, 0.012) 2px,
+      rgba(255, 255, 255, 0.012) 3px
+    );
+  pointer-events: none;
+  animation: grain-drift 18s linear infinite;
+}
+
+.landing-hero__inner {
+  position: relative;
+  z-index: 1;
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  animation: rise-in 0.75s ease-out both;
+}
+
+.brand-wordmark {
+  margin: 0 0 1.25rem;
+  font-family: var(--font-mono);
+  font-size: clamp(1.65rem, 4vw, 2.35rem);
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+}
+
+.brand-wordmark span {
+  color: var(--color-primary);
+}
+
+.landing-hero__headline {
+  margin: 0 auto;
+  max-width: 16ch;
+  font-size: clamp(2rem, 6vw, 3.35rem);
+  font-weight: 900;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+  color: var(--text-primary);
+  animation: rise-in 0.85s ease-out 0.08s both;
+}
+
+.landing-hero__lede {
+  margin: 1.25rem auto 0;
+  max-width: 36rem;
+  font-size: clamp(1rem, 1rem + 0.2vw, 1.125rem);
+  line-height: 1.7;
+  color: #b5c1cd;
+  letter-spacing: -0.01em;
+  animation: rise-in 0.9s ease-out 0.16s both;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem 1rem;
+  margin-top: 2rem;
+  animation: rise-in 0.95s ease-out 0.24s both;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.35rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  transition:
+    background var(--transition-base),
+    border-color var(--transition-base),
+    color var(--transition-base),
+    transform var(--transition-base);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: #061012;
+  border-color: var(--color-primary);
+}
+
+.btn-primary:hover {
+  background: var(--color-primary-light);
+  color: #061012;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-default);
+}
+
+.btn-ghost:hover {
+  color: var(--text-primary);
+  border-color: rgba(23, 195, 178, 0.45);
+}
+
+/* --- Specs / content sections --- */
+.section {
+  padding: clamp(2.5rem, 5vw, 4rem) 1.25rem;
+}
+
+.section--specs {
+  border-top: 1px solid var(--border-subtle);
+  background: linear-gradient(180deg, rgba(13, 16, 23, 0.55), transparent 40%);
+}
+
+.section__inner {
+  max-width: var(--content-max);
+  margin: 0 auto;
+}
+
+.section__eyebrow {
+  display: block;
+  margin-bottom: 0.65rem;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+}
+
+.section__title {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.4rem, 3vw, 1.85rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.section__lede {
+  margin: 0 0 1.75rem;
+  max-width: 40rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.spec-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.spec-list li {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.spec-list a {
+  display: block;
+  padding: 1rem 0.15rem;
+  color: var(--text-primary);
+  transition: color var(--transition-base), padding-left var(--transition-base);
+}
+
+.spec-list a:hover {
+  color: var(--color-primary);
+  padding-left: 0.35rem;
+}
+
+.spec-list strong {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.spec-list .spec-list__desc {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+/* --- Doc pages --- */
+.doc-hero {
+  padding: clamp(2rem, 5vw, 3.25rem) 1.25rem 1.75rem;
+  border-bottom: 1px solid var(--border-default);
+  background: linear-gradient(180deg, rgba(23, 195, 178, 0.06), transparent 70%);
+}
+
+.doc-hero__inner {
+  max-width: var(--content-max);
+  margin: 0 auto;
+}
+
+.doc-hero__crumb {
+  margin: 0 0 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.doc-hero h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.75rem, 4vw, 2.4rem);
+  font-weight: 900;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+}
+
+.doc-hero .lede {
+  margin: 0;
+  max-width: 40rem;
+  color: var(--text-secondary);
+  font-size: 1.02rem;
+}
+
+.doc-main {
+  max-width: var(--content-max);
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3.5rem;
+}
+
+.doc-main h2,
+.doc-main h3,
+.doc-main h4 {
+  margin-top: 2rem;
+  margin-bottom: 0.65rem;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+}
+
+.doc-main h2 {
+  font-size: 1.45rem;
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: 0.4rem;
+}
+
+.doc-main h3 {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+}
+
+.doc-main p {
+  color: var(--text-secondary);
+}
+
+.doc-main ul {
+  padding-left: 1.25rem;
+  color: var(--text-secondary);
+}
+
+.doc-main li + li {
+  margin-top: 0.35rem;
+}
+
+.doc-main code,
+.code-block code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--color-primary-light);
+}
+
+.doc-main :not(pre) > code {
+  padding: 0.12em 0.35em;
+  background: rgba(23, 195, 178, 0.08);
+  border: 1px solid rgba(23, 195, 178, 0.18);
+}
+
+pre.code-block,
+.doc-main pre {
+  margin: 1.1rem 0;
+  padding: 0.95rem 1.05rem;
+  overflow: auto;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-default);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
   margin: 1rem 0;
+  font-size: 0.9rem;
 }
 
 th,
 td {
-  border: 1px solid #222;
+  border: 1px solid var(--border-default);
   padding: 0.5rem 0.75rem;
   text-align: left;
 }
 
 th {
-  background: #111;
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+td {
+  color: var(--text-secondary);
+}
+
+/* --- Footer --- */
+.site-footer {
+  padding: 2.25rem 1.25rem 2.75rem;
+  text-align: center;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-disabled);
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+}
+
+.site-footer__tag {
+  display: block;
+  margin-bottom: 0.45rem;
+  color: var(--text-muted);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+@keyframes rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes grain-drift {
+  from {
+    background-position: 0 0, 0 0;
+  }
+  to {
+    background-position: 0 0, 0 120px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+@media (max-width: 640px) {
+  .site-nav {
+    padding: 0.7rem 1rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .btn {
+    width: 100%;
+  }
 }

--- a/scripts/pages-assets/styles/base.css
+++ b/scripts/pages-assets/styles/base.css
@@ -1,6 +1,6 @@
 /* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18 */
 /*
- * GitHub Pages shell — mirrors tiltcheck.me brand tokens (obsidian + teal).
+ * GitHub Pages shell — static twin of tiltcheck.me landing tokens/layout.
  * Absolute /paths break on project Pages; HTML uses relative asset hrefs.
  */
 
@@ -14,7 +14,6 @@
   --color-primary: #17c3b2;
   --color-primary-dark: #129d8f;
   --color-primary-light: #48d5c6;
-  --color-gold: #ffd700;
   --bg-primary: #06080b;
   --bg-secondary: #08090e;
   --bg-tertiary: #0d1017;
@@ -25,12 +24,13 @@
   --text-disabled: #4b5563;
   --border-subtle: #1e2533;
   --border-default: #283347;
-  --border-glow: rgba(23, 195, 178, 0.15);
   --font-sans: "Inter", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-mono: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
   --transition-base: 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  --weight-bold: 900;
+  --radius-md: 0px;
   --shell-max: 48rem;
-  --content-max: 56rem;
+  --content-max: min(100% - 2rem, 78rem);
 }
 
 html {
@@ -42,12 +42,13 @@ body {
   min-height: 100vh;
   color: var(--text-primary);
   background:
-    radial-gradient(ellipse 90% 55% at 50% -10%, rgba(23, 195, 178, 0.12), transparent 55%),
-    radial-gradient(ellipse 50% 40% at 100% 0%, rgba(23, 195, 178, 0.05), transparent 45%),
-    linear-gradient(180deg, #06080b 0%, #0a0c10 45%, #08090e 100%);
+    radial-gradient(ellipse 100% 70% at 50% -20%, rgba(23, 195, 178, 0.14), transparent 55%),
+    radial-gradient(ellipse 40% 35% at 90% 10%, rgba(23, 195, 178, 0.06), transparent 50%),
+    linear-gradient(180deg, #06080b 0%, #0a0c10 40%, #08090e 100%);
   font-family: var(--font-sans);
   line-height: 1.65;
   -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
 }
 
 img {
@@ -65,7 +66,7 @@ a:hover {
   color: var(--color-primary-light);
 }
 
-/* --- Top nav --- */
+/* --- Product nav --- */
 .site-nav {
   position: sticky;
   top: 0;
@@ -117,10 +118,10 @@ a:hover {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.35rem 1rem;
-  font-size: 0.75rem;
+  gap: 0.35rem 1.1rem;
+  font-size: 0.72rem;
   font-family: var(--font-mono);
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
@@ -133,8 +134,20 @@ a:hover {
   color: var(--color-primary);
 }
 
-/* --- Landing hero --- */
-.landing-hero {
+/* --- Landing page (web twin) --- */
+.landing-page {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(3.5rem, 7vw, 6rem);
+  padding: 0 0 clamp(3rem, 6vw, 5rem);
+}
+
+.landing-shell {
+  width: var(--content-max);
+  margin: 0 auto;
+}
+
+.hero-surface {
   position: relative;
   min-height: calc(100vh - 56px);
   display: flex;
@@ -146,12 +159,12 @@ a:hover {
   border-bottom: 1px solid var(--border-default);
 }
 
-.landing-hero::before {
+.hero-surface::before {
   content: "";
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(180deg, transparent 60%, rgba(6, 8, 11, 0.85) 100%),
+    linear-gradient(180deg, transparent 55%, rgba(6, 8, 11, 0.9) 100%),
     repeating-linear-gradient(
       0deg,
       transparent,
@@ -163,20 +176,24 @@ a:hover {
   animation: grain-drift 18s linear infinite;
 }
 
-.landing-hero__inner {
+.landing-hero-centered {
   position: relative;
   z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
   max-width: var(--shell-max);
   margin: 0 auto;
   animation: rise-in 0.75s ease-out both;
 }
 
 .brand-wordmark {
-  margin: 0 0 1.25rem;
+  margin: 0 0 1.1rem;
   font-family: var(--font-mono);
-  font-size: clamp(1.65rem, 4vw, 2.35rem);
+  font-size: clamp(1.35rem, 3.2vw, 1.85rem);
   font-weight: 900;
-  letter-spacing: 0.22em;
+  letter-spacing: 0.28em;
   text-transform: uppercase;
   color: var(--text-primary);
 }
@@ -185,25 +202,58 @@ a:hover {
   color: var(--color-primary);
 }
 
-.landing-hero__headline {
-  margin: 0 auto;
-  max-width: 16ch;
-  font-size: clamp(2rem, 6vw, 3.35rem);
+.brand-eyebrow {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: var(--color-primary);
+  border: 1px solid rgba(23, 195, 178, 0.4);
+  padding: 0.25rem 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.landing-hero-title {
+  margin: 0;
+  max-width: 14ch;
+  font-size: clamp(2.6rem, 7.5vw, 5.4rem);
   font-weight: 900;
-  letter-spacing: -0.03em;
-  line-height: 1.05;
-  color: var(--text-primary);
+  line-height: 0.96;
+  letter-spacing: -0.045em;
+  color: #f6fbff;
+  text-transform: uppercase;
+  text-wrap: balance;
+  -webkit-text-stroke: 1px rgba(0, 0, 0, 0.95);
+  paint-order: stroke fill;
+  text-shadow:
+    -1px -1px 0 rgba(0, 0, 0, 0.95),
+    1px -1px 0 rgba(0, 0, 0, 0.95),
+    -1px 1px 0 rgba(0, 0, 0, 0.95),
+    1px 1px 0 rgba(0, 0, 0, 0.95),
+    0 6px 18px rgba(0, 0, 0, 0.28);
   animation: rise-in 0.85s ease-out 0.08s both;
 }
 
-.landing-hero__lede {
-  margin: 1.25rem auto 0;
-  max-width: 36rem;
-  font-size: clamp(1rem, 1rem + 0.2vw, 1.125rem);
-  line-height: 1.7;
+.landing-hero-title--centered {
+  text-align: center;
+}
+
+.landing-hero-subtitle {
+  margin: 1.35rem 0 0;
+  max-width: 38rem;
+  font-size: clamp(1.02rem, 1rem + 0.25vw, 1.2rem);
+  line-height: 1.72;
   color: #b5c1cd;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.012em;
   animation: rise-in 0.9s ease-out 0.16s both;
+}
+
+.landing-hero-subtitle--centered {
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .hero-actions {
@@ -211,135 +261,176 @@ a:hover {
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem 1rem;
+  gap: 1rem 1.25rem;
   margin-top: 2rem;
   animation: rise-in 0.95s ease-out 0.24s both;
 }
 
 .btn {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.85rem 1.35rem;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0.75rem 1.5rem;
   font-family: var(--font-mono);
-  font-size: 0.7rem;
-  font-weight: 800;
-  letter-spacing: 0.14em;
+  font-size: 0.72rem;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  border: 1px solid transparent;
-  transition:
-    background var(--transition-base),
-    border-color var(--transition-base),
-    color var(--transition-base),
-    transform var(--transition-base);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  touch-action: manipulation;
 }
 
 .btn:hover {
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  filter: brightness(1.12);
+  box-shadow:
+    0 0 25px rgba(23, 195, 178, 0.4),
+    0 0 5px rgba(23, 195, 178, 0.2);
 }
 
 .btn-primary {
-  background: var(--color-primary);
-  color: #061012;
-  border-color: var(--color-primary);
+  background-color: var(--color-primary);
+  color: #000;
 }
 
 .btn-primary:hover {
-  background: var(--color-primary-light);
-  color: #061012;
+  color: #000;
 }
 
-.btn-ghost {
-  background: transparent;
+.hero-actions__secondary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
   color: var(--text-secondary);
-  border-color: var(--border-default);
-}
-
-.btn-ghost:hover {
-  color: var(--text-primary);
-  border-color: rgba(23, 195, 178, 0.45);
-}
-
-/* --- Specs / content sections --- */
-.section {
-  padding: clamp(2.5rem, 5vw, 4rem) 1.25rem;
-}
-
-.section--specs {
-  border-top: 1px solid var(--border-subtle);
-  background: linear-gradient(180deg, rgba(13, 16, 23, 0.55), transparent 40%);
-}
-
-.section__inner {
-  max-width: var(--content-max);
-  margin: 0 auto;
-}
-
-.section__eyebrow {
-  display: block;
-  margin-bottom: 0.65rem;
   font-family: var(--font-mono);
-  font-size: 0.68rem;
-  font-weight: 800;
-  letter-spacing: 0.18em;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  transition: color 0.2s ease;
+}
+
+.hero-actions__secondary-link:hover {
+  color: var(--color-primary);
+}
+
+/* --- Sections --- */
+.public-page-section {
+  padding: 0 1.25rem;
+}
+
+.public-page-section-heading {
+  margin-bottom: 1.5rem;
+}
+
+.public-page-section-heading__title {
+  margin: 0.75rem 0 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 900;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  text-transform: uppercase;
+  color: #f5fbff;
+  -webkit-text-stroke: 1px rgba(0, 0, 0, 0.95);
+  paint-order: stroke fill;
+  text-shadow:
+    -1px -1px 0 rgba(0, 0, 0, 0.95),
+    1px -1px 0 rgba(0, 0, 0, 0.95),
+    -1px 1px 0 rgba(0, 0, 0, 0.95),
+    1px 1px 0 rgba(0, 0, 0, 0.95),
+    0 6px 18px rgba(0, 0, 0, 0.28);
+}
+
+.public-page-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.public-page-grid--3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.public-page-card {
+  padding: 1.2rem 1.25rem;
+  border: 1px solid rgba(23, 195, 178, 0.15);
+  border-radius: 1.35rem;
+  background: rgba(10, 14, 19, 0.55);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow:
+    0 8px 32px 0 rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.public-page-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(23, 195, 178, 0.4);
+  box-shadow:
+    0 12px 40px 0 rgba(23, 195, 178, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.public-page-card__eyebrow {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--color-primary);
 }
 
-.section__title {
-  margin: 0 0 0.75rem;
-  font-size: clamp(1.4rem, 3vw, 1.85rem);
+.public-page-card__title {
+  margin: 0.7rem 0 0;
+  font-size: 1.2rem;
   font-weight: 800;
+  line-height: 1.15;
   letter-spacing: -0.02em;
+  text-transform: uppercase;
+  color: #f5fbff;
 }
 
-.section__lede {
-  margin: 0 0 1.75rem;
-  max-width: 40rem;
-  color: var(--text-muted);
+.public-page-card__copy {
+  margin: 0.75rem 0 0;
+  color: #b0bcc9;
   font-size: 0.95rem;
+  line-height: 1.65;
 }
 
-.spec-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  border-top: 1px solid var(--border-subtle);
+.public-page-card__copy--list {
+  padding-left: 1.15rem;
+  text-align: left;
 }
 
-.spec-list li {
-  border-bottom: 1px solid var(--border-subtle);
+.public-page-card__copy--list li + li {
+  margin-top: 0.45rem;
 }
 
-.spec-list a {
-  display: block;
-  padding: 1rem 0.15rem;
-  color: var(--text-primary);
-  transition: color var(--transition-base), padding-left var(--transition-base);
+.rg-disclaimer {
+  text-align: center;
+  font-size: 0.75rem;
+  color: #6b7a8d;
+  line-height: 1.6;
 }
 
-.spec-list a:hover {
+.rg-disclaimer a {
   color: var(--color-primary);
-  padding-left: 0.35rem;
 }
 
-.spec-list strong {
-  display: block;
-  font-size: 0.95rem;
+.rg-disclaimer strong {
+  color: #fff;
   font-weight: 700;
-  letter-spacing: -0.01em;
 }
 
-.spec-list .spec-list__desc {
-  display: block;
-  margin-top: 0.25rem;
-  color: var(--text-muted);
-  font-size: 0.8rem;
-  font-weight: 400;
-  line-height: 1.5;
-}
-
-/* --- Doc pages --- */
+/* --- Doc pages (secondary) --- */
 .doc-hero {
   padding: clamp(2rem, 5vw, 3.25rem) 1.25rem 1.75rem;
   border-bottom: 1px solid var(--border-default);
@@ -347,7 +438,7 @@ a:hover {
 }
 
 .doc-hero__inner {
-  max-width: var(--content-max);
+  max-width: 56rem;
   margin: 0 auto;
 }
 
@@ -377,7 +468,7 @@ a:hover {
 }
 
 .doc-main {
-  max-width: var(--content-max);
+  max-width: 56rem;
   margin: 0 auto;
   padding: 2rem 1.25rem 3.5rem;
 }
@@ -402,13 +493,13 @@ a:hover {
   color: var(--text-secondary);
 }
 
-.doc-main p {
+.doc-main p,
+.doc-main ul {
   color: var(--text-secondary);
 }
 
 .doc-main ul {
   padding-left: 1.25rem;
-  color: var(--text-secondary);
 }
 
 .doc-main li + li {
@@ -437,6 +528,44 @@ pre.code-block,
   border: 1px solid var(--border-default);
   font-size: 0.82rem;
   line-height: 1.55;
+}
+
+.spec-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.spec-list li {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.spec-list a {
+  display: block;
+  padding: 1rem 0.15rem;
+  color: var(--text-primary);
+  transition: color var(--transition-base), padding-left var(--transition-base);
+}
+
+.spec-list a:hover {
+  color: var(--color-primary);
+  padding-left: 0.35rem;
+}
+
+.spec-list strong {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.spec-list .spec-list__desc {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-weight: 400;
+  line-height: 1.5;
 }
 
 table {
@@ -486,6 +615,25 @@ td {
   text-transform: uppercase;
 }
 
+.site-footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem 1.25rem;
+  margin: 0.85rem 0 0.5rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.site-footer__links a {
+  color: var(--text-muted);
+}
+
+.site-footer__links a:hover {
+  color: var(--color-primary);
+}
+
 @keyframes rise-in {
   from {
     opacity: 0;
@@ -515,6 +663,12 @@ td {
   }
 }
 
+@media (max-width: 900px) {
+  .public-page-grid--3 {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 640px) {
   .site-nav {
     padding: 0.7rem 1rem;
@@ -522,10 +676,12 @@ td {
 
   .hero-actions {
     flex-direction: column;
+    align-items: stretch;
     width: 100%;
   }
 
-  .btn {
+  .btn,
+  .hero-actions__secondary-link {
     width: 100%;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem and motivation

The Railway-free Pages URL read like a docs site. Need a shareable link that looks like tiltcheck.me — product landing first — especially when Railway is down.

## Why this approach

Hand-built static HTML/CSS twin of `apps/web` home (Approach A). No Next export, no fake app routes. CTAs leave to live `tiltcheck.me`. Specs stay under `/docs` only.

## Scope of changes

- `scripts/convert-markdown.js` — product root landing; locked hero `House always wins? FUCK THAT.`; extension/casinos/operators CTAs
- `scripts/pages-assets/styles/base.css` — landing twin chrome (obsidian + `#17c3b2`)
- `docs/superpowers/specs/2026-07-18-pages-site-clone-design.md` — design
- `docs/superpowers/plans/2026-07-18-pages-site-clone.md` — plan
- `docs/GITHUB-PAGES-TROUBLESHOOTING.md` — path table updated

## Risk areas and mitigations

- **Static only:** interactive product still requires tiltcheck.me/API — intentional
- **Visual drift from Next.js CSS:** ported landing-critical rules, not all of `globals.css`
- **Deploy:** merges trigger `.github/workflows/pages.yml`; rollback = revert PR

## Test and manual verification plan

- [x] `pnpm docs:pages` builds
- [x] Root has locked hero + product CTAs; no “Docs mirror” / specs in hero
- [x] Relative CSS paths (no `href="/styles/..."`)
- [x] Local preview reads as product site (hero / three jobs / operators)
- [ ] After merge: Actions deploy + live https://tiltcheck-me.github.io/tiltcheck-monorepo/
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7216-c040-7f6e-999c-175909090c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7216-c040-7f6e-999c-175909090c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

