### PR TITLE
fix(pages): drop platforms/operators section from Pages twin

### DIFF
--- a/docs/GITHUB-PAGES-TROUBLESHOOTING.md
+++ b/docs/GITHUB-PAGES-TROUBLESHOOTING.md
@@ -11,11 +11,10 @@ GitHub Pages (`gh-pages` branch) is a **static product twin** of tiltcheck.me â€
 
 | Path on Pages | Source |
 |---------------|--------|
-| `/` | Product landing (hero + three jobs + tools/features + operators) |
+| `/` | Product landing (hero + what-it-is + how it works + tools/features + FAQ) |
 | `/extension.html` | Extension install twin |
 | `/casinos.html` | Curated casino directory from `apps/web/src/data/casinos.json` (search/filter) |
 | `/tools.html` | Toolkit catalog (links to live interactive tools) |
-| `/operators.html` | RGaaS marketing shell (key form stays on live site) |
 | `/docs/*.html` | Specs secondary surface |
 | `/styles/base.css` | `scripts/pages-assets/styles/base.css` |
 | `/docs-md/*.md` | Raw markdown from `docs/tiltcheck/` |

--- a/scripts/convert-markdown.js
+++ b/scripts/convert-markdown.js
@@ -4,7 +4,7 @@
  *
  * GitHub Pages site builder for TiltCheck.
  * - `/` product landing twin
- * - `/extension|casinos|tools|operators.html` product pages
+ * - `/extension|casinos|tools.html` product pages
  * - `/docs/*` specs from markdown
  *
  * Project Pages require relative asset paths — never "/styles/...".
