### PR TITLE
feat(pages): casinos, tools, extension, operators product pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-17
+# © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
 name: Deploy GitHub Pages Specs
 
 on:
@@ -7,7 +7,9 @@ on:
     paths:
       - 'docs/tiltcheck/**'
       - 'scripts/convert-markdown.js'
+      - 'scripts/pages-product-data.mjs'
       - 'scripts/pages-assets/**'
+      - 'apps/web/src/data/casinos.json'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 

--- a/docs/GITHUB-PAGES-TROUBLESHOOTING.md
+++ b/docs/GITHUB-PAGES-TROUBLESHOOTING.md
@@ -1,6 +1,7 @@
 # GitHub Pages Troubleshooting Guide
 
 <!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18 -->
+<!-- Product pages: extension, casinos, tools, operators + home tools/features section -->
 
 ## What GitHub Pages hosts now
 
@@ -10,8 +11,12 @@ GitHub Pages (`gh-pages` branch) is a **static product twin** of tiltcheck.me �
 
 | Path on Pages | Source |
 |---------------|--------|
-| `/` | Product landing clone (hero: `House always wins? FUCK THAT.`; CTAs → live `tiltcheck.me/extension` + `/casinos`) |
-| `/docs/*.html` | Specs secondary surface from `node scripts/convert-markdown.js` |
+| `/` | Product landing (hero + three jobs + tools/features + operators) |
+| `/extension.html` | Extension install twin |
+| `/casinos.html` | Curated casino directory from `apps/web/src/data/casinos.json` (search/filter) |
+| `/tools.html` | Toolkit catalog (links to live interactive tools) |
+| `/operators.html` | RGaaS marketing shell (key form stays on live site) |
+| `/docs/*.html` | Specs secondary surface |
 | `/styles/base.css` | `scripts/pages-assets/styles/base.css` |
 | `/docs-md/*.md` | Raw markdown from `docs/tiltcheck/` |
 

--- a/scripts/convert-markdown.js
+++ b/scripts/convert-markdown.js
@@ -2,57 +2,43 @@
 /**
  * © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
  *
- * Lightweight Markdown → HTML converter for TiltCheck docs / GitHub Pages.
- * Root `/` is a static product twin of tiltcheck.me. Specs live under `/docs`.
+ * GitHub Pages site builder for TiltCheck.
+ * - `/` product landing twin
+ * - `/extension|casinos|tools|operators.html` product pages
+ * - `/docs/*` specs from markdown
  *
- * Project Pages (github.io/<repo>/) require relative asset paths — never "/styles/...".
+ * Project Pages require relative asset paths — never "/styles/...".
  *
  * Usage:
  *   node scripts/convert-markdown.js [sourceDir] [outDir]
- * Defaults:
- *   sourceDir = docs/tiltcheck
- *   outDir = out/docs
  */
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  SITE_URL,
+  DISCORD_URL,
+  KOFI_URL,
+  EXTENSION_ZIP_URL,
+  SITE_HERO_HEADLINE,
+  SITE_ONE_LINER,
+  CORE_JOBS,
+  FEATURE_CARDS,
+  EXTENSION_SIGNALS,
+  OPERATOR_BULLETS,
+  OPERATOR_BENEFITS,
+  GRADING_STEPS,
+  TOOL_REGISTRY,
+  INSTALL_SURFACES,
+} from './pages-product-data.mjs';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
 const sourceRoot = path.resolve(process.argv[2] || 'docs/tiltcheck');
 const outRoot = path.resolve(process.argv[3] || 'out/docs');
 const FOOTER = 'Made for Degens. By Degens.';
 const COPYRIGHT = '© 2024–2026 TiltCheck Ecosystem. All Rights Reserved.';
-const SITE_URL = 'https://tiltcheck.me';
-const EXTENSION_URL = `${SITE_URL}/extension`;
-const CASINOS_URL = `${SITE_URL}/casinos`;
-const OPERATORS_URL = `${SITE_URL}/operators`;
-const DISCORD_URL = 'https://discord.gg/gdBsEJfCar';
-const KOFI_URL = 'https://ko-fi.com/jmenichole0';
-const SITE_HERO_HEADLINE = 'House always wins? FUCK THAT.';
-const SITE_ONE_LINER =
-  'Read-only browser guardrail. Watches pacing and tilt in real time — pulls you out before you rug yourself.';
-
-const CORE_JOBS = [
-  {
-    step: '01',
-    title: 'Kill the Auto-Pilot',
-    description: 'Tracks click-speed and bet pacing. Wakes you up when you play like a bot.',
-  },
-  {
-    step: '02',
-    title: 'Read the Room',
-    description: 'Flags sus pacing and pressure loops while you are still in the session.',
-  },
-  {
-    step: '03',
-    title: 'Enforce the Exit',
-    description: 'Set your line. We enforce it — not passive warnings.',
-  },
-];
-
-const OPERATOR_BULLETS = [
-  'Trust scoring as a service — non-affiliated, evidence-backed.',
-  'RGaaS API for session guardrails without custodial flows.',
-  'Sandbox access for operators who want tilt signals, not affiliate spam.',
-];
+const CASINOS_JSON = path.join(repoRoot, 'apps/web/src/data/casinos.json');
 
 const FONT_LINKS = `<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&family=JetBrains+Mono:wght@500;700;800&display=swap" rel="stylesheet"/>`;
 
