### PR TITLE
feat(bonuses): Daily Promo Gather for /bonuses

### DIFF
--- a/.cursor/agents/promo-gather.md
+++ b/.cursor/agents/promo-gather.md
@@ -1,0 +1,65 @@
+---
+name: promo-gather
+description: Daily free-spins / promotions gatherer for /bonuses. Use when refreshing priority Sweeps promos from email, Discord drops, or public promo pages, or when promoting scrape proposals.
+---
+
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18 -->
+
+You are the Daily Promo Gather agent for TiltCheck.
+
+Primary objective:
+- Keep `tiltcheck.me/bonuses` stocked with real free spins, daily logins, and codes for priority Sweeps casinos.
+- Never invent offers. Skip when unknown.
+
+## Scope (v1)
+
+- Allowlist only: `docs/ops/daily-promos-priority.json` (Sweeps)
+- Auto-live sources: email inbox feed + Discord drops JSON
+- Public-page scrapes → proposals only until human/agent promote
+- Durable VIP/redemption/welcome facts belong in operator-facts, not this store
+
+## Workflow
+
+1) Ingest trusted sources
+```bash
+pnpm ops:promos:gather
+# optional dry run
+pnpm ops:promos:gather -- --dry-run
+```
+
+Expected inputs:
+- `data/email-bonus-feed.json` (or `EMAIL_BONUS_FEED_PATH`)
+- `data/bonus-discord-drops.json` (or `DISCORD_BONUS_DROPS_PATH`) shape:
+  `{ "drops": [ { "brand", "bonus", "url", "code?" } ] }`
+
+2) Optional public-page proposals
+```bash
+pnpm ops:promos:gather -- --scrape
+```
+Writes to `data/trust-engine/daily-promos.proposals.json` only. Never auto-live.
+
+3) Promote / reject proposals
+```bash
+pnpm ops:promos:promote -- --list
+pnpm ops:promos:promote -- --accept <id>
+pnpm ops:promos:promote -- --reject <id>
+```
+
+4) Verify product surface
+- `GET /bonuses/daily-feed` merges live + inbox + CollectClock
+- Web: `apps/web` `/bonuses` with filters All / Free spins / Daily / Codes / Other
+
+## Rules
+
+- Sweeps allowlist mismatch → skip the row
+- No affiliate endorsement copy — tracker tone only
+- Avoid brand-law false “custodial” phrasing in comments/docs
+- Atomic docs: update `docs/ops/DAILY-PROMOS.md` / `docs/api/bonuses.md` with behavior changes
+- UI footer remains: Made for Degens. By Degens.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-07-18-daily-promo-gather-design.md`
+- Plan: `docs/superpowers/plans/2026-07-18-daily-promo-gather.md`
+- Ops: `docs/ops/DAILY-PROMOS.md`
+- API: `docs/api/bonuses.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-05-18 -->
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18 -->
 
 # TiltCheck Agent Directory
 
@@ -23,6 +23,7 @@ Located in .cursor/agents/
 | Brand Law Enforcer | .cursor/agents/brand-law-enforcer.md | **NEW:** Enforces "The Degen Laws" on PRs — brand tone, copyright headers, no secrets, atomic docs. |
 | Frontend & Marketing Suggestions | .cursor/agents/frontend-marketing-suggestions.md | **NEW:** Weekly code update suggestions for web, dashboard, and extension UX/UI improvements. |
 | Casino Scraper | .cursor/agents/casino-public-data-scraper.md | Scrapes public casino data for the Trust Engine. |
+| Promo Gather | .cursor/agents/promo-gather.md | Daily free-spins / promos gatherer for `/bonuses` (email + Discord auto-live, public-page proposals). |
 | Daily Issue Finder | .cursor/agents/daily-issue-finder.md | (Merged) Reviews code changes and performs smoke tests on new features. |
 | Regulatory Scout | .cursor/agents/regulatory-scout.md | Functional: Monitors commission filings via SusLink integration. |
 | Verifier | .cursor/agents/verifier.md | Validates completed work. Skeptically confirms implementations are functional after tasks are marked done. |

--- a/apps/api/src/lib/daily-bonus-feed.ts
+++ b/apps/api/src/lib/daily-bonus-feed.ts
@@ -1,0 +1,257 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
+/**
+ * Daily Bonus Feed Aggregator
+ *
+ * Merges daily-promos.live, email inbox, and CollectClock into one feed.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getActiveEmailBonusEntries, type EmailBonusFeedEntry } from './email-bonus-feed.js';
+import {
+  getLiveDailyPromos,
+  isPromoStale,
+  type DailyPromoRecord,
+} from './daily-promos-store.js';
+
+export type BonusFeedSourceKey = 'daily-promos' | 'collectclock' | 'email-inbox' | 'local-fallback';
+
+export interface DailyBonusFeedEntry {
+  id: string;
+  brand: string;
+  bonus: string;
+  url: string;
+  verified: string;
+  code: string | null;
+  sources: BonusFeedSourceKey[];
+  bonusType: string | null;
+  bonusValue: string | null;
+  expiresAt: string | null;
+  expiryMessage: string | null;
+  imageUrl: string | null;
+  slug: string | null;
+  stale: boolean;
+}
+
+export interface BonusSourceStatus {
+  key: BonusFeedSourceKey;
+  label: string;
+  available: boolean;
+  count: number;
+  updatedAt: string | null;
+  detail: string;
+}
+
+export interface DailyBonusFeedResult {
+  updatedAt: string;
+  total: number;
+  data: DailyBonusFeedEntry[];
+  sources: BonusSourceStatus[];
+}
+
+interface RawBonusEntry {
+  brand: string;
+  bonus: string;
+  url: string;
+  verified: string;
+  code?: string | null;
+}
+
+const COLLECTCLOCK_BONUS_URL =
+  'https://raw.githubusercontent.com/TiltCheck-ME/CollectClock/main/bonus-data.json';
+
+const SOURCE_LABELS: Record<BonusFeedSourceKey, string> = {
+  'daily-promos': 'Daily promos (live)',
+  collectclock: 'CollectClock',
+  'email-inbox': 'Email inbox',
+  'local-fallback': 'Local cache',
+};
+
+const API_LIB_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+function normalizeKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function normalizeBonusKey(entry: Pick<RawBonusEntry, 'brand' | 'bonus' | 'url'>): string {
+  return `${entry.brand.trim().toLowerCase()}::${entry.bonus.trim().toLowerCase()}::${entry.url.trim().toLowerCase()}`;
+}
+
+function isRawBonusEntry(value: unknown): value is RawBonusEntry {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<RawBonusEntry>;
+  return (
+    typeof candidate.brand === 'string' &&
+    typeof candidate.bonus === 'string' &&
+    typeof candidate.url === 'string' &&
+    typeof candidate.verified === 'string'
+  );
+}
+
+function loadLocalFallback(): RawBonusEntry[] {
+  const candidates = [
+    path.resolve(API_LIB_DIR, '../../../../data/bonus-data.json'),
+    path.resolve(process.cwd(), 'data/bonus-data.json'),
+  ];
+  for (const filePath of candidates) {
+    if (!existsSync(filePath)) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+      if (!Array.isArray(parsed)) continue;
+      return parsed.filter(isRawBonusEntry);
+    } catch {
+      /* try next */
+    }
+  }
+  return [];
+}
+
+async function loadCollectClock(): Promise<RawBonusEntry[]> {
+  try {
+    const response = await fetch(COLLECTCLOCK_BONUS_URL, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) return [];
+    const parsed = (await response.json()) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isRawBonusEntry);
+  } catch {
+    return [];
+  }
+}
+
+function fromPromo(record: DailyPromoRecord): DailyBonusFeedEntry {
+  return {
+    id: record.id || normalizeBonusKey(record),
+    brand: record.brand,
+    bonus: record.bonus,
+    url: record.url,
+    verified: record.verified,
+    code: record.code,
+    sources: ['daily-promos'],
+    bonusType: record.bonusType || null,
+    bonusValue: null,
+    expiresAt: record.expiresAt,
+    expiryMessage: record.expiryMessage,
+    imageUrl: record.imageUrl,
+    slug: record.slug || null,
+    stale: isPromoStale(record),
+  };
+}
+
+function fromEmail(entry: EmailBonusFeedEntry): DailyBonusFeedEntry {
+  return {
+    id: entry.id || normalizeBonusKey(entry),
+    brand: entry.brand,
+    bonus: entry.bonus,
+    url: entry.url,
+    verified: entry.verified,
+    code: entry.code,
+    sources: ['email-inbox'],
+    bonusType: entry.bonusType || null,
+    bonusValue: entry.bonusValue || null,
+    expiresAt: entry.expiresAt,
+    expiryMessage: entry.expiryMessage || null,
+    imageUrl: entry.imageUrl,
+    slug: null,
+    stale: false,
+  };
+}
+
+function fromRaw(entry: RawBonusEntry, source: BonusFeedSourceKey): DailyBonusFeedEntry {
+  return {
+    id: `${source}:${normalizeBonusKey(entry)}`,
+    brand: entry.brand,
+    bonus: entry.bonus,
+    url: entry.url,
+    verified: entry.verified,
+    code: entry.code ?? null,
+    sources: [source],
+    bonusType: null,
+    bonusValue: null,
+    expiresAt: null,
+    expiryMessage: null,
+    imageUrl: null,
+    slug: null,
+    stale: false,
+  };
+}
+
+function mergeEntries(legs: Array<{ key: BonusFeedSourceKey; entries: DailyBonusFeedEntry[] }>): {
+  data: DailyBonusFeedEntry[];
+  sources: BonusSourceStatus[];
+} {
+  const byKey = new Map<string, DailyBonusFeedEntry>();
+  const sources: BonusSourceStatus[] = [];
+
+  for (const leg of legs) {
+    sources.push({
+      key: leg.key,
+      label: SOURCE_LABELS[leg.key],
+      available: leg.entries.length > 0,
+      count: leg.entries.length,
+      updatedAt: leg.entries[0]?.verified ?? null,
+      detail: leg.entries.length ? `${leg.entries.length} rows` : 'empty',
+    });
+    for (const entry of leg.entries) {
+      const key = normalizeBonusKey(entry);
+      const existing = byKey.get(key);
+      if (!existing) {
+        byKey.set(key, entry);
+        continue;
+      }
+      const existingTs = Date.parse(existing.verified);
+      const nextTs = Date.parse(entry.verified);
+      const winner = nextTs >= existingTs ? entry : existing;
+      const loser = winner === entry ? existing : entry;
+      byKey.set(key, {
+        ...winner,
+        sources: [...new Set([...winner.sources, ...loser.sources])],
+        stale: Boolean(winner.stale || loser.stale),
+        code: winner.code ?? loser.code,
+        bonusType: winner.bonusType ?? loser.bonusType,
+        expiresAt: winner.expiresAt ?? loser.expiresAt,
+        slug: winner.slug ?? loser.slug,
+      });
+    }
+  }
+
+  const data = [...byKey.values()].sort(
+    (a, b) => Date.parse(b.verified) - Date.parse(a.verified),
+  );
+  return { data, sources };
+}
+
+export async function buildDailyBonusFeed(options?: {
+  bonusType?: string | null;
+}): Promise<DailyBonusFeedResult> {
+  const livePromos = getLiveDailyPromos().map(fromPromo);
+  const inbox = getActiveEmailBonusEntries().map(fromEmail);
+  const collectClock = (await loadCollectClock()).map((e) => fromRaw(e, 'collectclock'));
+  const local = collectClock.length ? [] : loadLocalFallback().map((e) => fromRaw(e, 'local-fallback'));
+
+  let { data, sources } = mergeEntries([
+    { key: 'daily-promos', entries: livePromos },
+    { key: 'email-inbox', entries: inbox },
+    { key: 'collectclock', entries: collectClock },
+    { key: 'local-fallback', entries: local },
+  ]);
+
+  const typeFilter = options?.bonusType?.trim().toLowerCase();
+  if (typeFilter && typeFilter !== 'all') {
+    data = data.filter((row) => (row.bonusType || '').toLowerCase() === typeFilter);
+  }
+
+  return {
+    updatedAt: new Date().toISOString(),
+    total: data.length,
+    data,
+    sources,
+  };
+}
+
+export function __testables() {
+  return { normalizeKey, normalizeBonusKey, mergeEntries, fromRaw };
+}