@@ -30,8 +30,6 @@ import {
   FEATURE_CARDS,
   FAQS,
   EXTENSION_SIGNALS,
-  OPERATOR_BULLETS,
-  OPERATOR_BENEFITS,
   GRADING_STEPS,
   TOOL_REGISTRY,
   INSTALL_SURFACES,
@@ -178,7 +176,6 @@ function navHtml(depth, current) {
     { id: 'extension', file: 'extension.html', label: 'Extension' },
     { id: 'casinos', file: 'casinos.html', label: 'Casinos' },
     { id: 'tools', file: 'tools.html', label: 'Tools' },
-    { id: 'operators', file: 'operators.html', label: 'Operators' },
     { id: 'specs', file: null, label: 'Specs' },
   ];
 
@@ -332,8 +329,6 @@ function buildRootLanding() {
 </details>`,
   ).join('\n');
 
-  const operatorList = OPERATOR_BULLETS.map((b) => `<li>${escapeHtml(b)}</li>`).join('\n');
-
   const content = `<main class="landing-page">
   <section class="hero-surface" aria-label="TiltCheck">
     <div class="landing-shell landing-hero-centered">
@@ -399,7 +394,7 @@ function buildRootLanding() {
         <span class="brand-eyebrow">Open these next</span>
         <h2 class="public-page-section-heading__title">Pages on this site.</h2>
       </div>
-      <p class="section-lede">Cold start? Extension first. Depositing somewhere new? Casinos. Want math tools? Toolkit. Running a platform? Operators.</p>
+      <p class="section-lede">Cold start? Extension first. Depositing somewhere new? Casinos. Want math tools? Toolkit.</p>
       <div class="public-page-grid public-page-grid--2">${featuresHtml}</div>
     </div>
   </section>
@@ -411,20 +406,6 @@ function buildRootLanding() {
         <h2 class="public-page-section-heading__title">Straight answers.</h2>
       </div>
       <div class="faq-list">${faqHtml}</div>
-    </div>
-  </section>
-
-  <section class="public-page-section" aria-label="Operators">
-    <div class="landing-shell">
-      <article class="public-page-card">
-        <span class="brand-eyebrow">For platforms / operators</span>
-        <h2 class="public-page-section-heading__title">Trust scoring as a service. Non-affiliated. RGaaS API.</h2>
-        <p class="public-page-card__copy">Players can skip this. If you need API access for trust signals or RG hooks:</p>
-        <ul class="public-page-card__copy public-page-card__copy--list">${operatorList}</ul>
-        <div style="margin-top:1.5rem">
-          <a class="btn btn-primary" href="operators.html">Operator details</a>
-        </div>
-      </article>
     </div>
   </section>
 
@@ -687,50 +668,6 @@ function buildToolsPage() {
   });
 }
 
-function buildOperatorsPage() {
-  const benefits = OPERATOR_BENEFITS.map(
-    (b) => `<article class="public-page-card">
-  <h3 class="public-page-card__title">${escapeHtml(b.title)}</h3>
-  <p class="public-page-card__copy">${escapeHtml(b.body)}</p>
-</article>`,
-  ).join('\n');
-
-  const content = `${productHero({
-    eyebrow: 'Operators / RGaaS',
-    title: 'Sandbox keys for trust signal — not vibes.',
-    lede: 'Plug RGaaS into onboarding, trust, or review queues. Free sandbox on the live site. This Pages twin is marketing-only — no key form here.',
-    actionsHtml: `<a class="btn btn-primary" href="${SITE_URL}/operators">Request sandbox keys</a>
-    <a class="hero-actions__secondary-link" href="${SITE_URL}/operators/pricing">Pricing</a>`,
-  })}
-<main class="product-main">
-  <section class="public-page-section">
-    <div class="landing-shell">
-      <div class="public-page-grid public-page-grid--3">${benefits}</div>
-    </div>
-  </section>
-  <section class="public-page-section">
-    <div class="landing-shell">
-      <article class="public-page-card">
-        <p class="public-page-card__eyebrow">Pricing snapshot</p>
-        <h2 class="public-page-card__title">Free sandbox. Production by review.</h2>
-        <p class="public-page-card__copy">Sandbox: mocked responses, capped volume. Production: manual review. Request keys on tiltcheck.me — we do not collect partner emails on GitHub Pages.</p>
-        <div style="margin-top:1.25rem">
-          <a class="btn btn-primary" href="${SITE_URL}/operators">Go to live operators</a>
-        </div>
-      </article>
-    </div>
-  </section>
-</main>`;
-
-  return shell({
-    title: 'Operators | TiltCheck',
-    description: 'TiltCheck RGaaS sandbox — trust scoring API for platforms.',
-    depth: 'root',
-    current: 'operators',
-    body: content,
-  });
-}
-
 function run() {
   if (!fs.existsSync(sourceRoot)) {
     console.error('Source directory missing:', sourceRoot);
@@ -770,11 +707,10 @@ function run() {
   fs.writeFileSync(path.join(siteRoot, 'extension.html'), buildExtensionPage());
   fs.writeFileSync(path.join(siteRoot, 'casinos.html'), buildCasinosPage(casinos));
   fs.writeFileSync(path.join(siteRoot, 'tools.html'), buildToolsPage());
-  fs.writeFileSync(path.join(siteRoot, 'operators.html'), buildOperatorsPage());
   fs.writeFileSync(path.join(siteRoot, '.nojekyll'), '');
 
   console.log(
-    `Built Pages site: ${files.length} specs + product pages (home, extension, casinos[${casinos.length}], tools, operators) → ${siteRoot}`,
+    `Built Pages site: ${files.length} specs + product pages (home, extension, casinos[${casinos.length}], tools) → ${siteRoot}`,
   );
 }
 

--- a/scripts/pages-product-data.mjs
+++ b/scripts/pages-product-data.mjs
@@ -117,14 +117,6 @@ export const FEATURE_CARDS = [
     href: 'tools.html',
     cta: 'See tools',
   },
-  {
-    eyebrow: 'Operators',
-    title: 'For platforms',
-    description:
-      'If you run a casino or RG product: RGaaS sandbox keys for trust signals — non-affiliated, non-custodial. Players skip this.',
-    href: 'operators.html',
-    cta: 'Operator access',
-  },
 ];
 
 export const FAQS = [
@@ -164,27 +156,6 @@ export const EXTENSION_SIGNALS = [
   { title: 'Read-only', body: 'Watches supported casino tabs. No private keys.' },
   { title: 'In-tab', body: 'Warnings and exit controls stay on your active screen.' },
   { title: 'Your rules', body: 'Profit targets and vault limits — we enforce what you set.' },
-];
-
-export const OPERATOR_BULLETS = [
-  'Trust scoring as a service — non-affiliated, evidence-backed.',
-  'RGaaS API for session guardrails without custodial flows.',
-  'Sandbox access for operators who want tilt signals, not affiliate spam.',
-];
-
-export const OPERATOR_BENEFITS = [
-  {
-    title: 'Trust scoring API',
-    body: 'Evidence-backed operator scores you can plug into onboarding or review queues.',
-  },
-  {
-    title: 'RG signals',
-    body: 'Session pacing and pressure-loop signals without custodial money movement.',
-  },
-  {
-    title: 'Sandbox first',
-    body: 'Free sandbox with mocked responses. Production keys by review — not vibes.',
-  },
 ];
 
 export const GRADING_STEPS = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Player-facing GitHub Pages twin still showed a **For platforms / operators** block (plus nav + feature card). Not needed on the share link.

## Change

- Remove home platforms section
- Remove Operators from nav and feature cards
- Stop generating `operators.html`
- Update Pages troubleshooting path table

## Verification

- [x] `pnpm docs:pages` — no operators.html; home has no platforms section
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7216-c040-7f6e-999c-175909090c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7216-c040-7f6e-999c-175909090c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