@@ -66,7 +52,7 @@ function slugify(name) {
 }
 
 function escapeHtml(str) {
-  return str.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+  return String(str).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
 
 function stripFrontmatter(md) {
@@ -176,37 +162,53 @@ function assetHref(depth, file) {
   return depth === 'root' ? `styles/${file}` : `../styles/${file}`;
 }
 
-/** @param {'root' | 'docs'} depth @param {'home' | 'specs'} current */
+/** @param {'root' | 'docs'} depth */
+function href(depth, file) {
+  return depth === 'root' ? file : `../${file}`;
+}
+
+/** @param {'root' | 'docs'} depth @param {string} current */
 function navHtml(depth, current) {
-  const home = depth === 'root' ? 'index.html' : '../index.html';
-  const specs = depth === 'root' ? 'docs/index.html' : 'index.html';
-  const homeCurrent = current === 'home' ? ' aria-current="page"' : '';
-  const specsCurrent = current === 'specs' ? ' aria-current="page"' : '';
+  const links = [
+    { id: 'extension', file: 'extension.html', label: 'Extension' },
+    { id: 'casinos', file: 'casinos.html', label: 'Casinos' },
+    { id: 'tools', file: 'tools.html', label: 'Tools' },
+    { id: 'operators', file: 'operators.html', label: 'Operators' },
+    { id: 'specs', file: null, label: 'Specs' },
+  ];
+
+  const linkHtml = links
+    .map((l) => {
+      const resolved =
+        l.id === 'specs' ? (depth === 'root' ? 'docs/index.html' : 'index.html') : href(depth, l.file);
+      const cur = current === l.id ? ' aria-current="page"' : '';
+      return `<a href="${resolved}"${cur}>${l.label}</a>`;
+    })
+    .join('\n    ');
+
   return `<nav class="site-nav" aria-label="Primary">
-  <a class="site-nav__brand" href="${home}"${homeCurrent}><span class="site-nav__mark" aria-hidden="true">TC</span>TiltCheck</a>
+  <a class="site-nav__brand" href="${href(depth, 'index.html')}"${current === 'home' ? ' aria-current="page"' : ''}><span class="site-nav__mark" aria-hidden="true">TC</span>TiltCheck</a>
   <div class="site-nav__links">
-    <a href="${EXTENSION_URL}">Extension</a>
-    <a href="${CASINOS_URL}">Casinos</a>
+    ${linkHtml}
     <a href="${DISCORD_URL}" rel="noopener noreferrer">Discord</a>
-    <a href="${specs}"${specsCurrent}>Specs</a>
   </div>
 </nav>`;
 }
 
 function footerHtml(depth) {
-  const specs = depth === 'root' ? 'docs/index.html' : 'index.html';
   return `<footer class="site-footer">
   <span class="site-footer__tag">${FOOTER}</span>
   <div class="site-footer__links">
     <a href="${SITE_URL}">tiltcheck.me</a>
-    <a href="${specs}">Specs</a>
+    <a href="${href(depth, 'tools.html')}">Tools</a>
+    <a href="${depth === 'root' ? 'docs/index.html' : 'index.html'}">Specs</a>
     <a href="${KOFI_URL}" rel="noopener noreferrer">Support</a>
   </div>
   ${COPYRIGHT}
 </footer>`;
 }
 
-function shell({ title, description, depth, current, body }) {
+function shell({ title, description, depth, current, body, extraHead = '' }) {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -217,6 +219,7 @@ function shell({ title, description, depth, current, body }) {
 <meta name="theme-color" content="#06080b"/>
 ${FONT_LINKS}
 <link rel="stylesheet" href="${assetHref(depth, 'base.css')}"/>
+${extraHead}
 </head>
 <body>
 ${navHtml(depth, current)}
@@ -226,7 +229,18 @@ ${footerHtml(depth)}
 </html>`;
 }
 
-function buildPage({ title, description, body }) {
+function productHero({ eyebrow, title, lede, actionsHtml }) {
+  return `<header class="product-hero">
+  <div class="landing-shell">
+    <span class="brand-eyebrow">${escapeHtml(eyebrow)}</span>
+    <h1 class="product-hero__title">${escapeHtml(title)}</h1>
+    <p class="product-hero__lede">${escapeHtml(lede)}</p>
+    ${actionsHtml ? `<div class="hero-actions hero-actions--start">${actionsHtml}</div>` : ''}
+  </div>
+</header>`;
+}
+
+function buildDocPage({ title, description, body }) {
   const content = `<header class="doc-hero"><div class="doc-hero__inner">
 <p class="doc-hero__crumb">Specs / ${escapeHtml(title)}</p>
 <h1>${escapeHtml(title)}</h1>
@@ -243,7 +257,7 @@ function buildPage({ title, description, body }) {
   });
 }
 
-function buildIndexPage(entries) {
+function buildDocsIndexPage(entries) {
   const listHtml = entries
     .map(
       (e) =>
@@ -254,7 +268,7 @@ function buildIndexPage(entries) {
   const content = `<header class="doc-hero"><div class="doc-hero__inner">
 <p class="doc-hero__crumb">TiltCheck / Specs</p>
 <h1>Ecosystem specs</h1>
-<p class="lede">Static mirror of <code>docs/tiltcheck/</code>. The product lives at <a href="${SITE_URL}">tiltcheck.me</a>.</p>
+<p class="lede">Static mirror of <code>docs/tiltcheck/</code>. Product pages live on this same Pages site.</p>
 </div></header>
 <main class="doc-main">
 <ul class="spec-list">${listHtml}</ul>
@@ -278,6 +292,15 @@ function buildRootLanding() {
 </article>`,
   ).join('\n');
 
+  const featuresHtml = FEATURE_CARDS.map(
+    (card) => `<article class="public-page-card feature-card">
+  <p class="public-page-card__eyebrow">${escapeHtml(card.eyebrow)}</p>
+  <h3 class="public-page-card__title">${escapeHtml(card.title)}</h3>
+  <p class="public-page-card__copy">${escapeHtml(card.description)}</p>
+  <a class="feature-card__link" href="${escapeHtml(card.href)}">${escapeHtml(card.cta)} →</a>
+</article>`,
+  ).join('\n');
+
   const operatorList = OPERATOR_BULLETS.map((b) => `<li>${escapeHtml(b)}</li>`).join('\n');
 
   const content = `<main class="landing-page">
@@ -288,8 +311,8 @@ function buildRootLanding() {
       <h1 class="landing-hero-title landing-hero-title--centered">${escapeHtml(SITE_HERO_HEADLINE)}</h1>
       <p class="landing-hero-subtitle landing-hero-subtitle--centered">${escapeHtml(SITE_ONE_LINER)}</p>
       <div class="hero-actions">
-        <a class="btn btn-primary" href="${EXTENSION_URL}">Install the Extension</a>
-        <a class="hero-actions__secondary-link" href="${CASINOS_URL}">Check Casino Trust</a>
+        <a class="btn btn-primary" href="extension.html">Install the Extension</a>
+        <a class="hero-actions__secondary-link" href="casinos.html">Check Casino Trust</a>
       </div>
     </div>
   </section>
@@ -300,9 +323,17 @@ function buildRootLanding() {
         <span class="brand-eyebrow">Three jobs</span>
         <h2 class="public-page-section-heading__title">Protect the bankroll.</h2>
       </div>
-      <div class="public-page-grid public-page-grid--3">
-        ${jobsHtml}
+      <div class="public-page-grid public-page-grid--3">${jobsHtml}</div>
+    </div>
+  </section>
+
+  <section class="public-page-section" id="features" aria-label="Tools and features">
+    <div class="landing-shell">
+      <div class="public-page-section-heading">
+        <span class="brand-eyebrow">Tools / features</span>
+        <h2 class="public-page-section-heading__title">What you can open here.</h2>
       </div>
+      <div class="public-page-grid public-page-grid--2">${featuresHtml}</div>
     </div>
   </section>
 
@@ -311,11 +342,9 @@ function buildRootLanding() {
       <article class="public-page-card">
         <span class="brand-eyebrow">For platforms / operators</span>
         <h2 class="public-page-section-heading__title">Trust scoring as a service. Non-affiliated. RGaaS API.</h2>
-        <ul class="public-page-card__copy public-page-card__copy--list">
-          ${operatorList}
-        </ul>
+        <ul class="public-page-card__copy public-page-card__copy--list">${operatorList}</ul>
         <div style="margin-top:1.5rem">
-          <a class="btn btn-primary" href="${OPERATORS_URL}">Get Sandbox Access</a>
+          <a class="btn btn-primary" href="operators.html">Get Sandbox Access</a>
         </div>
       </article>
     </div>
@@ -341,15 +370,294 @@ function buildRootLanding() {
   });
 }
 
+function buildExtensionPage() {
+  const signals = EXTENSION_SIGNALS.map(
+    (s) => `<article class="public-page-card">
+  <h2 class="public-page-card__title">${escapeHtml(s.title)}</h2>
+  <p class="public-page-card__copy">${escapeHtml(s.body)}</p>
+</article>`,
+  ).join('\n');
+
+  const actions = `
+    <a class="btn btn-primary" href="${EXTENSION_ZIP_URL}">Download the zip</a>
+    <a class="hero-actions__secondary-link" href="${SITE_URL}/extension">Open live setup</a>`;
+
+  const content = `${productHero({
+    eyebrow: 'Browser extension',
+    title: 'TiltCheck lives in the casino tab.',
+    lede: 'Runs inside your active session — blocks pressure loops before they cook your account. Sideload beta now; store listing later.',
+    actionsHtml: actions,
+  })}
+<main class="product-main">
+  <section class="public-page-section">
+    <div class="landing-shell">
+      <article class="public-page-card">
+        <p class="public-page-card__eyebrow">Install</p>
+        <h2 class="public-page-card__title">Two steps</h2>
+        <ol class="public-page-list">
+          <li>Download the zip, extract to a folder.</li>
+          <li><code>chrome://extensions</code> → Developer mode → Load unpacked → select folder.</li>
+        </ol>
+        <p class="public-page-card__copy">Then open dashboard setup on tiltcheck.me before a live session.</p>
+      </article>
+    </div>
+  </section>
+  <section class="public-page-section">
+    <div class="landing-shell">
+      <div class="public-page-section-heading">
+        <span class="brand-eyebrow">Core</span>
+        <h2 class="public-page-section-heading__title">What it does.</h2>
+      </div>
+      <div class="public-page-grid public-page-grid--3">${signals}</div>
+    </div>
+  </section>
+</main>`;
+
+  return shell({
+    title: 'Extension | TiltCheck',
+    description: 'TiltCheck browser extension — read-only session guardrail in the casino tab.',
+    depth: 'root',
+    current: 'extension',
+    body: content,
+  });
+}
+
+function gradeClass(grade) {
+  const g = String(grade || '').toUpperCase();
+  if (g.startsWith('A')) return 'grade-a';
+  if (g.startsWith('B')) return 'grade-b';
+  if (g.startsWith('C')) return 'grade-c';
+  if (g.startsWith('D')) return 'grade-d';
+  return 'grade-f';
+}
+
+function buildCasinosPage(casinos) {
+  const categories = [...new Set(casinos.map((c) => c.category))].sort();
+  const cards = casinos
+    .map((c) => {
+      const slug = String(c.name)
+        .toLowerCase()
+        .replace(/&/g, ' and ')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+      const live = `${SITE_URL}/casinos/${slug}`;
+      return `<article class="casino-card" data-name="${escapeHtml(c.name.toLowerCase())}" data-category="${escapeHtml(c.category)}" data-grade="${escapeHtml(c.grade)}">
+  <div class="casino-card__top">
+    <span class="casino-card__grade ${gradeClass(c.grade)}">${escapeHtml(c.grade)}</span>
+    <span class="casino-card__cat">${escapeHtml(c.category)}</span>
+  </div>
+  <h3 class="casino-card__name">${escapeHtml(c.name)}</h3>
+  <p class="casino-card__risk">Risk: ${escapeHtml(c.risk)}</p>
+  <a class="casino-card__link" href="${live}" rel="noopener noreferrer">Full audit on tiltcheck.me →</a>
+</article>`;
+    })
+    .join('\n');
+
+  const filters = ['All', ...categories]
+    .map(
+      (cat, i) =>
+        `<button type="button" class="filter-chip${i === 0 ? ' is-active' : ''}" data-filter="${escapeHtml(cat)}">${escapeHtml(cat)}</button>`,
+    )
+    .join('\n');
+
+  const steps = GRADING_STEPS.map(
+    (s) => `<li><strong>${escapeHtml(s.title)}</strong> — ${escapeHtml(s.body)}</li>`,
+  ).join('\n');
+
+  const script = `<script>
+(function () {
+  var input = document.getElementById('casino-search');
+  var chips = document.querySelectorAll('.filter-chip');
+  var cards = Array.prototype.slice.call(document.querySelectorAll('.casino-card'));
+  var count = document.getElementById('casino-count');
+  var activeCat = 'All';
+  function apply() {
+    var q = (input.value || '').trim().toLowerCase();
+    var shown = 0;
+    cards.forEach(function (card) {
+      var name = card.getAttribute('data-name') || '';
+      var cat = card.getAttribute('data-category') || '';
+      var okCat = activeCat === 'All' || cat === activeCat;
+      var okQ = !q || name.indexOf(q) !== -1;
+      var show = okCat && okQ;
+      card.hidden = !show;
+      if (show) shown += 1;
+    });
+    if (count) count.textContent = shown + ' operators';
+  }
+  if (input) input.addEventListener('input', apply);
+  chips.forEach(function (chip) {
+    chip.addEventListener('click', function () {
+      chips.forEach(function (c) { c.classList.remove('is-active'); });
+      chip.classList.add('is-active');
+      activeCat = chip.getAttribute('data-filter') || 'All';
+      apply();
+    });
+  });
+  apply();
+})();
+</script>`;
+
+  const content = `${productHero({
+    eyebrow: 'Casino trust',
+    title: 'Look up the operator. Read the proof.',
+    lede: `Curated grades for ${casinos.length} operators on this static mirror. Full proof lanes and live RGaaS overlays stay on tiltcheck.me.`,
+    actionsHtml: `<a class="btn btn-primary" href="${SITE_URL}/casinos">Open live directory</a>
+    <a class="hero-actions__secondary-link" href="tools.html">Related tools</a>`,
+  })}
+<main class="product-main">
+  <section class="public-page-section">
+    <div class="landing-shell">
+      <div class="casino-toolbar">
+        <label class="casino-search">
+          <span class="sr-only">Search casinos</span>
+          <input id="casino-search" type="search" placeholder="Search operator name…" autocomplete="off"/>
+        </label>
+        <div class="filter-row" role="group" aria-label="Category filters">${filters}</div>
+        <p class="casino-count" id="casino-count">${casinos.length} operators</p>
+      </div>
+      <div class="casino-grid">${cards}</div>
+    </div>
+  </section>
+  <section class="public-page-section">
+    <div class="landing-shell">
+      <div class="public-page-section-heading">
+        <span class="brand-eyebrow">Methodology</span>
+        <h2 class="public-page-section-heading__title">How letter grades are built.</h2>
+      </div>
+      <ol class="method-list">${steps}</ol>
+    </div>
+  </section>
+</main>
+${script}`;
+
+  return shell({
+    title: 'Casino Trust | TiltCheck',
+    description: 'Curated casino trust grades — static mirror of the TiltCheck directory.',
+    depth: 'root',
+    current: 'casinos',
+    body: content,
+  });
+}
+
+function buildToolsPage() {
+  const install = INSTALL_SURFACES.map(
+    (t) => `<article class="public-page-card">
+  <p class="public-page-card__eyebrow">${escapeHtml(t.label)}</p>
+  <h3 class="public-page-card__title">${escapeHtml(t.title)}</h3>
+  <p class="public-page-card__copy">${escapeHtml(t.description)}</p>
+  <a class="feature-card__link" href="${SITE_URL}${t.href}">Open install →</a>
+</article>`,
+  ).join('\n');
+
+  const tools = TOOL_REGISTRY.map(
+    (t) => `<article class="public-page-card tool-card">
+  <div class="tool-card__meta">
+    <p class="public-page-card__eyebrow">${escapeHtml(t.label)}</p>
+    <span class="status-pill status-pill--${escapeHtml(t.status)}">${escapeHtml(t.status)}</span>
+  </div>
+  <h3 class="public-page-card__title">${escapeHtml(t.title)}</h3>
+  <p class="public-page-card__copy">${escapeHtml(t.description)}</p>
+  <a class="feature-card__link" href="${SITE_URL}${t.href}">Open on tiltcheck.me →</a>
+</article>`,
+  ).join('\n');
+
+  const content = `${productHero({
+    eyebrow: 'TiltCheck Toolkit',
+    title: 'Install first. Tools second.',
+    lede: 'Static catalog of the toolkit. Interactive verifiers and scanners run on tiltcheck.me — this page is the map.',
+    actionsHtml: `<a class="btn btn-primary" href="extension.html">Install extension</a>
+    <a class="hero-actions__secondary-link" href="${SITE_URL}/tools">Open live tools</a>`,
+  })}
+<main class="product-main">
+  <section class="public-page-section">
+    <div class="landing-shell">
+      <div class="public-page-section-heading">
+        <span class="brand-eyebrow">Install surfaces</span>
+        <h2 class="public-page-section-heading__title">AutoVault setups.</h2>
+      </div>
+      <div class="public-page-grid public-page-grid--2">${install}</div>
+    </div>
+  </section>
+  <section class="public-page-section">
+    <div class="landing-shell">
+      <div class="public-page-section-heading">
+        <span class="brand-eyebrow">Features</span>
+        <h2 class="public-page-section-heading__title">The toolkit.</h2>
+      </div>
+      <div class="public-page-grid public-page-grid--2">${tools}</div>
+    </div>
+  </section>
+</main>`;
+
+  return shell({
+    title: 'Tools | TiltCheck',
+    description: 'TiltCheck toolkit — verifiers, scanners, vault, and accountability tools.',
+    depth: 'root',
+    current: 'tools',
+    body: content,
+  });
+}
+
+function buildOperatorsPage() {
+  const benefits = OPERATOR_BENEFITS.map(
+    (b) => `<article class="public-page-card">
+  <h3 class="public-page-card__title">${escapeHtml(b.title)}</h3>
+  <p class="public-page-card__copy">${escapeHtml(b.body)}</p>
+</article>`,
+  ).join('\n');
+
+  const content = `${productHero({
+    eyebrow: 'Operators / RGaaS',
+    title: 'Sandbox keys for trust signal — not vibes.',
+    lede: 'Plug RGaaS into onboarding, trust, or review queues. Free sandbox on the live site. This Pages twin is marketing-only — no key form here.',
+    actionsHtml: `<a class="btn btn-primary" href="${SITE_URL}/operators">Request sandbox keys</a>
+    <a class="hero-actions__secondary-link" href="${SITE_URL}/operators/pricing">Pricing</a>`,
+  })}
+<main class="product-main">
+  <section class="public-page-section">
+    <div class="landing-shell">
+      <div class="public-page-grid public-page-grid--3">${benefits}</div>
+    </div>
+  </section>
+  <section class="public-page-section">
+    <div class="landing-shell">
+      <article class="public-page-card">
+        <p class="public-page-card__eyebrow">Pricing snapshot</p>
+        <h2 class="public-page-card__title">Free sandbox. Production by review.</h2>
+        <p class="public-page-card__copy">Sandbox: mocked responses, capped volume. Production: manual review. Request keys on tiltcheck.me — we do not collect partner emails on GitHub Pages.</p>
+        <div style="margin-top:1.25rem">
+          <a class="btn btn-primary" href="${SITE_URL}/operators">Go to live operators</a>
+        </div>
+      </article>
+    </div>
+  </section>
+</main>`;
+
+  return shell({
+    title: 'Operators | TiltCheck',
+    description: 'TiltCheck RGaaS sandbox — trust scoring API for platforms.',
+    depth: 'root',
+    current: 'operators',
+    body: content,
+  });
+}
+
 function run() {
   if (!fs.existsSync(sourceRoot)) {
     console.error('Source directory missing:', sourceRoot);
+    process.exit(1);
+  }
+  if (!fs.existsSync(CASINOS_JSON)) {
+    console.error('Casinos data missing:', CASINOS_JSON);
     process.exit(1);
   }
 
   const siteRoot = path.dirname(outRoot);
   fs.mkdirSync(outRoot, { recursive: true });
   fs.mkdirSync(siteRoot, { recursive: true });
+
+  const casinos = JSON.parse(fs.readFileSync(CASINOS_JSON, 'utf-8'));
 
   const files = fs
     .readdirSync(sourceRoot)
@@ -364,16 +672,22 @@ function run() {
     const slug = slugify(file);
     const meta = extractMeta(raw);
     const body = renderMarkdown(raw);
-    const html = buildPage({ title: meta.title, description: meta.description, body });
+    const html = buildDocPage({ title: meta.title, description: meta.description, body });
     fs.writeFileSync(path.join(outRoot, `${slug}.html`), html);
     indexEntries.push({ slug, title: meta.title, description: meta.description });
   }
 
-  fs.writeFileSync(path.join(outRoot, 'index.html'), buildIndexPage(indexEntries));
+  fs.writeFileSync(path.join(outRoot, 'index.html'), buildDocsIndexPage(indexEntries));
   fs.writeFileSync(path.join(siteRoot, 'index.html'), buildRootLanding());
+  fs.writeFileSync(path.join(siteRoot, 'extension.html'), buildExtensionPage());
+  fs.writeFileSync(path.join(siteRoot, 'casinos.html'), buildCasinosPage(casinos));
+  fs.writeFileSync(path.join(siteRoot, 'tools.html'), buildToolsPage());
+  fs.writeFileSync(path.join(siteRoot, 'operators.html'), buildOperatorsPage());
   fs.writeFileSync(path.join(siteRoot, '.nojekyll'), '');
 
-  console.log(`Converted ${files.length} markdown files to HTML in ${outRoot}`);
+  console.log(
+    `Built Pages site: ${files.length} specs + product pages (home, extension, casinos[${casinos.length}], tools, operators) → ${siteRoot}`,
+  );
 }
 
 run();

--- a/scripts/convert-markdown.js
+++ b/scripts/convert-markdown.js
@@ -22,8 +22,13 @@ import {
   EXTENSION_ZIP_URL,
   SITE_HERO_HEADLINE,
   SITE_ONE_LINER,
+  SITE_META_DESCRIPTION,
+  WHAT_IT_IS,
+  HOW_IT_WORKS,
   CORE_JOBS,
+  PROBLEM_SIGNALS,
   FEATURE_CARDS,
+  FAQS,
   EXTENSION_SIGNALS,
   OPERATOR_BULLETS,
   OPERATOR_BENEFITS,
@@ -284,11 +289,30 @@ function buildDocsIndexPage(entries) {
 }
 
 function buildRootLanding() {
+  const whatParas = WHAT_IT_IS.paragraphs.map((p) => `<p class="explainer__p">${escapeHtml(p)}</p>`).join('\n');
+  const whatBullets = WHAT_IT_IS.bullets.map((b) => `<li>${escapeHtml(b)}</li>`).join('\n');
+
+  const flowHtml = HOW_IT_WORKS.map(
+    (step) => `<article class="public-page-card">
+  <p class="public-page-card__eyebrow">Step ${escapeHtml(step.step)}</p>
+  <h3 class="public-page-card__title">${escapeHtml(step.title)}</h3>
+  <p class="public-page-card__copy">${escapeHtml(step.body)}</p>
+  <p class="public-page-card__note">${escapeHtml(step.note)}</p>
+</article>`,
+  ).join('\n');
+
   const jobsHtml = CORE_JOBS.map(
     (job) => `<article class="public-page-card">
-  <p class="public-page-card__eyebrow">Step ${escapeHtml(job.step)}</p>
+  <p class="public-page-card__eyebrow">Job ${escapeHtml(job.step)}</p>
   <h3 class="public-page-card__title">${escapeHtml(job.title)}</h3>
   <p class="public-page-card__copy">${escapeHtml(job.description)}</p>
+</article>`,
+  ).join('\n');
+
+  const signalsHtml = PROBLEM_SIGNALS.map(
+    (s) => `<article class="signal-row">
+  <h3 class="signal-row__title">${escapeHtml(s.title)}</h3>
+  <p class="signal-row__body">${escapeHtml(s.body)}</p>
 </article>`,
   ).join('\n');
 
@@ -301,26 +325,68 @@ function buildRootLanding() {
 </article>`,
   ).join('\n');
 
+  const faqHtml = FAQS.map(
+    (faq) => `<details class="faq-item">
+  <summary class="faq-item__q">${escapeHtml(faq.question)}</summary>
+  <p class="faq-item__a">${escapeHtml(faq.answer)}</p>
+</details>`,
+  ).join('\n');
+
   const operatorList = OPERATOR_BULLETS.map((b) => `<li>${escapeHtml(b)}</li>`).join('\n');
 
   const content = `<main class="landing-page">
   <section class="hero-surface" aria-label="TiltCheck">
     <div class="landing-shell landing-hero-centered">
       <p class="brand-wordmark">Tilt<span>Check</span></p>
-      <span class="brand-eyebrow">Built for Degens. By Degens.</span>
+      <span class="brand-eyebrow">The Degen Audit Layer</span>
       <h1 class="landing-hero-title landing-hero-title--centered">${escapeHtml(SITE_HERO_HEADLINE)}</h1>
       <p class="landing-hero-subtitle landing-hero-subtitle--centered">${escapeHtml(SITE_ONE_LINER)}</p>
       <div class="hero-actions">
         <a class="btn btn-primary" href="extension.html">Install the Extension</a>
-        <a class="hero-actions__secondary-link" href="casinos.html">Check Casino Trust</a>
+        <a class="hero-actions__secondary-link" href="#what">What is this?</a>
       </div>
+    </div>
+  </section>
+
+  <section class="public-page-section" id="what" aria-label="What is TiltCheck">
+    <div class="landing-shell explainer">
+      <div class="public-page-section-heading">
+        <span class="brand-eyebrow">${escapeHtml(WHAT_IT_IS.eyebrow)}</span>
+        <h2 class="public-page-section-heading__title">${escapeHtml(WHAT_IT_IS.title)}</h2>
+      </div>
+      ${whatParas}
+      <ul class="explainer__list">${whatBullets}</ul>
+      <div class="hero-actions hero-actions--start" style="margin-top:1.5rem">
+        <a class="btn btn-primary" href="extension.html">Start with the extension</a>
+        <a class="hero-actions__secondary-link" href="casinos.html">Or check a casino first</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="public-page-section" aria-label="How it works">
+    <div class="landing-shell">
+      <div class="public-page-section-heading">
+        <span class="brand-eyebrow">How it works</span>
+        <h2 class="public-page-section-heading__title">Install. Watch. Exit.</h2>
+      </div>
+      <div class="public-page-grid public-page-grid--3">${flowHtml}</div>
+    </div>
+  </section>
+
+  <section class="public-page-section" aria-label="What it catches">
+    <div class="landing-shell">
+      <div class="public-page-section-heading">
+        <span class="brand-eyebrow">What you get</span>
+        <h2 class="public-page-section-heading__title">Problems it actually names.</h2>
+      </div>
+      <div class="signal-list">${signalsHtml}</div>
     </div>
   </section>
 
   <section class="public-page-section" aria-label="Three jobs">
     <div class="landing-shell">
       <div class="public-page-section-heading">
-        <span class="brand-eyebrow">Three jobs</span>
+        <span class="brand-eyebrow">In-session jobs</span>
         <h2 class="public-page-section-heading__title">Protect the bankroll.</h2>
       </div>
       <div class="public-page-grid public-page-grid--3">${jobsHtml}</div>
@@ -330,10 +396,21 @@ function buildRootLanding() {
   <section class="public-page-section" id="features" aria-label="Tools and features">
     <div class="landing-shell">
       <div class="public-page-section-heading">
-        <span class="brand-eyebrow">Tools / features</span>
-        <h2 class="public-page-section-heading__title">What you can open here.</h2>
+        <span class="brand-eyebrow">Open these next</span>
+        <h2 class="public-page-section-heading__title">Pages on this site.</h2>
       </div>
+      <p class="section-lede">Cold start? Extension first. Depositing somewhere new? Casinos. Want math tools? Toolkit. Running a platform? Operators.</p>
       <div class="public-page-grid public-page-grid--2">${featuresHtml}</div>
+    </div>
+  </section>
+
+  <section class="public-page-section" aria-label="FAQ">
+    <div class="landing-shell">
+      <div class="public-page-section-heading">
+        <span class="brand-eyebrow">FAQ</span>
+        <h2 class="public-page-section-heading__title">Straight answers.</h2>
+      </div>
+      <div class="faq-list">${faqHtml}</div>
     </div>
   </section>
 
@@ -342,9 +419,10 @@ function buildRootLanding() {
       <article class="public-page-card">
         <span class="brand-eyebrow">For platforms / operators</span>
         <h2 class="public-page-section-heading__title">Trust scoring as a service. Non-affiliated. RGaaS API.</h2>
+        <p class="public-page-card__copy">Players can skip this. If you need API access for trust signals or RG hooks:</p>
         <ul class="public-page-card__copy public-page-card__copy--list">${operatorList}</ul>
         <div style="margin-top:1.5rem">
-          <a class="btn btn-primary" href="operators.html">Get Sandbox Access</a>
+          <a class="btn btn-primary" href="operators.html">Operator details</a>
         </div>
       </article>
     </div>
@@ -363,7 +441,7 @@ function buildRootLanding() {
 
   return shell({
     title: 'TiltCheck | The Degen Audit Layer',
-    description: SITE_ONE_LINER,
+    description: SITE_META_DESCRIPTION,
     depth: 'root',
     current: 'home',
     body: content,
@@ -385,10 +463,20 @@ function buildExtensionPage() {
   const content = `${productHero({
     eyebrow: 'Browser extension',
     title: 'TiltCheck lives in the casino tab.',
-    lede: 'Runs inside your active session — blocks pressure loops before they cook your account. Sideload beta now; store listing later.',
+    lede: 'This is the main product. A free Chrome extension that watches your live online-casino session — bet pacing, tilt spirals, pressure loops — and enforces the exit rules you set. Read-only. No wallet keys. Sideload beta now; store listing later.',
     actionsHtml: actions,
   })}
 <main class="product-main">
+  <section class="public-page-section">
+    <div class="landing-shell explainer">
+      <div class="public-page-section-heading">
+        <span class="brand-eyebrow">Why install</span>
+        <h2 class="public-page-section-heading__title">You already know the spiral.</h2>
+      </div>
+      <p class="explainer__p">Three losses. Bet size climbs. “Im due.” Another deposit. The extension’s job is to notice that pacing while the tab is still open and push the exit you configured when you were still thinking straight.</p>
+      <p class="explainer__p">It does not place bets for you. It does not “beat the house.” It is brakes — the same idea as a seatbelt, except for sessions that feel immortal at 2am.</p>
+    </div>
+  </section>
   <section class="public-page-section">
     <div class="landing-shell">
       <article class="public-page-card">
@@ -398,7 +486,7 @@ function buildExtensionPage() {
           <li>Download the zip, extract to a folder.</li>
           <li><code>chrome://extensions</code> → Developer mode → Load unpacked → select folder.</li>
         </ol>
-        <p class="public-page-card__copy">Then open dashboard setup on tiltcheck.me before a live session.</p>
+        <p class="public-page-card__copy">Then open dashboard setup on tiltcheck.me before a live session so your profit/loss lines are set.</p>
       </article>
     </div>
   </section>
@@ -415,7 +503,7 @@ function buildExtensionPage() {
 
   return shell({
     title: 'Extension | TiltCheck',
-    description: 'TiltCheck browser extension — read-only session guardrail in the casino tab.',
+    description: 'Install the TiltCheck Chrome extension — read-only session guardrail that watches tilt and enforces your exit rules.',
     depth: 'root',
     current: 'extension',
     body: content,
@@ -501,7 +589,7 @@ function buildCasinosPage(casinos) {
   const content = `${productHero({
     eyebrow: 'Casino trust',
     title: 'Look up the operator. Read the proof.',
-    lede: `Curated grades for ${casinos.length} operators on this static mirror. Full proof lanes and live RGaaS overlays stay on tiltcheck.me.`,
+    lede: `Before you deposit, check who you are playing. This page lists ${casinos.length} curated operators with letter grades and risk labels (sweeps, crypto, regulated, scam, and more). It is a starting point — not a green light. Full license, domain, and scam proof lanes open on tiltcheck.me.`,
     actionsHtml: `<a class="btn btn-primary" href="${SITE_URL}/casinos">Open live directory</a>
     <a class="hero-actions__secondary-link" href="tools.html">Related tools</a>`,
   })}
@@ -565,7 +653,7 @@ function buildToolsPage() {
   const content = `${productHero({
     eyebrow: 'TiltCheck Toolkit',
     title: 'Install first. Tools second.',
-    lede: 'Static catalog of the toolkit. Interactive verifiers and scanners run on tiltcheck.me — this page is the map.',
+    lede: 'The extension is the session brakes. These tools are the homework: verify a bet from seeds, compare claimed payout vs what you got, check if a domain is sus, look up geo rules, track bonus timers. Interactive versions run on tiltcheck.me — this page tells you what each tool is for.',
     actionsHtml: `<a class="btn btn-primary" href="extension.html">Install extension</a>
     <a class="hero-actions__secondary-link" href="${SITE_URL}/tools">Open live tools</a>`,
   })}

--- a/scripts/pages-assets/styles/base.css
+++ b/scripts/pages-assets/styles/base.css
@@ -663,8 +663,267 @@ td {
   }
 }
 
+.public-page-grid--2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.feature-card__link {
+  display: inline-block;
+  margin-top: 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+}
+
+.feature-card__link:hover {
+  color: var(--color-primary-light);
+}
+
+.product-hero {
+  padding: clamp(2.5rem, 6vw, 4rem) 1.25rem 2rem;
+  border-bottom: 1px solid var(--border-default);
+  background: linear-gradient(180deg, rgba(23, 195, 178, 0.07), transparent 70%);
+}
+
+.product-hero__title {
+  margin: 0;
+  max-width: 16ch;
+  font-size: clamp(2.2rem, 5.5vw, 3.75rem);
+  font-weight: 900;
+  line-height: 0.98;
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+  color: #f6fbff;
+  -webkit-text-stroke: 1px rgba(0, 0, 0, 0.95);
+  paint-order: stroke fill;
+  text-shadow:
+    -1px -1px 0 rgba(0, 0, 0, 0.95),
+    1px -1px 0 rgba(0, 0, 0, 0.95),
+    -1px 1px 0 rgba(0, 0, 0, 0.95),
+    1px 1px 0 rgba(0, 0, 0, 0.95),
+    0 6px 18px rgba(0, 0, 0, 0.28);
+}
+
+.product-hero__lede {
+  margin: 1.1rem 0 0;
+  max-width: 40rem;
+  color: #b5c1cd;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.hero-actions--start {
+  justify-content: flex-start;
+}
+
+.product-main {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 5vw, 4rem);
+  padding: clamp(2rem, 4vw, 3rem) 0 clamp(3rem, 6vw, 5rem);
+}
+
+.public-page-list {
+  margin: 1rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.public-page-list li + li {
+  margin-top: 0.45rem;
+}
+
+.casino-toolbar {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.casino-search input {
+  width: 100%;
+  min-height: 44px;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-default);
+  background: rgba(8, 10, 13, 0.85);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+}
+
+.casino-search input:focus {
+  outline: none;
+  border-color: rgba(23, 195, 178, 0.55);
+  box-shadow: 0 0 0 1px rgba(23, 195, 178, 0.25);
+}
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filter-chip {
+  min-height: 36px;
+  padding: 0.4rem 0.75rem;
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all var(--transition-base);
+}
+
+.filter-chip:hover,
+.filter-chip.is-active {
+  color: #061012;
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.casino-count {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.casino-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.85rem;
+}
+
+.casino-card {
+  padding: 1rem 1.05rem 1.15rem;
+  border: 1px solid rgba(23, 195, 178, 0.14);
+  border-radius: 1.1rem;
+  background: rgba(10, 14, 19, 0.55);
+  transition: border-color var(--transition-base), transform var(--transition-base);
+}
+
+.casino-card:hover {
+  border-color: rgba(23, 195, 178, 0.4);
+  transform: translateY(-2px);
+}
+
+.casino-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.65rem;
+}
+
+.casino-card__grade {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+}
+
+.grade-a { color: #48d5c6; }
+.grade-b { color: #17c3b2; }
+.grade-c { color: #ffd700; }
+.grade-d { color: #f59e0b; }
+.grade-f { color: #ef4444; }
+
+.casino-card__cat {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.casino-card__name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.casino-card__risk {
+  margin: 0.4rem 0 0;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.casino-card__link {
+  display: inline-block;
+  margin-top: 0.85rem;
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.method-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.method-list li + li {
+  margin-top: 0.75rem;
+}
+
+.tool-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.status-pill {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.45rem;
+  border: 1px solid var(--border-default);
+  color: var(--text-muted);
+}
+
+.status-pill--live {
+  color: var(--color-primary);
+  border-color: rgba(23, 195, 178, 0.45);
+}
+
+.status-pill--beta {
+  color: #ffd700;
+  border-color: rgba(255, 215, 0, 0.35);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @media (max-width: 900px) {
-  .public-page-grid--3 {
+  .public-page-grid--3,
+  .public-page-grid--2 {
     grid-template-columns: 1fr;
   }
 }

--- a/scripts/pages-assets/styles/base.css
+++ b/scripts/pages-assets/styles/base.css
@@ -667,6 +667,114 @@ td {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.section-lede {
+  margin: -0.5rem 0 1.5rem;
+  max-width: 40rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+.explainer {
+  max-width: min(100% - 0rem, 48rem);
+}
+
+.explainer__p {
+  margin: 0 0 1rem;
+  color: #b5c1cd;
+  font-size: 1.05rem;
+  line-height: 1.75;
+}
+
+.explainer__list {
+  margin: 1.25rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.explainer__list li + li {
+  margin-top: 0.45rem;
+}
+
+.public-page-card__note {
+  margin: 0.75rem 0 0;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+}
+
+.signal-list {
+  display: grid;
+  gap: 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.signal-row {
+  display: grid;
+  grid-template-columns: minmax(8rem, 14rem) 1fr;
+  gap: 1rem 1.5rem;
+  padding: 1.15rem 0.1rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.signal-row__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+}
+
+.signal-row__body {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+.faq-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.faq-item {
+  border: 1px solid rgba(23, 195, 178, 0.15);
+  border-radius: 1rem;
+  background: rgba(10, 14, 19, 0.45);
+  padding: 0.85rem 1.1rem;
+}
+
+.faq-item__q {
+  cursor: pointer;
+  list-style: none;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+.faq-item__q::-webkit-details-marker {
+  display: none;
+}
+
+.faq-item__a {
+  margin: 0.75rem 0 0.25rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+@media (max-width: 700px) {
+  .signal-row {
+    grid-template-columns: 1fr;
+    gap: 0.35rem;
+  }
+}
+
 .feature-card__link {
   display: inline-block;
   margin-top: 1rem;

--- a/scripts/pages-product-data.mjs
+++ b/scripts/pages-product-data.mjs
@@ -10,54 +10,153 @@ export const EXTENSION_ZIP_URL = `${SITE_URL}/downloads/tiltcheck-extension.zip`
 
 export const SITE_HERO_HEADLINE = 'House always wins? FUCK THAT.';
 export const SITE_ONE_LINER =
-  'Read-only browser guardrail. Watches pacing and tilt in real time — pulls you out before you rug yourself.';
+  'TiltCheck is a free, read-only browser extension for online casino sessions. It watches how fast you bet, flags tilt and pressure loops, and enforces the exit rules you set — before another deposit cooks you.';
+
+export const SITE_META_DESCRIPTION =
+  'TiltCheck: read-only browser guardrail for online casino play. Spot tilt, check casino trust grades, verify bets, and brake before you rug yourself.';
+
+/** Plain-English pitch for cold visitors — sits under the hero. */
+export const WHAT_IT_IS = {
+  eyebrow: 'What this is',
+  title: 'Brakes for the session. Not another casino.',
+  paragraphs: [
+    'Online casinos are built to keep you spinning. TiltCheck sits in your browser tab as a read-only audit layer: it watches pacing and session behavior, pairs that with public trust signals, and pushes you to cash out or stop when your own rules say so.',
+    'We never ask for wallet keys. We never hold your money. We are not a casino, not an affiliate ranking farm, and not therapy — we are the brakes you install before tilt writes the next chapter.',
+  ],
+  bullets: [
+    'Browser extension that watches supported casino tabs in real time',
+    'Public casino trust grades so you can look up an operator before you deposit',
+    'Tools to verify bets, scan shady domains, and check house-edge claims',
+    'Optional vault / profit-lock flows so wins are harder to spin back',
+  ],
+};
+
+export const HOW_IT_WORKS = [
+  {
+    step: '01',
+    title: 'Install',
+    body: 'Sideload the read-only Chrome extension. No private keys. It lives in the casino tab you already use.',
+    note: 'One install. Two minutes.',
+  },
+  {
+    step: '02',
+    title: 'Watch',
+    body: 'Compares live click-speed, bet pacing, and session events to your guardrails and known pressure patterns.',
+    note: 'Flags sus spirals while you are still in the session.',
+  },
+  {
+    step: '03',
+    title: 'Exit',
+    body: 'When the line is crossed: warning, cash-out push, or hard stop — whatever you configured. Proof over emotion.',
+    note: 'You set the rules. We enforce them.',
+  },
+];
 
 export const CORE_JOBS = [
   {
     step: '01',
     title: 'Kill the Auto-Pilot',
-    description: 'Tracks click-speed and bet pacing. Wakes you up when you play like a bot.',
+    description:
+      'Rapid clicking, loss chasing, Martingale ladders — the bot mode you slip into after three bad spins. We track pacing and wake you up.',
   },
   {
     step: '02',
     title: 'Read the Room',
-    description: 'Flags sus pacing and pressure loops while you are still in the session.',
+    description:
+      'Pressure loops, sus session dynamics, and “im due” energy in real time — while the tab is still open, not in a postmortem.',
   },
   {
     step: '03',
     title: 'Enforce the Exit',
-    description: 'Set your line. We enforce it — not passive warnings.',
+    description:
+      'Profit targets and loss limits you chose ahead of time. Not a polite toast. A real stop before you give the heater back.',
+  },
+];
+
+export const PROBLEM_SIGNALS = [
+  {
+    title: 'Tilt detection',
+    body: 'Know when you hit The Loop — Auto-Pilot patterns before the bankroll pays tuition.',
+  },
+  {
+    title: 'Casino trust grades',
+    body: 'Letter grades and risk labels for sweeps, crypto, regulated, and known scam names — community-curated, not casino-sponsored.',
+  },
+  {
+    title: 'Receipts over vibes',
+    body: 'Recompute a bet from seeds, check claimed RTP vs what you got, scan domains before you click a “support” link.',
+  },
+  {
+    title: 'Lock the win',
+    body: 'Vault / AutoVault flows make profit harder to spin back when the next bonus screen starts whispering.',
   },
 ];
 
 export const FEATURE_CARDS = [
   {
     eyebrow: 'Extension',
-    title: 'Lives in the casino tab',
-    description: 'Read-only session guardrail. Sideload the zip — store listing later.',
+    title: 'The actual product',
+    description:
+      'Chrome extension that watches your live casino session. Install this first if you want the brakes — everything else is support gear.',
     href: 'extension.html',
-    cta: 'Install extension',
+    cta: 'How to install',
   },
   {
     eyebrow: 'Casino trust',
-    title: 'Look up the operator',
-    description: 'Curated grades, risk, and category on every card. Proof lanes stay on live.',
+    title: 'Who are you depositing with?',
+    description:
+      'Browse curated operator grades (A through F), risk, and category. Open a full proof page on tiltcheck.me when you need license and scam lanes.',
     href: 'casinos.html',
     cta: 'Browse casinos',
   },
   {
     eyebrow: 'Toolkit',
-    title: 'Install first. Tools second.',
-    description: 'Verifier, delta engine, geo laws, phishing shield — open live for interactive runs.',
+    title: 'Math and scam tools',
+    description:
+      'Bet verifier, house-edge calculator, geo-laws, phishing shield, shadow-ban log. Interactive runs live on tiltcheck.me — this page is the map.',
     href: 'tools.html',
     cta: 'See tools',
   },
   {
     eyebrow: 'Operators',
-    title: 'RGaaS sandbox',
-    description: 'Trust scoring as a service. Non-affiliated. Request keys on the live site.',
+    title: 'For platforms',
+    description:
+      'If you run a casino or RG product: RGaaS sandbox keys for trust signals — non-affiliated, non-custodial. Players skip this.',
     href: 'operators.html',
     cta: 'Operator access',
+  },
+];
+
+export const FAQS = [
+  {
+    question: 'Do you see my wallet key or hold my money?',
+    answer:
+      'No. Never. The extension is read-only on casino tabs. No custodial wallets. If someone asks for your seed phrase “for TiltCheck,” that is a scam.',
+  },
+  {
+    question: 'Is TiltCheck a casino or a tipster?',
+    answer:
+      'Neither. We do not take bets, sell picks, or rank casinos for affiliate kickbacks. We are an audit / guardrail layer for people who already play.',
+  },
+  {
+    question: 'What problem does the extension solve?',
+    answer:
+      'You know the spiral: three losses, bet size climbs, “im due,” deposit again. TiltCheck watches pacing and enforces the exit you set when you were still sober about it.',
+  },
+  {
+    question: 'What is a casino trust grade?',
+    answer:
+      'A curated letter grade plus risk label for an operator (sweeps, crypto, regulated, scam, etc.). It is a starting point — open the live proof page for license, domain, and issue lanes.',
+  },
+  {
+    question: 'Why does this GitHub Pages site exist?',
+    answer:
+      'Shareable static twin when the main app host is down or you just need the pitch + directory. Interactive tools and dashboards still live on tiltcheck.me.',
+  },
+  {
+    question: 'Crisis or addiction help?',
+    answer:
+      'TiltCheck is brakes, not therapy. Call 1-800-GAMBLER or visit ncpg.org.',
   },
 ];
 

--- a/scripts/pages-product-data.mjs
+++ b/scripts/pages-product-data.mjs
@@ -1,0 +1,196 @@
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18 */
+/**
+ * Static product catalog for GitHub Pages twin (no API).
+ */
+
+export const SITE_URL = 'https://tiltcheck.me';
+export const DISCORD_URL = 'https://discord.gg/gdBsEJfCar';
+export const KOFI_URL = 'https://ko-fi.com/jmenichole0';
+export const EXTENSION_ZIP_URL = `${SITE_URL}/downloads/tiltcheck-extension.zip`;
+
+export const SITE_HERO_HEADLINE = 'House always wins? FUCK THAT.';
+export const SITE_ONE_LINER =
+  'Read-only browser guardrail. Watches pacing and tilt in real time — pulls you out before you rug yourself.';
+
+export const CORE_JOBS = [
+  {
+    step: '01',
+    title: 'Kill the Auto-Pilot',
+    description: 'Tracks click-speed and bet pacing. Wakes you up when you play like a bot.',
+  },
+  {
+    step: '02',
+    title: 'Read the Room',
+    description: 'Flags sus pacing and pressure loops while you are still in the session.',
+  },
+  {
+    step: '03',
+    title: 'Enforce the Exit',
+    description: 'Set your line. We enforce it — not passive warnings.',
+  },
+];
+
+export const FEATURE_CARDS = [
+  {
+    eyebrow: 'Extension',
+    title: 'Lives in the casino tab',
+    description: 'Read-only session guardrail. Sideload the zip — store listing later.',
+    href: 'extension.html',
+    cta: 'Install extension',
+  },
+  {
+    eyebrow: 'Casino trust',
+    title: 'Look up the operator',
+    description: 'Curated grades, risk, and category on every card. Proof lanes stay on live.',
+    href: 'casinos.html',
+    cta: 'Browse casinos',
+  },
+  {
+    eyebrow: 'Toolkit',
+    title: 'Install first. Tools second.',
+    description: 'Verifier, delta engine, geo laws, phishing shield — open live for interactive runs.',
+    href: 'tools.html',
+    cta: 'See tools',
+  },
+  {
+    eyebrow: 'Operators',
+    title: 'RGaaS sandbox',
+    description: 'Trust scoring as a service. Non-affiliated. Request keys on the live site.',
+    href: 'operators.html',
+    cta: 'Operator access',
+  },
+];
+
+export const EXTENSION_SIGNALS = [
+  { title: 'Read-only', body: 'Watches supported casino tabs. No private keys.' },
+  { title: 'In-tab', body: 'Warnings and exit controls stay on your active screen.' },
+  { title: 'Your rules', body: 'Profit targets and vault limits — we enforce what you set.' },
+];
+
+export const OPERATOR_BULLETS = [
+  'Trust scoring as a service — non-affiliated, evidence-backed.',
+  'RGaaS API for session guardrails without custodial flows.',
+  'Sandbox access for operators who want tilt signals, not affiliate spam.',
+];
+
+export const OPERATOR_BENEFITS = [
+  {
+    title: 'Trust scoring API',
+    body: 'Evidence-backed operator scores you can plug into onboarding or review queues.',
+  },
+  {
+    title: 'RG signals',
+    body: 'Session pacing and pressure-loop signals without custodial money movement.',
+  },
+  {
+    title: 'Sandbox first',
+    body: 'Free sandbox with mocked responses. Production keys by review — not vibes.',
+  },
+];
+
+export const GRADING_STEPS = [
+  {
+    title: 'Curated baseline grade',
+    body: 'Each operator starts from a researched letter grade in our casino directory. That maps to a numeric score — not vibes, not affiliate rank.',
+  },
+  {
+    title: 'Category split',
+    body: 'Regulated, Sweeps, Crypto, Offshore, Grey Market, Skill Game, Scam — same grade can mean different risk shapes.',
+  },
+  {
+    title: 'Documented issues',
+    body: 'Known violations and license basis show on live proof pages. Empty here is not a clean bill — it means this static mirror lists baseline cards only.',
+  },
+  {
+    title: 'Live feed overlay',
+    body: 'On tiltcheck.me, RGaaS can overlay a live score. This Pages twin ships curated baselines only — we do not invent live data.',
+  },
+];
+
+export const TOOL_REGISTRY = [
+  {
+    href: '/tools/verify',
+    label: 'THE RECEIPT',
+    title: 'Manual Bet Verifier',
+    description: 'Recompute one bet from seeds/outcomes — no trusting the casino.',
+    status: 'live',
+  },
+  {
+    href: '/tools/domain-verifier',
+    label: 'PHISHING SHIELD',
+    title: 'Domain + Email Verifier',
+    description: 'Scan domains and emails for scam signals before you click.',
+    status: 'live',
+  },
+  {
+    href: '/tools/house-edge-scanner',
+    label: 'THE DELTA ENGINE',
+    title: 'House Edge Calculator',
+    description: 'Claimed payout vs what you got — rigged-session confidence score.',
+    status: 'live',
+  },
+  {
+    href: '/tools/geo-laws',
+    label: 'GEO LAWS',
+    title: 'Regulation by Region',
+    description: 'Legal status, regulators, and self-exclusion links by country.',
+    status: 'live',
+  },
+  {
+    href: '/tools/justthetip',
+    label: 'JUST THE TIP',
+    title: 'SOL Peer Tipping',
+    description: 'Tip SOL by Discord username. Non-custodial.',
+    status: 'live',
+  },
+  {
+    href: '/tools/session-stats',
+    label: 'PAYOUT DRIFT MONITOR',
+    title: 'Slot Math Index',
+    description: 'Certified RTP tier spreads per casino.',
+    status: 'beta',
+  },
+  {
+    href: '/tools/scan-scams',
+    label: 'SHADOW-BAN TRACKER',
+    title: 'Casino Restriction Log',
+    description: 'Community withdrawal delays and account restrictions.',
+    status: 'beta',
+  },
+  {
+    href: '/tools/collectclock',
+    label: 'COLLECTCLOCK',
+    title: 'BonusCheck 2.0',
+    description: 'Bonus cooldown timers and formula lab.',
+    status: 'beta',
+  },
+  {
+    href: '/tools/auto-vault',
+    label: 'LOCKVAULT',
+    title: 'Auto Profit Lock',
+    description: 'Durable vault rules in dashboard. In-tab skim via install links.',
+    status: 'beta',
+  },
+  {
+    href: '/tools/buddy-system',
+    label: 'BUDDY SYSTEM',
+    title: 'Accountability Partner',
+    description: 'Partner alerts when sessions go sideways.',
+    status: 'beta',
+  },
+];
+
+export const INSTALL_SURFACES = [
+  {
+    href: '/nuts',
+    label: 'NUTS AUTOVAULT',
+    title: 'Auto-lock wins on nuts.gg',
+    description: '4-step Android setup. DM link only — not nuts chat.',
+  },
+  {
+    href: '/stake',
+    label: 'STAKE AUTOVAULT',
+    title: 'Auto-lock wins on Stake.us',
+    description: 'Same script, Stake.us steps. SC/GC vault + session stats.',
+  },
+];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem and motivation

Pages home linked product routes but still read like brand vibes — a cold visitor would not know what TiltCheck *does*. Need plain-English pitch + linked product pages.

## Why this approach

Keep the static twin pipeline. Generate product HTML at build time. Add explainer sections (what it is, how it works, problem signals, FAQ) so the share link teaches the product without the API.

## Scope

- Home: what-it-is, Install/Watch/Exit, problem signals, FAQ, tools/features, operators
- Pages: `extension.html`, `casinos.html` (116 + search/filter), `tools.html`, `operators.html`
- Clearer ledes on extension / casinos / tools
- Nav/CTAs local; interactive tools deep-link to tiltcheck.me

## Verification

- [x] `pnpm docs:pages` builds
- [x] Home contains “What this is”, FAQ wallet answer, how-it-works
- [ ] After merge: live Pages spot-check
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7216-c040-7f6e-999c-175909090c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7216-c040-7f6e-999c-175909090c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