--- a/apps/api/src/lib/daily-promos-store.test.ts
+++ b/apps/api/src/lib/daily-promos-store.test.ts
@@ -1,0 +1,108 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
+import { describe, expect, it } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  getLiveDailyPromos,
+  isPromoExpired,
+  isPromoStale,
+  readDailyPromosLive,
+} from './daily-promos-store.js';
+
+describe('daily-promos-store', () => {
+  it('marks expired promos', () => {
+    expect(
+      isPromoExpired({
+        id: '1',
+        brand: 'Pulsz',
+        slug: 'pulsz',
+        bonus: '10 free spins',
+        bonusType: 'free_spins',
+        code: null,
+        url: 'https://www.pulsz.com/',
+        source: 'email-inbox',
+        verified: '2026-07-01',
+        asOf: '2026-07-01T00:00:00.000Z',
+        expiresAt: '2020-01-01T00:00:00.000Z',
+        expiryMessage: null,
+        imageUrl: null,
+        status: 'live',
+      }),
+    ).toBe(true);
+  });
+
+  it('marks stale when verified older than 7 days', () => {
+    expect(
+      isPromoStale({
+        id: '2',
+        brand: 'McLuck',
+        slug: 'mcluck',
+        bonus: 'Daily login',
+        bonusType: 'daily_login',
+        code: null,
+        url: 'https://www.mcluck.com/',
+        source: 'discord',
+        verified: '2020-01-01',
+        asOf: '2020-01-01T00:00:00.000Z',
+        expiresAt: null,
+        expiryMessage: null,
+        imageUrl: null,
+        status: 'live',
+      }),
+    ).toBe(true);
+  });
+
+  it('loads live file and drops ancient rows', () => {
+    const dir = path.join(tmpdir(), `daily-promos-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, 'daily-promos.live.json');
+    writeFileSync(
+      filePath,
+      JSON.stringify({
+        updatedAt: new Date().toISOString(),
+        promos: [
+          {
+            id: 'fresh',
+            brand: 'Stake.us',
+            slug: 'stake-us',
+            bonus: '5 free spins',
+            bonusType: 'free_spins',
+            code: null,
+            url: 'https://stake.us/',
+            source: 'email-inbox',
+            verified: new Date().toISOString().slice(0, 10),
+            asOf: new Date().toISOString(),
+            expiresAt: null,
+            expiryMessage: null,
+            imageUrl: null,
+            status: 'live',
+          },
+          {
+            id: 'ancient',
+            brand: 'Pulsz',
+            slug: 'pulsz',
+            bonus: 'old',
+            bonusType: 'other',
+            code: null,
+            url: 'https://www.pulsz.com/',
+            source: 'discord',
+            verified: '2019-01-01',
+            asOf: '2019-01-01T00:00:00.000Z',
+            expiresAt: null,
+            expiryMessage: null,
+            imageUrl: null,
+            status: 'live',
+          },
+        ],
+      }),
+      'utf8',
+    );
+
+    const file = readDailyPromosLive(filePath);
+    expect(file.promos).toHaveLength(2);
+    const live = getLiveDailyPromos(filePath);
+    expect(live.map((p) => p.id)).toEqual(['fresh']);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/apps/api/src/lib/daily-promos-store.ts
+++ b/apps/api/src/lib/daily-promos-store.ts
@@ -1,0 +1,91 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
+/**
+ * Daily promo live store loader for the API daily-feed aggregator.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type PromoSource = 'email-inbox' | 'discord' | 'public-page' | 'collectclock';
+export type PromoBonusType = 'free_spins' | 'daily_login' | 'deposit_match' | 'code' | 'other';
+
+export interface DailyPromoRecord {
+  id: string;
+  brand: string;
+  slug: string;
+  bonus: string;
+  bonusType: PromoBonusType | string;
+  code: string | null;
+  url: string;
+  source: PromoSource | string;
+  verified: string;
+  asOf: string;
+  expiresAt: string | null;
+  expiryMessage: string | null;
+  imageUrl: string | null;
+  status: 'live' | 'proposed' | 'rejected' | 'expired' | string;
+}
+
+export interface DailyPromosFile {
+  copyright?: string;
+  updatedAt: string | null;
+  promos: DailyPromoRecord[];
+}
+
+const STALE_MS = 7 * 86400000;
+const DROP_MS = 14 * 86400000;
+
+const API_LIB_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+export function getDailyPromosLivePath(): string {
+  return (
+    process.env.DAILY_PROMOS_LIVE_PATH?.trim() ||
+    path.resolve(API_LIB_DIR, '../../../../data/trust-engine/daily-promos.live.json')
+  );
+}
+
+export function isPromoExpired(entry: DailyPromoRecord, now = Date.now()): boolean {
+  if (!entry.expiresAt) return false;
+  const t = Date.parse(entry.expiresAt);
+  return Number.isFinite(t) && t < now;
+}
+
+export function isPromoStale(entry: DailyPromoRecord, now = Date.now()): boolean {
+  if (isPromoExpired(entry, now)) return false;
+  const verified = Date.parse(entry.verified || entry.asOf || '');
+  if (!Number.isFinite(verified)) return true;
+  return now - verified > STALE_MS;
+}
+
+function shouldDrop(entry: DailyPromoRecord, now = Date.now()): boolean {
+  if (isPromoExpired(entry, now)) return true;
+  const verified = Date.parse(entry.verified || entry.asOf || '');
+  if (!Number.isFinite(verified)) return true;
+  return now - verified > DROP_MS;
+}
+
+export function readDailyPromosLive(filePath = getDailyPromosLivePath()): DailyPromosFile {
+  if (!existsSync(filePath)) {
+    return { updatedAt: null, promos: [] };
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as Partial<DailyPromosFile>;
+    return {
+      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : null,
+      promos: Array.isArray(parsed.promos) ? (parsed.promos as DailyPromoRecord[]) : [],
+    };
+  } catch {
+    return { updatedAt: null, promos: [] };
+  }
+}
+
+/** Live-visible promos for the public feed. */
+export function getLiveDailyPromos(filePath = getDailyPromosLivePath()): DailyPromoRecord[] {
+  const now = Date.now();
+  const { promos } = readDailyPromosLive(filePath);
+  return promos
+    .filter((p) => p && p.status !== 'rejected' && p.status !== 'proposed')
+    .filter((p) => !shouldDrop(p, now))
+    .sort((a, b) => Date.parse(b.asOf || b.verified || 0) - Date.parse(a.asOf || a.verified || 0));
+}

--- a/apps/api/src/routes/bonuses.ts
+++ b/apps/api/src/routes/bonuses.ts
@@ -1,12 +1,15 @@
-// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
 /**
  * @tiltcheck/api - CollectClock Bonuses Proxy Routes
  *
- * Route: GET /bonuses         - Proxy CollectClock bonus data with trust score enrichment
- * Route: GET /bonuses/trust/:casinoName - Get trust score for a casino by name
+ * Route: GET /bonuses              - Proxy CollectClock bonus data
+ * Route: GET /bonuses/inbox        - Email inbox bonus feed
+ * Route: GET /bonuses/daily-feed   - Unified daily promo feed
+ * Route: GET /bonuses/trust/:name  - Stub trust score
  */
 
 import { Router, Request, Response } from 'express';
+import { buildDailyBonusFeed } from '../lib/daily-bonus-feed.js';
 import { getActiveEmailBonusEntries, readEmailBonusFeed } from '../lib/email-bonus-feed.js';
 import { optionalAuthMiddleware } from '../middleware/auth.js';
 import { resolveExclusionProfileForRequest, suppressBonusEntries } from '../services/bonus-suppression.js';
@@ -128,6 +131,41 @@ router.get('/inbox', optionalAuthMiddleware, async (req: Request, res: Response)
       total: 0,
       data: [],
       error: 'INBOX_FEED_LOAD_FAILED',
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /bonuses/daily-feed
+// Unified feed: daily-promos.live + email inbox + CollectClock (+ local fallback)
+// ---------------------------------------------------------------------------
+router.get('/daily-feed', optionalAuthMiddleware, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const bonusType = typeof req.query.bonusType === 'string' ? req.query.bonusType : null;
+    const feed = await buildDailyBonusFeed({ bonusType });
+    const profile = await resolveExclusionProfileForRequest(req);
+    const suppression = suppressBonusEntries(
+      feed.data as unknown as Record<string, unknown>[],
+      profile,
+    );
+
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.json({
+      ...feed,
+      total: suppression.entries.length,
+      data: suppression.entries,
+      suppression: {
+        active: suppression.active,
+        hiddenCount: suppression.hiddenCount,
+      },
+    });
+  } catch (error) {
+    console.error('[Bonuses] Failed to build daily feed:', error);
+    res.status(500).json({
+      error: 'DAILY_FEED_BUILD_FAILED',
+      message: 'Could not build daily bonus feed.',
+      total: 0,
+      data: [],
     });
   }
 });

--- a/apps/web/src/app/bonuses/page.tsx
+++ b/apps/web/src/app/bonuses/page.tsx
@@ -1,138 +1,56 @@
-/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-04-19 */
+/* © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18 */
 import React from 'react';
 import type { Metadata } from 'next';
-import BonusGrid, { BonusEntry } from '@/components/BonusGrid';
+import BonusGrid, { type BonusEntry } from '@/components/BonusGrid';
+import DailyBonusFeed from '@/components/DailyBonusFeed';
 import PublicPageHero from '@/components/PublicPageHero';
+import { fetchDailyBonusFeed } from '@/lib/daily-bonus-feed';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
   title: 'Daily Bonus Tracker | TiltCheck',
   description:
-    'Sweepstakes and social casino bonuses sourced from CollectClock and TiltCheck inbox intel.',
+    'Free spins and daily promos at priority sweeps casinos — gathered from inbox, Discord drops, and CollectClock.',
   openGraph: {
     title: 'Daily Bonus Tracker | TiltCheck',
     description:
-      'Sweepstakes and social casino bonuses sourced from CollectClock and TiltCheck inbox intel.',
+      'Free spins and daily promos at priority sweeps casinos — gathered from inbox, Discord drops, and CollectClock.',
     url: 'https://tiltcheck.me/bonuses',
   },
 };
 
 const COLLECTCLOCK_RAW_URL =
   'https://raw.githubusercontent.com/TiltCheck-ME/CollectClock/main/bonus-data.json';
-
 const COLLECTCLOCK_SITE_URL = 'https://tiltcheck-me.github.io/CollectClock/';
-const EMAIL_FEED_API_URL = (() => {
-  const apiBase = process.env.NEXT_PUBLIC_API_URL || process.env.API_URL;
-  if (!apiBase) return null;
-  return `${apiBase.replace(/\/$/, '')}/bonuses/inbox`;
-})();
 
-type BonusFeedResponse = {
-  data?: BonusEntry[];
-  available?: boolean;
-  updatedAt?: string | null;
-};
-
-function normalizeBonusKey(entry: BonusEntry): string {
-  return `${entry.brand.trim().toLowerCase()}::${entry.bonus.trim().toLowerCase()}::${entry.url.trim().toLowerCase()}`;
-}
-
-function mergeBonuses(...sources: BonusEntry[][]): BonusEntry[] {
-  const byKey = new Map<string, BonusEntry>();
-
-  for (const source of sources) {
-    for (const entry of source) {
-      const key = normalizeBonusKey(entry);
-      const existing = byKey.get(key);
-
-      if (!existing || Date.parse(entry.verified) > Date.parse(existing.verified)) {
-        byKey.set(key, entry);
-      }
-    }
-  }
-
-  return [...byKey.values()].sort(
-    (left, right) => Date.parse(right.verified) - Date.parse(left.verified)
-  );
-}
-
-type BonusFeedResult = {
-  bonuses: BonusEntry[];
-  available: boolean;
-  updatedAt: string | null;
-};
-
-async function fetchCollectClockBonuses(): Promise<BonusFeedResult> {
+async function fetchCollectClockFallback(): Promise<BonusEntry[]> {
   try {
-    const res = await fetch(COLLECTCLOCK_RAW_URL, {
-      next: { revalidate: 3600 },
-    });
-    if (!res.ok) {
-      console.error(
-        `[BonusTracker] CollectClock fetch failed: ${res.status} ${res.statusText}`
-      );
-      return { bonuses: [], available: false, updatedAt: null };
-    }
-    const data: BonusEntry[] = await res.json();
-    const bonuses = Array.isArray(data) ? data : [];
-    return {
-      bonuses,
-      available: bonuses.length > 0,
-      updatedAt: bonuses[0]?.verified ?? null,
-    };
-  } catch (err) {
-    console.error('[BonusTracker] Failed to load bonus data:', err);
-    return { bonuses: [], available: false, updatedAt: null };
-  }
-}
-
-async function fetchInboxBonuses(): Promise<BonusFeedResult> {
-  if (!EMAIL_FEED_API_URL) {
-    return { bonuses: [], available: false, updatedAt: null };
-  }
-
-  try {
-    const res = await fetch(EMAIL_FEED_API_URL, {
-      next: { revalidate: 300 },
-    });
-    if (!res.ok) {
-      console.error(
-        `[BonusTracker] Inbox bonus feed fetch failed: ${res.status} ${res.statusText}`
-      );
-      return { bonuses: [], available: false, updatedAt: null };
-    }
-    const data: BonusFeedResponse = await res.json();
-    const bonuses = Array.isArray(data.data) ? data.data : [];
-    return {
-      bonuses,
-      available: Boolean(data.available) && bonuses.length > 0,
-      updatedAt: data.updatedAt ?? bonuses[0]?.verified ?? null,
-    };
-  } catch (err) {
-    console.error('[BonusTracker] Failed to load inbox bonus feed:', err);
-    return { bonuses: [], available: false, updatedAt: null };
+    const res = await fetch(COLLECTCLOCK_RAW_URL, { next: { revalidate: 3600 } });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
   }
 }
 
 export default async function BonusesPage() {
-  const [collectClockFeed, inboxFeed] = await Promise.all([
-    fetchCollectClockBonuses(),
-    fetchInboxBonuses(),
-  ]);
-  const bonuses = mergeBonuses(inboxFeed.bonuses, collectClockFeed.bonuses);
-  const hasAnyFeed = bonuses.length > 0;
-  const sourceLabel = inboxFeed.available ? 'COLLECTCLOCK + EMAIL INBOX' : 'COLLECTCLOCK';
+  const feed = await fetchDailyBonusFeed();
+  const fallback = feed.available ? [] : await fetchCollectClockFallback();
+  const useFallback = !feed.available && fallback.length > 0;
 
   return (
     <main className="public-page public-page--tight text-white">
       <PublicPageHero
         compact
-        eyebrow="Bonus intel"
-        title="Claim first. Deposit later."
+        eyebrow="Daily promos"
+        title="Free spins. Daily drops. Receipts optional."
         description={
           <p>
-            CollectClock plus inbox email drops — free value before real-money deposits.
+            Priority sweeps promos gathered for `/bonuses` — free spins, daily logins, and codes.
+            Trusted inbox/Discord hits go live; public-page scrapes stay proposals until promoted.
+            Always verify terms on the casino site.
           </p>
         }
         actions={
@@ -150,37 +68,30 @@ export default async function BonusesPage() {
 
       <section className="public-page-section px-4">
         <div className="landing-shell">
-          <p className="mb-4 text-[11px] font-mono uppercase tracking-[0.16em] text-gray-500">
-            {bonuses.length} offers · {sourceLabel.toLowerCase()} · verify terms before claiming
-          </p>
-          {!collectClockFeed.available && inboxFeed.available && (
-            <div className="mb-6 public-page-card public-page-card--accent">
-              <p className="text-xs font-mono uppercase tracking-widest text-[#17c3b2]">
-                [COLLECTCLOCK OFFLINE] Showing inbox-discovered bonuses only.
-              </p>
-            </div>
-          )}
-
-          {!hasAnyFeed ? (
-            <div className="public-page-card py-20 text-center">
-              <p className="font-mono text-xs uppercase tracking-widest text-[#17c3b2] mb-2">
-                [DATA UNAVAILABLE]
-              </p>
-              <p className="font-mono text-[#8a97a8] text-sm">
-                CollectClock and inbox feeds are empty or unreachable. Check back shortly or visit{' '}
-                <a
-                  href={COLLECTCLOCK_SITE_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-[#17c3b2] hover:underline"
-                >
-                  CollectClock directly
-                </a>
-                .
-              </p>
-            </div>
+          {feed.available ? (
+            <DailyBonusFeed entries={feed.entries} sourceSummary={feed.sourceSummary} />
+          ) : useFallback ? (
+            <>
+              <div className="mb-6 public-page-card public-page-card--accent">
+                <p className="text-xs font-mono uppercase tracking-widest text-[#17c3b2]">
+                  [DAILY-FEED OFFLINE] Showing CollectClock fallback only.
+                </p>
+              </div>
+              <BonusGrid bonuses={fallback} />
+              <p className="mt-8 text-center text-[11px] text-gray-600">Made for Degens. By Degens.</p>
+            </>
           ) : (
-            <BonusGrid bonuses={bonuses} />
+            <div className="public-page-card py-20 text-center">
+              <p className="mb-2 font-mono text-xs uppercase tracking-widest text-[#17c3b2]">
+                [NO LIVE PROMOS YET]
+              </p>
+              <p className="font-mono text-sm text-[#8a97a8]">
+                Priority Sweeps gather has nothing live and CollectClock is unreachable. Run{' '}
+                <code className="text-[#17c3b2]">pnpm ops:promos:gather</code> after inbox/Discord
+                sources have data, or check back soon.
+              </p>
+              <p className="mt-8 text-[11px] text-gray-600">Made for Degens. By Degens.</p>
+            </div>
           )}
         </div>
       </section>

--- a/apps/web/src/components/DailyBonusFeed.tsx
+++ b/apps/web/src/components/DailyBonusFeed.tsx
@@ -1,0 +1,133 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { DailyBonusFeedEntry } from '@/lib/daily-bonus-feed';
+
+const FILTERS = [
+  { id: 'all', label: 'All' },
+  { id: 'free_spins', label: 'Free spins' },
+  { id: 'daily_login', label: 'Daily' },
+  { id: 'code', label: 'Codes' },
+  { id: 'other', label: 'Other' },
+] as const;
+
+function matchesFilter(entry: DailyBonusFeedEntry, filter: string): boolean {
+  if (filter === 'all') return true;
+  const type = (entry.bonusType || 'other').toLowerCase();
+  if (filter === 'other') {
+    return !['free_spins', 'daily_login', 'code', 'deposit_match'].includes(type);
+  }
+  return type === filter;
+}
+
+export default function DailyBonusFeed({
+  entries,
+  sourceSummary,
+}: {
+  entries: DailyBonusFeedEntry[];
+  sourceSummary: string;
+}) {
+  const [filter, setFilter] = useState<string>('all');
+  const visible = useMemo(
+    () => entries.filter((e) => matchesFilter(e, filter)),
+    [entries, filter],
+  );
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        {FILTERS.map((f) => (
+          <button
+            key={f.id}
+            type="button"
+            onClick={() => setFilter(f.id)}
+            className={`min-h-[36px] border px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.14em] transition-colors ${
+              filter === f.id
+                ? 'border-[#17c3b2] bg-[#17c3b2] text-black'
+                : 'border-[#283347] text-gray-400 hover:border-[#17c3b2]/50 hover:text-white'
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <p className="mb-4 text-[11px] font-mono uppercase tracking-[0.16em] text-gray-500">
+        {visible.length} offers · {sourceSummary.toLowerCase()} · verify terms before claiming
+      </p>
+
+      {visible.length === 0 ? (
+        <div className="public-page-card py-16 text-center">
+          <p className="mb-2 font-mono text-xs uppercase tracking-widest text-[#17c3b2]">
+            [NO MATCHES]
+          </p>
+          <p className="font-mono text-sm text-[#8a97a8]">
+            No live promos for this filter yet. Priority Sweeps gather is warming up — CollectClock
+            rows still merge in when the API can reach them.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {visible.map((entry) => (
+            <article
+              key={entry.id}
+              className="public-page-card flex flex-col justify-between border border-[#283347] bg-[#0a0c10]/80 p-4"
+            >
+              <div>
+                <div className="mb-2 flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-[#17c3b2]">
+                    {entry.bonusType || 'offer'}
+                  </span>
+                  {(entry.sources || []).slice(0, 2).map((src) => (
+                    <span
+                      key={src}
+                      className="border border-[#283347] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wider text-gray-500"
+                    >
+                      {src}
+                    </span>
+                  ))}
+                  {entry.stale ? (
+                    <span className="border border-yellow-500/40 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wider text-yellow-400">
+                      stale
+                    </span>
+                  ) : null}
+                </div>
+                <h3 className="text-lg font-black uppercase tracking-tight text-white">{entry.brand}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-[#c4ced8]">{entry.bonus}</p>
+                {entry.code ? (
+                  <p className="mt-2 font-mono text-xs uppercase tracking-widest text-[#ffd700]">
+                    Code: {entry.code}
+                  </p>
+                ) : null}
+                <p className="mt-2 font-mono text-[10px] uppercase tracking-wider text-gray-600">
+                  Verified {entry.verified}
+                </p>
+              </div>
+              <div className="mt-4 flex flex-wrap gap-3">
+                <a
+                  href={entry.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn btn-primary text-[10px]"
+                >
+                  Open offer
+                </a>
+                {entry.slug ? (
+                  <a
+                    href={`/casinos/${entry.slug}`}
+                    className="font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-[#17c3b2] hover:underline"
+                  >
+                    Trust page
+                  </a>
+                ) : null}
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+
+      <p className="mt-8 text-center text-[11px] text-gray-600">Made for Degens. By Degens.</p>
+    </div>
+  );
+}

--- a/apps/web/src/lib/daily-bonus-feed.ts
+++ b/apps/web/src/lib/daily-bonus-feed.ts
@@ -1,0 +1,64 @@
+// © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
+
+export type DailyBonusFeedEntry = {
+  id: string;
+  brand: string;
+  bonus: string;
+  url: string;
+  verified: string;
+  code: string | null;
+  sources?: string[];
+  bonusType?: string | null;
+  bonusValue?: string | null;
+  expiresAt?: string | null;
+  expiryMessage?: string | null;
+  imageUrl?: string | null;
+  slug?: string | null;
+  stale?: boolean;
+};
+
+export type DailyBonusFeedResponse = {
+  updatedAt?: string;
+  total?: number;
+  data?: DailyBonusFeedEntry[];
+  sources?: Array<{ key: string; label: string; available: boolean; count: number }>;
+};
+
+export function getDailyBonusFeedUrl(): string | null {
+  const apiBase = process.env.NEXT_PUBLIC_API_URL || process.env.API_URL;
+  if (!apiBase) return null;
+  return `${apiBase.replace(/\/$/, '')}/bonuses/daily-feed`;
+}
+
+export async function fetchDailyBonusFeed(bonusType?: string): Promise<{
+  entries: DailyBonusFeedEntry[];
+  available: boolean;
+  updatedAt: string | null;
+  sourceSummary: string;
+}> {
+  const base = getDailyBonusFeedUrl();
+  if (!base) {
+    return { entries: [], available: false, updatedAt: null, sourceSummary: 'api offline' };
+  }
+  const url = bonusType && bonusType !== 'all' ? `${base}?bonusType=${encodeURIComponent(bonusType)}` : base;
+  try {
+    const res = await fetch(url, { next: { revalidate: 300 } });
+    if (!res.ok) {
+      return { entries: [], available: false, updatedAt: null, sourceSummary: 'daily-feed error' };
+    }
+    const body = (await res.json()) as DailyBonusFeedResponse;
+    const entries = Array.isArray(body.data) ? body.data : [];
+    const activeSources = (body.sources || [])
+      .filter((s) => s.available)
+      .map((s) => s.label)
+      .join(' + ');
+    return {
+      entries,
+      available: entries.length > 0,
+      updatedAt: body.updatedAt ?? null,
+      sourceSummary: activeSources || 'daily-feed',
+    };
+  } catch {
+    return { entries: [], available: false, updatedAt: null, sourceSummary: 'daily-feed unreachable' };
+  }
+}

--- a/data/trust-engine/daily-promos.live.json
+++ b/data/trust-engine/daily-promos.live.json
@@ -1,0 +1,5 @@
+{
+  "copyright": "© 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18",
+  "updatedAt": null,
+  "promos": []
+}

--- a/data/trust-engine/daily-promos.proposals.json
+++ b/data/trust-engine/daily-promos.proposals.json
@@ -1,0 +1,5 @@
+{
+  "copyright": "© 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18",
+  "updatedAt": null,
+  "promos": []
+}

--- a/docs/api/bonuses.md
+++ b/docs/api/bonuses.md
@@ -1,0 +1,81 @@
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18 -->
+
+# Bonuses API
+
+Daily promo tracker endpoints for free spins, daily logins, and codes on priority Sweeps casinos. Primary product surface: `tiltcheck.me/bonuses`.
+
+Ops runbook: [docs/ops/DAILY-PROMOS.md](../ops/DAILY-PROMOS.md)
+
+## `GET /bonuses/daily-feed`
+
+Unified feed: `daily-promos.live` + email inbox + CollectClock (+ local `data/bonus-data.json` fallback when CollectClock is empty).
+
+### Query
+
+| Param | Type | Notes |
+|-------|------|-------|
+| `bonusType` | string | Optional. `free_spins`, `daily_login`, `code`, `deposit_match`, `other`, or `all` |
+
+### Response
+
+```json
+{
+  "updatedAt": "2026-07-18T12:00:00.000Z",
+  "total": 2,
+  "data": [
+    {
+      "id": "promo-id",
+      "brand": "Pulsz",
+      "bonus": "10 free spins",
+      "url": "https://www.pulsz.com/",
+      "verified": "2026-07-18",
+      "code": null,
+      "sources": ["daily-promos", "email-inbox"],
+      "bonusType": "free_spins",
+      "bonusValue": null,
+      "expiresAt": null,
+      "expiryMessage": null,
+      "imageUrl": null,
+      "slug": "pulsz",
+      "stale": false
+    }
+  ],
+  "sources": [
+    {
+      "key": "daily-promos",
+      "label": "Daily promos (live)",
+      "available": true,
+      "count": 1,
+      "updatedAt": "2026-07-18",
+      "detail": "1 rows"
+    }
+  ],
+  "suppression": {
+    "active": false,
+    "hiddenCount": 0
+  }
+}
+```
+
+### Notes
+
+- CORS: `Access-Control-Allow-Origin: *`
+- Auth optional (`optionalAuthMiddleware`); exclusion profile can suppress rows
+- Public-page scrape proposals are **not** in this feed until promoted to live
+- Expired / >14d unverified live rows are omitted by the store filter
+- 7–14d unverified rows may appear with `stale: true`
+
+## Related routes
+
+| Route | Role |
+|-------|------|
+| `GET /bonuses/inbox` | Raw email inbox bonus entries |
+| `GET /bonuses/trust/:casinoName` | Trust stub for casino name |
+
+## Ops ingest
+
+```bash
+pnpm ops:promos:gather
+pnpm ops:promos:gather -- --scrape
+pnpm ops:promos:promote -- --list
+```

--- a/docs/ops/DAILY-PROMOS.md
+++ b/docs/ops/DAILY-PROMOS.md
@@ -1,0 +1,53 @@
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18 -->
+
+# Daily Promos Ops Runbook
+
+Hybrid gatherer for free spins / daily promotions on priority Sweeps casinos. Primary UI: `tiltcheck.me/bonuses`.
+
+## Stores
+
+| File | Role |
+|------|------|
+| `docs/ops/daily-promos-priority.json` | Sweeps allowlist + optional `promoUrl` |
+| `data/trust-engine/daily-promos.live.json` | Auto + promoted live rows |
+| `data/trust-engine/daily-promos.proposals.json` | Public-page scrape proposals |
+
+## Commands
+
+```bash
+# Ingest email feed + Discord drops JSON → live (allowlist only)
+pnpm ops:promos:gather
+
+# Also fetch public promo URLs → proposals only (never auto-live)
+pnpm ops:promos:gather -- --scrape
+
+# Dry run
+pnpm ops:promos:gather -- --dry-run
+
+# Promote proposals
+pnpm ops:promos:promote -- --list
+pnpm ops:promos:promote -- --accept <id>
+pnpm ops:promos:promote -- --reject <id>
+```
+
+## Trusted auto-live sources
+
+1. `data/email-bonus-feed.json` (or `EMAIL_BONUS_FEED_PATH`)
+2. `data/bonus-discord-drops.json` (or `DISCORD_BONUS_DROPS_PATH`) — shape: `{ "drops": [ { "brand", "bonus", "url", "code?" } ] }`
+
+Brand must match a Sweeps allowlist name/slug or the row is skipped.
+
+## Public-page scrapes
+
+`--scrape` fetches each allowlist `promoUrl`. Only creates a proposal when the page title/body clearly mentions free spins / daily bonus language. No inventing.
+
+## API
+
+`GET /bonuses/daily-feed` merges live promos + email inbox + CollectClock (+ local `data/bonus-data.json` fallback).
+
+## Rules
+
+- Never auto-promote `public-page` sources
+- Expired / >14d unverified rows drop from feed
+- 7–14d unverified → stale badge
+- Not affiliate endorsements — tracker only

--- a/docs/ops/daily-promos-priority.json
+++ b/docs/ops/daily-promos-priority.json
@@ -1,0 +1,25 @@
+{
+  "copyright": "© 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18",
+  "coverageNote": "v1 Sweeps-only allowlist derived from operator-facts-priority.json",
+  "operators": [
+    { "slug": "chumba-casino", "name": "Chumba Casino", "promoUrl": "https://www.chumbacasino.com/" },
+    { "slug": "global-poker", "name": "Global Poker", "promoUrl": "https://www.globalpoker.com/" },
+    { "slug": "luckyland-slots", "name": "LuckyLand Slots", "promoUrl": "https://www.luckylandslots.com/" },
+    { "slug": "pulsz", "name": "Pulsz", "promoUrl": "https://www.pulsz.com/" },
+    { "slug": "wow-vegas", "name": "WOW Vegas", "promoUrl": "https://www.wowvegas.com/" },
+    { "slug": "high-5-casino", "name": "High 5 Casino", "promoUrl": "https://www.high5casino.com/" },
+    { "slug": "stake-us", "name": "Stake.us", "promoUrl": "https://stake.us/" },
+    { "slug": "mcluck", "name": "McLuck", "promoUrl": "https://www.mcluck.com/" },
+    { "slug": "fortune-coins", "name": "Fortune Coins", "promoUrl": "https://www.fortunecoins.com/" },
+    { "slug": "hello-millions", "name": "Hello Millions", "promoUrl": "https://hellomillions.com/" },
+    { "slug": "modo-casino", "name": "Modo Casino", "promoUrl": "https://modo.us/" },
+    { "slug": "myprize-us", "name": "MyPrize US", "promoUrl": "https://myprize.com/" },
+    { "slug": "crown-coins-casino", "name": "Crown Coins Casino", "promoUrl": "https://crowncoinscasino.com/" },
+    { "slug": "funrize", "name": "Funrize", "promoUrl": "https://funrize.com/" },
+    { "slug": "zula-casino", "name": "Zula Casino", "promoUrl": "https://zulacasino.com/" },
+    { "slug": "real-prize", "name": "Real Prize", "promoUrl": "https://realprize.com/" },
+    { "slug": "jackpota", "name": "Jackpota", "promoUrl": "https://www.jackpota.com/" },
+    { "slug": "nolimitcoins", "name": "NoLimitCoins", "promoUrl": "https://nolimitcoins.com/" },
+    { "slug": "rolla", "name": "Rolla", "promoUrl": "https://rolla.com/" }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-18-daily-promo-gather.md
+++ b/docs/superpowers/plans/2026-07-18-daily-promo-gather.md
@@ -1,0 +1,96 @@
+# Daily Promo Gather Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hybrid promo gatherer (email + Discord auto-live, public-page proposals) feeding `GET /bonuses/daily-feed` and `tiltcheck.me/bonuses` for priority Sweeps free spins / daily promos.
+
+**Architecture:** JSON live/proposals stores under `data/trust-engine/`, ops gather + promote CLIs, API aggregator merging live promos + email inbox + CollectClock, web `/bonuses` consuming daily-feed with type filters.
+
+**Tech Stack:** Node ESM scripts, Express API (`apps/api`), Next.js web (`apps/web`), vitest, existing email-bonus-feed + CollectClock URLs.
+
+**Spec:** [docs/superpowers/specs/2026-07-18-daily-promo-gather-design.md](../specs/2026-07-18-daily-promo-gather-design.md)
+
+## Global Constraints
+
+- Copyright header: `© 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18`
+- No emojis; footer on user UI: `Made for Degens. By Degens.`
+- Sweeps-only allowlist in v1; never auto-promote `public-page` sources
+- No invented offers; omit when unknown
+- Atomic docs with code (`docs/ops/DAILY-PROMOS.md`, API note)
+- Avoid brand-law false “custodial” hits in source comments (do not phrase as holding user funds)
+
+## File map
+
+| Path | Responsibility |
+|------|----------------|
+| `docs/ops/daily-promos-priority.json` | Sweeps allowlist + optional promoUrl |
+| `data/trust-engine/daily-promos.live.json` | Live promos |
+| `data/trust-engine/daily-promos.proposals.json` | Proposed scrapes |
+| `apps/api/src/lib/daily-promos-store.ts` | Load/save/normalize/dedupe/freshness |
+| `apps/api/src/lib/daily-bonus-feed.ts` | Aggregator for daily-feed |
+| `apps/api/src/routes/bonuses.ts` | `GET /bonuses/daily-feed` |
+| `scripts/ops/gather-daily-promos.mjs` | Ingest email/discord → live; public-page → proposals |
+| `scripts/ops/promote-daily-promos.mjs` | list/accept/reject |
+| `apps/web/src/lib/daily-bonus-feed.ts` | Client types + fetch helper |
+| `apps/web/src/components/DailyBonusFeed.tsx` | Filtered list UI |
+| `apps/web/src/app/bonuses/page.tsx` | Wire daily-feed |
+| `docs/ops/DAILY-PROMOS.md` | Ops runbook |
+| `docs/api/bonuses.md` | API contract |
+| `.cursor/agents/promo-gather.md` | Agent instructions |
+| `package.json` | `ops:promos:gather`, `ops:promos:promote` |
+| `tests/ops/daily-promos-store.test.ts` or api unit tests | Store + merge tests |
+
+---
+
+### Task 1: Priority list + empty stores + store helpers
+
+**Files:**
+- Create: `docs/ops/daily-promos-priority.json`
+- Create: `data/trust-engine/daily-promos.live.json`
+- Create: `data/trust-engine/daily-promos.proposals.json`
+- Create: `apps/api/src/lib/daily-promos-store.ts`
+- Create: `apps/api/src/lib/daily-promos-store.test.ts` (or under tests/)
+
+**Interfaces:**
+- Produces: `DailyPromoRecord`, `loadDailyPromosLive()`, `loadDailyPromosProposals()`, `upsertPromo()`, `isPromoStale()`, `isPromoExpired()`, `normalizePromoDedupeKey()`, `filterFeedPromos()`
+
+- [x] Write store tests (expire/stale/dedupe/allowlist)
+- [x] Implement store + empty JSON files + priority JSON (Sweeps only)
+- [x] Commit
+
+### Task 2: Gather + promote CLIs
+
+**Files:**
+- Create: `scripts/ops/gather-daily-promos.mjs`
+- Create: `scripts/ops/promote-daily-promos.mjs`
+- Modify: `package.json`
+- Create: `docs/ops/DAILY-PROMOS.md`
+
+- [x] Promote CLI mirror facts promote (list/accept/reject by id)
+- [x] Gather: read email feed file if present + bonus-drops JSON if present → live; optional `--scrape` stub that writes proposals from priority `promoUrl` titles only when fetch succeeds with clear text (no invent)
+- [x] Commit
+
+### Task 3: API daily-feed
+
+**Files:**
+- Create: `apps/api/src/lib/daily-bonus-feed.ts`
+- Modify: `apps/api/src/routes/bonuses.ts`
+- Create: `docs/api/bonuses.md`
+- Test: aggregator unit test
+
+- [x] Merge live + inbox + CollectClock (+ local fallback)
+- [x] Route `GET /bonuses/daily-feed`
+- [x] Commit
+
+### Task 4: Web `/bonuses` UI
+
+**Files:**
+- Create: `apps/web/src/lib/daily-bonus-feed.ts`
+- Create: `apps/web/src/components/DailyBonusFeed.tsx`
+- Modify: `apps/web/src/app/bonuses/page.tsx`
+- Create: `.cursor/agents/promo-gather.md`
+
+- [x] Fetch daily-feed with CollectClock+inbox fallback if API missing
+- [x] Filters: All / Free spins / Daily / Codes / Other
+- [x] Source + stale badges; footer degen line
+- [x] Commit + push + update PR

--- a/docs/superpowers/specs/2026-07-18-daily-promo-gather-design.md
+++ b/docs/superpowers/specs/2026-07-18-daily-promo-gather-design.md
@@ -1,0 +1,200 @@
+<!-- © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18 -->
+
+# Daily Promo Gather Agent — Design Spec
+
+Status: Approved (design)  
+Owner: founder (solo)  
+Surface: `tiltcheck.me/bonuses` (primary); API `GET /bonuses/daily-feed`  
+Related: CollectClock bonus feed, email inbox bonus intel, channel-watcher Discord drops, operator-facts promote pattern, MVP patch `docs/migration/tiltcheckmvp-patches/daily-bonus-feed/`
+
+## Problem
+
+Users want a trustworthy list of **free spins and other daily promotions** at relevant casinos. Today `/bonuses` merges CollectClock + email inbox, but there is no dedicated gatherer for rotating free-spin / daily promo inventory, no proposal lane for public-page finds, and no unified daily-feed contract on main.
+
+## Goals
+
+- Hybrid gather: **email inbox + Discord drops + public promo pages** (+ CollectClock as merge source)
+- Priority **Sweeps** operators from `docs/ops/operator-facts-priority.json` (v1)
+- Auto-publish from trusted sources (email + Discord); public-page scrapes → proposals until promote
+- Primary UI: **`/bonuses`** showing free spins and daily promos with filters
+- Canonical API: **`GET /bonuses/daily-feed`**
+- No invented offers — omit when unknown; label source + freshness
+
+## Non-goals (v1)
+
+- Auto-promote public-page scrapes
+- Full `casinos.json` coverage
+- Crypto operators in v1 feed (priority JSON includes crypto; **v1 allowlist = Sweeps category only**)
+- Discord or extension as primary UI (may consume the same API later)
+- Login-walled or authenticated casino scrapes
+- Replacing CollectClock timers / claim UX
+- Operator-facts welcome-bonus store (different job: cited durable facts, not daily inventory)
+
+## Decisions (locked)
+
+| Topic | Choice |
+|-------|--------|
+| Primary surface | `tiltcheck.me/bonuses` |
+| Gather mode | Hybrid: email + public pages + Discord |
+| Casino scope | Priority list Sweeps only (~19 from operator-facts-priority) |
+| Publish gate | Auto-live: email + Discord; propose: public-page |
+| Architecture | Extend existing bonus stack + live/proposals JSON + promote CLI |
+| CollectClock | Remains a merge source in daily-feed aggregator |
+
+## Allowlist (v1)
+
+Derived from `docs/ops/operator-facts-priority.json` where `category === "Sweeps"`:
+
+Chumba, Global Poker, LuckyLand Slots, Pulsz, WOW Vegas, High 5 Casino, Stake.us, McLuck, Fortune Coins, Hello Millions, Modo Casino, MyPrize US, Crown Coins Casino, Funrize, Zula Casino, Real Prize, Jackpota, NoLimitCoins, Rolla.
+
+Tracked as `docs/ops/daily-promos-priority.json` (generated or hand-copied from that filter) so promo ops do not silently pick up crypto rows.
+
+## Data stores
+
+| Path | Visibility | Writers |
+|------|------------|---------|
+| `data/trust-engine/daily-promos.live.json` | Merged into `/bonuses` via daily-feed | Email + Discord auto-ingest; promote CLI |
+| `data/trust-engine/daily-promos.proposals.json` | Ops only | Public-page gather agent |
+
+### Entry schema
+
+```ts
+type PromoSource = 'email-inbox' | 'discord' | 'public-page' | 'collectclock';
+type PromoBonusType = 'free_spins' | 'daily_login' | 'deposit_match' | 'code' | 'other';
+
+interface DailyPromoRecord {
+  id: string;              // stable hash or uuid
+  brand: string;
+  slug: string;            // casino slug aligned with trust/casinos
+  bonus: string;           // human offer text
+  bonusType: PromoBonusType;
+  code: string | null;
+  url: string;             // claim / promo URL
+  source: PromoSource;
+  verified: string;        // ISO date (discovery / last confirm)
+  asOf: string;            // ISO datetime
+  expiresAt: string | null;
+  expiryMessage: string | null;
+  imageUrl: string | null;
+  status: 'live' | 'proposed' | 'rejected' | 'expired';
+}
+```
+
+File wrappers:
+
+```json
+{
+  "copyright": "© 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: YYYY-MM-DD",
+  "updatedAt": "ISO",
+  "promos": []
+}
+```
+
+### Freshness rules
+
+- Hide when `expiresAt` is in the past (status → `expired` or filtered out of feed)
+- If no `expiresAt` and `verified` older than **7 days** without refresh → show **stale** badge; still list until 14 days, then drop from feed
+- Dedupe key: `normalize(brand) + normalize(bonus) + normalize(url)` (same idea as existing BonusGrid merge)
+
+## Promo Gather agent
+
+### Responsibilities
+
+1. **Ingest email** — read new email-bonus-feed entries; if brand/slug on Sweeps allowlist → upsert **live** with `source: email-inbox`
+2. **Ingest Discord** — consume channel-watcher / bonus-drop payloads; allowlist → upsert **live** with `source: discord`
+3. **Scrape public pages** — for each allowlist casino with a configured public promo URL, fetch HTML/JSON, extract candidate offers → upsert **proposals** with `source: public-page` (never auto-live)
+4. **Normalize** — map free-spin language, codes, expiry strings into schema; refuse garbage / empty bonus text
+5. **Report** — stdout or ops log: counts live/proposed/stale/skipped
+
+### Configuration
+
+- `docs/ops/daily-promos-priority.json` — allowlist + optional `promoUrl` per casino
+- Env: reuse existing email/Discord paths; optional `DAILY_PROMOS_LIVE_PATH` / `DAILY_PROMOS_PROPOSALS_PATH` overrides
+- Rate limits: polite delays between public-page fetches; no auth cookies; skip non-200 / challenge pages
+
+### Promote CLI
+
+`pnpm ops:promos:promote` (script under `scripts/ops/promote-daily-promos.mjs`):
+
+- `list` — show proposals
+- `accept <id>` — move proposal → live
+- `reject <id>` — mark rejected
+- Same human-gate spirit as `pnpm ops:facts:promote`
+
+### Cursor agent doc
+
+`.cursor/agents/` (or extend casino-public-data-scraper notes) — **Promo Gather** instructions: allowlist, propose vs live rules, never invent offers, atomic docs.
+
+## API
+
+### `GET /bonuses/daily-feed`
+
+Land aggregator inspired by `docs/migration/tiltcheckmvp-patches/daily-bonus-feed/`:
+
+**Merge order (deduped):** daily-promos.live → email inbox → CollectClock → local fallback  
+
+**Query:** `usOnly` default true; optional `bonusType=free_spins`
+
+**Response:** `{ updatedAt, total, data[], sources[] }` where each entry includes `sources[]`, `bonusType`, `expiresAt`, trust/category enrichment when available.
+
+Existing `GET /bonuses` and `GET /bonuses/inbox` remain; daily-feed becomes the preferred consumer for the public page.
+
+## UI (`/bonuses`)
+
+- Hero: daily promo tracker framing (free spins + daily offers at priority sweeps)
+- Filter chips: All · Free spins · Daily login · Codes · Other
+- Cards: brand, offer, type, code (if any), source badge, verified/stale, CTA to claim URL; secondary link to `/casinos/[slug]` when known
+- Empty state: honest — “No live promos yet for the priority set. CollectClock fallback may still show.”
+- Footer: Made for Degens. By Degens.
+- Do not imply affiliate endorsement; not financial advice
+
+## Components / files (expected)
+
+| Path | Role |
+|------|------|
+| `data/trust-engine/daily-promos.live.json` | Live promos |
+| `data/trust-engine/daily-promos.proposals.json` | Proposed scrapes |
+| `docs/ops/daily-promos-priority.json` | Sweeps allowlist + promo URLs |
+| `docs/ops/DAILY-PROMOS.md` | Ops runbook |
+| `scripts/ops/gather-daily-promos.mjs` | Gather agent entry |
+| `scripts/ops/promote-daily-promos.mjs` | Promote CLI |
+| `apps/api/src/lib/daily-bonus-feed.ts` | Aggregator |
+| `apps/api/src/routes/bonuses.ts` | `GET /bonuses/daily-feed` |
+| `apps/web/src/app/bonuses/page.tsx` | Consume daily-feed |
+| `apps/web/src/components/DailyBonusFeed.tsx` (or BonusGrid evolution) | List UI |
+| `.cursor/agents/` promo-gather notes | Agent instructions |
+| `docs/bonuses.md` or `docs/api/bonuses.md` | Public/API docs (atomic) |
+
+## Threat / risk notes
+
+| Risk | Mitigation |
+|------|------------|
+| False or expired promo | TTL/stale rules; source badges; scrape propose-only |
+| Scrape ToS / blocks | Public URLs only; rate limit; skip challenges; no credentials |
+| Affiliate-looking UI | Blunt copy: tracker not endorsements |
+| Secret leakage | No tokens in git; env for Discord/email only |
+| Empty product | CollectClock fallback + empty state; coverage grows with ingest |
+
+## Rollback
+
+- Feature-flag or route `/bonuses` back to CollectClock+inbox-only merge
+- Empty live JSON → feed ignores that leg
+- Revert PR if aggregator regresses
+
+## Success criteria
+
+- [ ] Priority Sweeps allowlist file exists
+- [ ] Live + proposals JSON stores exist (may start empty)
+- [ ] Email/Discord allowlisted hits auto-upsert live
+- [ ] Public-page finds land in proposals only
+- [ ] `pnpm ops:promos:promote` accept/reject works
+- [ ] `GET /bonuses/daily-feed` returns merged feed
+- [ ] `/bonuses` shows free-spin filter and source badges
+- [ ] Docs + copyright headers atomic with code
+
+## Out of band (later)
+
+- Expand allowlist to crypto / full catalog
+- Discord digest consuming daily-feed
+- Extension sidebar switch to daily-feed
+- Auto-expiry sweeper cron on Railway/VPS

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "ops:research:run": "node scripts/ops/research-brief.mjs",
     "ops:research:merge-tasks": "node scripts/ops/merge-proposed-tasks.mjs",
     "ops:facts:promote": "node scripts/ops/promote-operator-facts.mjs",
+    "ops:promos:gather": "node scripts/ops/gather-daily-promos.mjs",
+    "ops:promos:promote": "node scripts/ops/promote-daily-promos.mjs",
     "seed:casino-trust": "node scripts/seed-casino-trust-from-scrape.js --include-existing --runtime-output ./data/casino-trust.json",
     "ops:task-ai": "node scripts/daily-task-ai.mjs",
     "trust:build": "pnpm --filter @tiltcheck/trust-engines build",

--- a/scripts/ops/gather-daily-promos.mjs
+++ b/scripts/ops/gather-daily-promos.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
+ *
+ * Promo Gather agent entrypoint.
+ * - Email inbox feed + Discord-shaped drops → auto-live (Sweeps allowlist)
+ * - Optional --scrape public promo URLs → proposals only (never auto-live)
+ *
+ * Usage:
+ *   node scripts/ops/gather-daily-promos.mjs
+ *   node scripts/ops/gather-daily-promos.mjs --scrape
+ *   node scripts/ops/gather-daily-promos.mjs --dry-run
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  REPO_ROOT,
+  DEFAULT_LIVE_PATH,
+  DEFAULT_PROPOSALS_PATH,
+  DEFAULT_PRIORITY_PATH,
+  loadPriority,
+  matchAllowlist,
+  readPromoFile,
+  writePromoFile,
+  upsertPromo,
+  inferBonusType,
+  normalizeRecord,
+} from './lib/daily-promos.mjs';
+
+function parseArgs(argv) {
+  return {
+    scrape: argv.includes('--scrape'),
+    dryRun: argv.includes('--dry-run'),
+    help: argv.includes('--help') || argv.includes('-h'),
+  };
+}
+
+function readJsonSafe(filePath, fallback) {
+  if (!existsSync(filePath)) return fallback;
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return fallback;
+  }
+}
+
+function loadEmailEntries() {
+  const feedPath = process.env.EMAIL_BONUS_FEED_PATH?.trim() || path.join(REPO_ROOT, 'data/email-bonus-feed.json');
+  const feed = readJsonSafe(feedPath, { bonuses: [] });
+  return Array.isArray(feed.bonuses) ? feed.bonuses : [];
+}
+
+/**
+ * Accept either channel-watcher style objects or a simple { brand, bonus, url } list
+ * under data/bonus-discord-drops.json (ops-maintained).
+ */
+function loadDiscordEntries() {
+  const dropPath =
+    process.env.DISCORD_BONUS_DROPS_PATH?.trim() || path.join(REPO_ROOT, 'data/bonus-discord-drops.json');
+  const raw = readJsonSafe(dropPath, { drops: [] });
+  if (Array.isArray(raw)) return raw;
+  if (Array.isArray(raw.drops)) return raw.drops;
+  if (Array.isArray(raw.bonuses)) return raw.bonuses;
+  return [];
+}
+
+function toLiveFromTrusted(entry, source, priority) {
+  const brand = entry.brand || entry.casino || entry.name;
+  const hit = matchAllowlist(brand, priority);
+  if (!hit) return null;
+  if (entry.isExpired) return null;
+  const bonus = entry.bonus || entry.offer || entry.title;
+  const url = entry.url || hit.promoUrl;
+  if (!bonus || !url) return null;
+  return normalizeRecord({
+    brand: hit.name,
+    slug: hit.slug,
+    bonus: String(bonus),
+    url: String(url),
+    code: entry.code ?? null,
+    bonusType: entry.bonusType || inferBonusType(bonus),
+    source,
+    verified: (entry.verified || entry.discoveredAt || new Date().toISOString()).toString().slice(0, 10),
+    asOf: entry.updatedAt || entry.discoveredAt || new Date().toISOString(),
+    expiresAt: entry.expiresAt || null,
+    expiryMessage: entry.expiryMessage || null,
+    imageUrl: entry.imageUrl || null,
+    status: 'live',
+  });
+}
+
+/** Very conservative public-page extract: title + first free-spin-ish line only. */
+async function scrapePublicProposal(op) {
+  if (!op.promoUrl) return null;
+  try {
+    const res = await fetch(op.promoUrl, {
+      headers: { Accept: 'text/html,application/xhtml+xml', 'User-Agent': 'TiltCheckPromoGather/1.0' },
+      signal: AbortSignal.timeout(12_000),
+      redirect: 'follow',
+    });
+    if (!res.ok) return null;
+    const html = await res.text();
+    const titleMatch = html.match(/<title[^>]*>([^<]{3,120})<\/title>/i);
+    const title = titleMatch ? titleMatch[1].replace(/\s+/g, ' ').trim() : '';
+    const bodyText = html
+      .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .slice(0, 8000);
+    const spinMatch = bodyText.match(/(.{0,40}free\s*spins?.{0,60})/i);
+    const dailyMatch = bodyText.match(/(.{0,40}(daily\s+bonus|login\s+bonus|daily\s+collect).{0,60})/i);
+    const snippet = (spinMatch?.[1] || dailyMatch?.[1] || '').trim();
+    if (!snippet && !/promo|bonus|free\s*spin/i.test(title)) {
+      // Do not invent — skip when no clear promo language
+      return null;
+    }
+    const bonus = snippet || `${title} (public page promo signal)`.slice(0, 160);
+    return normalizeRecord({
+      brand: op.name,
+      slug: op.slug,
+      bonus,
+      url: op.promoUrl,
+      bonusType: inferBonusType(bonus),
+      source: 'public-page',
+      status: 'proposed',
+      verified: new Date().toISOString().slice(0, 10),
+      asOf: new Date().toISOString(),
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(`gather-daily-promos
+
+  (default)  Ingest email + Discord allowlisted entries → live
+  --scrape   Also fetch public promo URLs → proposals only
+  --dry-run  Print actions without writing
+`);
+    return;
+  }
+
+  const priority = loadPriority(DEFAULT_PRIORITY_PATH);
+  const livePath = process.env.DAILY_PROMOS_LIVE_PATH || DEFAULT_LIVE_PATH;
+  const proposalsPath = process.env.DAILY_PROMOS_PROPOSALS_PATH || DEFAULT_PROPOSALS_PATH;
+  let liveDoc = readPromoFile(livePath);
+  let proposalsDoc = readPromoFile(proposalsPath);
+
+  const stats = { emailLive: 0, discordLive: 0, scrapeProposed: 0, skipped: 0 };
+
+  for (const entry of loadEmailEntries()) {
+    const rec = toLiveFromTrusted(entry, 'email-inbox', priority);
+    if (!rec) {
+      stats.skipped += 1;
+      continue;
+    }
+    const result = upsertPromo(liveDoc.promos, rec);
+    liveDoc.promos = result.promos;
+    if (result.changed) stats.emailLive += 1;
+  }
+
+  for (const entry of loadDiscordEntries()) {
+    const rec = toLiveFromTrusted(entry, 'discord', priority);
+    if (!rec) {
+      stats.skipped += 1;
+      continue;
+    }
+    const result = upsertPromo(liveDoc.promos, rec);
+    liveDoc.promos = result.promos;
+    if (result.changed) stats.discordLive += 1;
+  }
+
+  if (args.scrape) {
+    for (const op of priority) {
+      const proposal = await scrapePublicProposal(op);
+      if (!proposal) {
+        stats.skipped += 1;
+        continue;
+      }
+      const result = upsertPromo(proposalsDoc.promos, { ...proposal, status: 'proposed' });
+      proposalsDoc.promos = result.promos.map((p) =>
+        p.id === result.record?.id ? { ...p, status: 'proposed' } : p,
+      );
+      if (result.changed) stats.scrapeProposed += 1;
+      await new Promise((r) => setTimeout(r, 750));
+    }
+  }
+
+  console.log(JSON.stringify({ dryRun: args.dryRun, ...stats, allowlist: priority.length }, null, 2));
+
+  if (!args.dryRun) {
+    writePromoFile(livePath, liveDoc);
+    writePromoFile(proposalsPath, proposalsDoc);
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/ops/lib/daily-promos.mjs
+++ b/scripts/ops/lib/daily-promos.mjs
@@ -1,0 +1,169 @@
+/**
+ * © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
+ *
+ * Shared helpers for daily promo gather / promote CLIs.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+export const DEFAULT_LIVE_PATH = path.join(REPO_ROOT, 'data/trust-engine/daily-promos.live.json');
+export const DEFAULT_PROPOSALS_PATH = path.join(REPO_ROOT, 'data/trust-engine/daily-promos.proposals.json');
+export const DEFAULT_PRIORITY_PATH = path.join(REPO_ROOT, 'docs/ops/daily-promos-priority.json');
+
+const COPYRIGHT = '© 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18';
+const STALE_DAYS = 7;
+const DROP_DAYS = 14;
+
+export function normalizeKey(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+export function dedupeKey(entry) {
+  return `${normalizeKey(entry.brand)}::${normalizeKey(entry.bonus)}::${normalizeKey(entry.url)}`;
+}
+
+export function promoId(entry) {
+  return createHash('sha256').update(dedupeKey(entry)).digest('hex').slice(0, 16);
+}
+
+export function inferBonusType(text) {
+  const t = String(text || '').toLowerCase();
+  if (/free\s*spin|freespin|fs\b/.test(t)) return 'free_spins';
+  if (/daily|login\s*bonus|collect/.test(t)) return 'daily_login';
+  if (/deposit|match|%/.test(t)) return 'deposit_match';
+  if (/code|promo\s*code/.test(t)) return 'code';
+  return 'other';
+}
+
+export function loadPriority(filePath = DEFAULT_PRIORITY_PATH) {
+  const raw = JSON.parse(readFileSync(filePath, 'utf8'));
+  const operators = Array.isArray(raw.operators) ? raw.operators : [];
+  return operators
+    .filter((o) => o && typeof o.slug === 'string' && typeof o.name === 'string')
+    .map((o) => ({
+      slug: o.slug,
+      name: o.name,
+      promoUrl: typeof o.promoUrl === 'string' ? o.promoUrl : null,
+    }));
+}
+
+export function matchAllowlist(brand, priority) {
+  const key = normalizeKey(brand);
+  return priority.find((o) => normalizeKey(o.name) === key || normalizeKey(o.slug) === key) || null;
+}
+
+export function emptyFile() {
+  return { copyright: COPYRIGHT, updatedAt: null, promos: [] };
+}
+
+export function readPromoFile(filePath) {
+  if (!existsSync(filePath)) return emptyFile();
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+    return {
+      copyright: typeof parsed.copyright === 'string' ? parsed.copyright : COPYRIGHT,
+      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : null,
+      promos: Array.isArray(parsed.promos) ? parsed.promos : [],
+    };
+  } catch {
+    return emptyFile();
+  }
+}
+
+export function writePromoFile(filePath, doc) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const out = {
+    copyright: COPYRIGHT,
+    updatedAt: new Date().toISOString(),
+    promos: Array.isArray(doc.promos) ? doc.promos : [],
+  };
+  writeFileSync(filePath, `${JSON.stringify(out, null, 2)}\n`, 'utf8');
+  return out;
+}
+
+export function isExpired(entry, now = Date.now()) {
+  if (!entry?.expiresAt) return false;
+  const t = Date.parse(entry.expiresAt);
+  return Number.isFinite(t) && t < now;
+}
+
+export function isStale(entry, now = Date.now()) {
+  if (isExpired(entry, now)) return false;
+  const verified = Date.parse(entry?.verified || entry?.asOf || '');
+  if (!Number.isFinite(verified)) return true;
+  return now - verified > STALE_DAYS * 86400000;
+}
+
+export function shouldDrop(entry, now = Date.now()) {
+  if (isExpired(entry, now)) return true;
+  const verified = Date.parse(entry?.verified || entry?.asOf || '');
+  if (!Number.isFinite(verified)) return true;
+  return now - verified > DROP_DAYS * 86400000;
+}
+
+export function normalizeRecord(partial) {
+  const brand = String(partial.brand || '').trim();
+  const bonus = String(partial.bonus || '').trim();
+  const url = String(partial.url || '').trim();
+  if (!brand || !bonus || !url) return null;
+
+  const base = {
+    brand,
+    bonus,
+    url,
+    slug: String(partial.slug || '').trim(),
+    bonusType: partial.bonusType || inferBonusType(bonus),
+    code: partial.code == null || partial.code === '' ? null : String(partial.code),
+    source: partial.source || 'other',
+    verified: partial.verified || new Date().toISOString().slice(0, 10),
+    asOf: partial.asOf || new Date().toISOString(),
+    expiresAt: partial.expiresAt || null,
+    expiryMessage: partial.expiryMessage || null,
+    imageUrl: partial.imageUrl || null,
+    status: partial.status || 'live',
+  };
+  return {
+    ...base,
+    id: partial.id || promoId(base),
+  };
+}
+
+/**
+ * Upsert by dedupe key. Prefer newer verified timestamp.
+ */
+export function upsertPromo(promos, incoming) {
+  const rec = normalizeRecord(incoming);
+  if (!rec) return { promos, changed: false, record: null };
+  const key = dedupeKey(rec);
+  const next = [...promos];
+  const idx = next.findIndex((p) => dedupeKey(p) === key || p.id === rec.id);
+  if (idx === -1) {
+    next.push(rec);
+    return { promos: next, changed: true, record: rec };
+  }
+  const existing = next[idx];
+  const existingTs = Date.parse(existing.asOf || existing.verified || 0);
+  const incomingTs = Date.parse(rec.asOf || rec.verified || 0);
+  if (incomingTs >= existingTs) {
+    next[idx] = { ...existing, ...rec, id: existing.id || rec.id };
+    return { promos: next, changed: true, record: next[idx] };
+  }
+  return { promos: next, changed: false, record: existing };
+}
+
+export function filterVisiblePromos(promos, { includeStale = true } = {}) {
+  const now = Date.now();
+  return (promos || [])
+    .filter((p) => p && p.status !== 'rejected' && p.status !== 'proposed')
+    .filter((p) => !shouldDrop(p, now))
+    .filter((p) => includeStale || !isStale(p, now))
+    .sort((a, b) => Date.parse(b.asOf || b.verified || 0) - Date.parse(a.asOf || a.verified || 0));
+}

--- a/scripts/ops/promote-daily-promos.mjs
+++ b/scripts/ops/promote-daily-promos.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * © 2024–2026 TiltCheck Ecosystem. All Rights Reserved. Last Updated: 2026-07-18
+ *
+ * Promote or reject daily promo proposals into the live store.
+ *
+ * Usage:
+ *   node scripts/ops/promote-daily-promos.mjs --list
+ *   node scripts/ops/promote-daily-promos.mjs --accept <id>
+ *   node scripts/ops/promote-daily-promos.mjs --reject <id>
+ */
+
+import {
+  DEFAULT_LIVE_PATH,
+  DEFAULT_PROPOSALS_PATH,
+  readPromoFile,
+  writePromoFile,
+  upsertPromo,
+} from './lib/daily-promos.mjs';
+
+function parseArgs(argv) {
+  const out = { action: null, id: '', help: false };
+  for (let i = 0; i < argv.length; ) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      out.help = true;
+      i += 1;
+      continue;
+    }
+    if (arg === '--list') {
+      out.action = 'list';
+      i += 1;
+      continue;
+    }
+    if (arg === '--accept' || arg.startsWith('--accept=')) {
+      out.action = 'accept';
+      out.id = arg.includes('=') ? arg.split('=').slice(1).join('=') : argv[i + 1] || '';
+      i += arg.includes('=') ? 1 : 2;
+      continue;
+    }
+    if (arg === '--reject' || arg.startsWith('--reject=')) {
+      out.action = 'reject';
+      out.id = arg.includes('=') ? arg.split('=').slice(1).join('=') : argv[i + 1] || '';
+      i += arg.includes('=') ? 1 : 2;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!out.help && !out.action) {
+    throw new Error('Expected one of --list, --accept <id>, or --reject <id>');
+  }
+  if ((out.action === 'accept' || out.action === 'reject') && !out.id.trim()) {
+    throw new Error(`Expected id for --${out.action}`);
+  }
+  return out;
+}
+
+function printHelp() {
+  console.log(`Daily promo promote CLI
+
+  --list              List proposals
+  --accept <id>       Move proposal to live (status=live)
+  --reject <id>       Mark proposal rejected
+`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const proposalsPath = process.env.DAILY_PROMOS_PROPOSALS_PATH || DEFAULT_PROPOSALS_PATH;
+  const livePath = process.env.DAILY_PROMOS_LIVE_PATH || DEFAULT_LIVE_PATH;
+  const proposalsDoc = readPromoFile(proposalsPath);
+  const liveDoc = readPromoFile(livePath);
+
+  if (args.action === 'list') {
+    const open = proposalsDoc.promos.filter((p) => p.status === 'proposed' || !p.status || p.status === 'live');
+    // proposals file should only contain proposed; show all non-rejected
+    const rows = proposalsDoc.promos.filter((p) => p.status !== 'rejected');
+    if (!rows.length) {
+      console.log('No open proposals.');
+      return;
+    }
+    for (const p of rows) {
+      console.log(`${p.id}\t${p.status || 'proposed'}\t${p.brand}\t${p.bonusType}\t${p.bonus}`);
+    }
+    console.log(`Total: ${rows.length}`);
+    return;
+  }
+
+  const idx = proposalsDoc.promos.findIndex((p) => p.id === args.id);
+  if (idx === -1) {
+    throw new Error(`Proposal not found: ${args.id}`);
+  }
+  const proposal = proposalsDoc.promos[idx];
+
+  if (args.action === 'reject') {
+    proposalsDoc.promos[idx] = { ...proposal, status: 'rejected', asOf: new Date().toISOString() };
+    writePromoFile(proposalsPath, proposalsDoc);
+    console.log(`Rejected ${args.id}`);
+    return;
+  }
+
+  // accept
+  const liveRec = {
+    ...proposal,
+    status: 'live',
+    source: proposal.source || 'public-page',
+    asOf: new Date().toISOString(),
+    verified: new Date().toISOString().slice(0, 10),
+  };
+  const { promos, record } = upsertPromo(liveDoc.promos, liveRec);
+  liveDoc.promos = promos;
+  writePromoFile(livePath, liveDoc);
+  proposalsDoc.promos.splice(idx, 1);
+  writePromoFile(proposalsPath, proposalsDoc);
+  console.log(`Accepted ${record.id} → live (${record.brand})`);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Need a data-gathering path for free spins and daily promotions at priority Sweeps casinos, shown on `tiltcheck.me/bonuses`.

## Why this approach

Extend the existing bonus stack (email inbox + CollectClock) with a Sweeps allowlist store and hybrid gatherer — not a FreeSpinScan greenfield. Email/Discord auto-live; public-page scrapes stay proposals until promote.

## Scope

- Spec + plan: `docs/superpowers/specs/2026-07-18-daily-promo-gather-design.md`, `docs/superpowers/plans/2026-07-18-daily-promo-gather.md`
- Stores: `docs/ops/daily-promos-priority.json`, `data/trust-engine/daily-promos.{live,proposals}.json`
- Ops: `pnpm ops:promos:gather` / `pnpm ops:promos:promote` + `docs/ops/DAILY-PROMOS.md`
- API: `GET /bonuses/daily-feed` merges live + inbox + CollectClock (+ local fallback)
- Web: `/bonuses` with All / Free spins / Daily / Codes / Other filters
- Agent: `.cursor/agents/promo-gather.md` + `docs/api/bonuses.md`

## Risks

- External fetches (CollectClock, optional `--scrape` promo URLs) can fail; feed falls back / omits invented rows
- Empty inbox/Discord until ops seeds `data/email-bonus-feed.json` or `data/bonus-discord-drops.json` — UI still shows CollectClock when reachable
- Rollback: revert this PR; live/proposals JSON are additive

## Validation

- [x] `pnpm exec vitest --run apps/api/src/lib/daily-promos-store.test.ts` (3 passed)
- [x] `pnpm ops:promos:gather -- --dry-run` (19 allowlist brands)
- [x] `pnpm ops:promos:promote -- --list` (no open proposals)

Manual after merge/dev:

```bash
pnpm ops:promos:gather
# with API up: GET /bonuses/daily-feed
# web: /bonuses
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7216-c040-7f6e-999c-175909090c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7216-c040-7f6e-999c-175909090c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

